### PR TITLE
Drop Binder URLs, pin Colab URLs to workspace tag 2026.4.13.6

### DIFF
--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -1,0 +1,23 @@
+name: URL Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  url_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          path: repo
+      - name: Checkout PyAutoBuild
+        uses: actions/checkout@v4
+        with:
+          repository: PyAutoLabs/PyAutoBuild
+          ref: main
+          path: PyAutoBuild
+      - name: Run url_check.sh
+        run: bash PyAutoBuild/autobuild/url_check.sh repo

--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,6 @@ The following links are useful for anyone more interested in the **PyAutoLens** 
 
 - `The PyAutoLens readthedocs <https://pyautolens.readthedocs.io/en/latest>`_: which includes `an overview of PyAutoLens's core features <https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html>`_, `a new user starting guide <https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html>`_ and `an installation guide <https://pyautolens.readthedocs.io/en/latest/installation/overview.html>`_.
 
-- `The introduction Jupyter Notebook on Binder <https://mybinder.org/v2/gh/Jammy2211/autolens_workspace/release?filepath=start_here.ipynb>`_: try **PyAutoLens** in a web browser (without installation).
+- `The introduction Jupyter Notebook on Colab <https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb>`_: try **PyAutoLens** in a web browser (without installation).
 
 - `The autolens_workspace GitHub repository <https://github.com/Jammy2211/autolens_workspace>`_: example scripts and the HowToLens Jupyter notebook lectures.


### PR DESCRIPTION
## Summary

Drop all `mybinder.org` URLs in favour of Google Colab. Pin every Colab URL to the
date-based workspace tag (currently `2026.4.13.6`) so links stay aligned with the
PyPI-released library that users will have installed. Rewrite the GitHub owner
from `Jammy2211` to `PyAutoLabs`.

## What changed

- **URL rewrites** across `*.rst`, `*.md`, `*.ipynb`, `*.py`:
  - `mybinder.org/v2/gh/Jammy2211/<ws>/release?filepath=<path>` → `colab.research.google.com/github/PyAutoLabs/<ws>/blob/2026.4.13.6/<path>`
  - `mybinder.org/v2/gh/Jammy2211/<ws>/HEAD` → `colab.research.google.com/github/PyAutoLabs/<ws>/blob/2026.4.13.6/start_here.ipynb`
  - `colab…/Jammy2211/<ws>/blob/release/<path>` → `colab…/PyAutoLabs/<ws>/blob/2026.4.13.6/<path>`
- **Badge swap**: Binder badge images replaced with the official Colab badge
  (`colab-badge.svg`); RST `|binder|` substitution renamed to `|colab|`.
- **Prose cleanup**: every "Binder" link caption / sentence rewritten to "Colab"
  (case-preserving) so link text matches link target.

## Release-pipeline integration

The release workflow in PyAutoBuild (#49, merged) now invokes
`bump_colab_urls.sh <new-tag>` against this repo on every release, so the pinned
tag advances automatically. No manual maintenance is required after this PR.

## Regression guard

Adds `.github/workflows/url_check.yml` which runs PyAutoBuild's
`autobuild/url_check.sh` on every push and pull request. Re-introducing any
`mybinder.org` URL, `Jammy2211/` Colab owner, or `/blob/release/` Colab ref will
fail CI.

## Test Plan
- [ ] `url_check.yml` workflow passes on this PR
- [ ] Spot-check a Colab URL by clicking through to confirm the notebook loads at the pinned tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
