### PR TITLE
feat: integrate euclid into /smoke_test and fix PYAUTO_TEST_MODE env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ __pycache__/
 .Python
 *.egg-info/
 dist/
-build/
+/build/
 
 # PyAutoLens / PyAutoFit outputs
 output/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,20 +47,20 @@ All scripts accept `--dataset`, `--sample` (optional), and `--iterations_per_qui
 
 ## Test Runs
 
-Set `PYAUTOFIT_TEST_MODE=1` to make all non-linear searches complete almost instantly with trivial samples. Use this to verify the full pipeline executes without errors before submitting to the HPC or running a real fit.
+Set `PYAUTO_TEST_MODE=1` to make all non-linear searches complete almost instantly with trivial samples. Use this to verify the full pipeline executes without errors before submitting to the HPC or running a real fit. Set `PYAUTO_TEST_MODE=2` to additionally skip the sampler step entirely — fastest mode, used by the `/smoke_test` skill.
 
 ```bash
 # Initial lens model
-PYAUTOFIT_TEST_MODE=1 python start_here.py --dataset=102018665_NEG570040238507752998 --sample=q1_walsmley
+PYAUTO_TEST_MODE=1 python start_here.py --dataset=102018665_NEG570040238507752998 --sample=q1_walsmley
 
 # Full SLaM pipeline
-PYAUTOFIT_TEST_MODE=1 python scripts/full_model.py --dataset=102018665_NEG570040238507752998 --sample=q1_walsmley
+PYAUTO_TEST_MODE=1 python scripts/full_model.py --dataset=102018665_NEG570040238507752998 --sample=q1_walsmley
 
 # Sersic lens model
-PYAUTOFIT_TEST_MODE=1 python scripts/sersic_lens_model.py --dataset=102018665_NEG570040238507752998 --sample=q1_walsmley
+PYAUTO_TEST_MODE=1 python scripts/sersic_lens_model.py --dataset=102018665_NEG570040238507752998 --sample=q1_walsmley
 
 # MGE lens-only subtraction
-PYAUTOFIT_TEST_MODE=1 python scripts/mge_lens_only.py --dataset=102018665_NEG570040238507752998 --sample=q1_walsmley
+PYAUTO_TEST_MODE=1 python scripts/mge_lens_only.py --dataset=102018665_NEG570040238507752998 --sample=q1_walsmley
 ```
 
 The example dataset lives at `dataset/q1_walsmley/102018665_NEG570040238507752998/`.

--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -1,0 +1,31 @@
+# Per-script environment variable configuration for automated runs
+# (smoke tests, pre-release checks, CI).
+#
+# "defaults" are applied to every script on top of the inherited environment.
+# "overrides" selectively unset or replace vars for matching path patterns.
+# "args_default" is appended to the `python <script>` command for every
+# script (euclid-specific: pipeline scripts require --dataset and --sample).
+#
+# Pattern convention (same as no_run.yaml):
+#   - Patterns containing '/' do a substring match against the file path
+#   - Patterns without '/' match the file stem exactly
+#
+# Note: PYAUTO_SMALL_DATASETS is intentionally NOT set here — the euclid
+# pipeline is validated against real Euclid VIS imaging committed under
+# dataset/q1_walsmley/102018665_NEG570040238507752998/. Test mode alone
+# is enough to keep smoke runs fast.
+
+defaults:
+  PYAUTO_TEST_MODE: "2"                 # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
+  PYAUTO_SKIP_FIT_OUTPUT: "1"           # Skip pre/post-fit I/O, VRAM profiling, result text
+  PYAUTO_SKIP_VISUALIZATION: "1"        # Skip fit visualization and plotting
+  PYAUTO_SKIP_CHECKS: "1"               # Skip mesh validation, position checks, weight thresholds
+  PYAUTO_DISABLE_JAX: "1"               # Force use_jax=False, avoid JIT compilation overhead
+  PYAUTO_FAST_PLOTS: "1"                # Skip tight_layout() + critical curve/caustic overlays
+  JAX_ENABLE_X64: "True"                # Enable 64-bit precision in JAX
+  NUMBA_CACHE_DIR: "/tmp/numba_cache"   # Writable cache dir for numba
+  MPLCONFIGDIR: "/tmp/matplotlib"       # Writable config dir for matplotlib
+
+args_default: "--dataset=102018665_NEG570040238507752998 --sample=q1_walsmley"
+
+overrides: []

--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -1,0 +1,18 @@
+# Scripts to skip during automated runs (smoke tests, pre-release checks, CI).
+# Each entry is matched against script paths:
+#   - Entries with '/' do a substring match against the file path
+#   - Entries without '/' match the file stem exactly
+# Add an inline # comment to document the reason for skipping.
+#
+# SLOW-skip convention:
+#   Entries tagged `# SLOW <YYYY-MM-DD> - <reason>` mark scripts that are
+#   skipped because they exceed the per-script timeout cap. These are
+#   NOT permanent skips — investigate the performance issue and remove
+#   the SLOW marker.
+#
+# NEEDS_FIX convention:
+#   Entries tagged `# NEEDS_FIX <YYYY-MM-DD> - <reason>` mark scripts that
+#   are broken and parked as a to-do list. Investigate the failure, fix
+#   the underlying bug, and remove the NEEDS_FIX marker.
+
+[]

--- a/smoke_tests.txt
+++ b/smoke_tests.txt
@@ -1,0 +1,6 @@
+start_here.py
+scripts/initial_lens_model.py
+scripts/full_model.py
+scripts/lens_model_waveband.py
+scripts/mge_lens_only.py
+scripts/sersic_lens_model.py


### PR DESCRIPTION
## Summary

Wires the euclid pipeline into the `/smoke_test` rotation by adding the standard
config files the runner expects, and fixes a silent env-var bug in CLAUDE.md.

## Scripts / Files Changed

- `config/build/env_vars.yaml` — test-mode env vars for automated runs. Intentionally does NOT set `PYAUTO_SMALL_DATASETS`: euclid is validated against real Euclid VIS imaging (`dataset/q1_walsmley/102018665_NEG570040238507752998/`). Test mode alone keeps runs fast (clean `start_here.py` run measured at ~20s).
- `config/build/env_vars.yaml` — new `args_default` field passes `--dataset=... --sample=...` to every script, since euclid scripts require them.
- `config/build/no_run.yaml` — empty skip list to start.
- `smoke_tests.txt` — initial set: `start_here.py` + 5 scripts from `scripts/`.
- `.gitignore` — anchor `build/` to repo root (`/build/`) so `config/build/` is trackable.
- `CLAUDE.md` — fix `PYAUTOFIT_TEST_MODE` → `PYAUTO_TEST_MODE` (5 occurrences). The libraries only respect `PYAUTO_TEST_MODE` (see `PyAutoConf/autoconf/test_mode.py:13`), so the old env var silently did nothing. Also added a note that `TEST_MODE=2` skips the sampler entirely (used by `/smoke_test`).

## Companion skill updates (admin_jammy, committed separately)

- `smoke_test` SKILL: added euclid to the workspace mapping; documented the new optional `args_default` field; added path-resolution fallback so scripts at the repo root (like `start_here.py`) run without a `scripts/` prefix.
- `status` SKILL: added euclid to "All repos to scan".
- `handoff` SKILL: added euclid to the GitHub org mapping (Jammy2211).

## Test Plan

- [x] Verified `start_here.py` runs clean in ~20s with `PYAUTO_TEST_MODE=2` + the full env var set.
- [ ] Run `/smoke_test euclid` end-to-end once admin_jammy skill updates are in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)