### PR TITLE
docs: update stale Python >= 3.9 claim to Python >= 3.12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ If you install **PyAutoLens** without a proper GPU setup, a warning will be disp
 Getting Started
 ---------------
 
-**PyAutoLens** supports Python 3.9 to 3.12, with **Python 3.11 recommended**.
+**PyAutoLens** supports Python 3.12 and later, with **Python 3.13 recommended**.
 
 You first may want to set up a **Python virtual environment** or **conda environment** to install the pipeline
 in (see https://docs.python.org/3/library/venv.html).


### PR DESCRIPTION
## Summary
Updates the stale "Python >= 3.9" line in this repo's top-level docs to
"Python >= 3.12", matching the actual `requires-python>=3.12` pin in the
relevant `pyproject.toml`.

Follows on from PyAutoFit#1236 / PyAutoGalaxy#378 / PyAutoLens#481, which
added install-docs notes about the Python 3.9/3.10/3.11 drop. With this
PR the public-facing version claim is consistent everywhere.

## API Changes
None — docs-only.

## Test Plan
- [ ] Visual confirmation that the line now reads "Python >= 3.12" (or
      "Python 3.12 and later" in the euclid README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)