### PR TITLE
feat: embed workspace_version in config/general.yaml

### DIFF
--- a/config/general.yaml
+++ b/config/general.yaml
@@ -48,3 +48,6 @@ test:
   check_likelihood_function: true   # if True, when a search is resumed the likelihood of a previous sample is recalculated to ensure it is consistent with the previous run.
   lh_timeout_seconds:               # If a float is input, the log_likelihood_function call is timed out after this many seconds, to diagnose infinite loops. Default is None, meaning no timeout.
   disable_positions_lh_inversion_check: true
+version:
+  workspace_version: 2026.4.13.6    # Pinned by the release pipeline; must match the installed library version.
+  workspace_version_check: True     # If False, bypass the workspace/library version check. Set to False on `main`-branch clones — `main` updates faster than releases, so mismatches are expected and not actionable.


### PR DESCRIPTION
## Summary
Add a `version:` block to `config/general.yaml` with `workspace_version: 2026.4.13.6` and a user-facing `workspace_version_check: True` override flag, so the new config-aware `autoconf.workspace.check_version` (PyAutoLabs/PyAutoConf#101, now called from every `import autolens`) can resolve the workspace version from a canonical source. Previously this pipeline had neither `version.txt` nor a config-embedded version, so `verify_workspace_versions.sh` always SKIPped it. With this PR it joins the 6 main/HowTo workspaces in the standard version-pinning flow.

Setting `workspace_version_check: False` is the recommended bypass for users on `main`-branch clones, where `main` updates faster than library releases and mismatches are expected.

## Scripts Changed
- `config/general.yaml` — add a `version:` block with `workspace_version: 2026.4.13.6` and `workspace_version_check: True`

## Upstream PR
- PyAutoLabs/PyAutoConf#101 — config-aware `check_version` (core change)
- PyAutoLabs/PyAutoLens#484 — call `check_version` on `import autolens`
- PyAutoLabs/PyAutoBuild#70 — release pipeline writes the new YAML key; `verify_workspace_versions.sh` reads it

## Test Plan
- [x] `python -c "import autolens"` from this pipeline directory runs silently (no warning, no error)
- [x] `bash PyAutoBuild/verify_workspace_versions.sh` reports this pipeline as `ok` (was `SKIP` before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)