### PR TITLE
refactor: replace os.path with pathlib in workspace scripts

### DIFF
--- a/tools/extra_galaxies_centres_gui.py
+++ b/tools/extra_galaxies_centres_gui.py
@@ -161,7 +161,7 @@ if len(extra_galaxies_centres) > 1:
 
 info = {}
 
-if os.path.exists(dataset_main_path / "info.json"):
+if Path(dataset_main_path / "info.json").exists():
     try:
         with open(dataset_main_path / "info.json") as json_file:
             info = json.load(json_file)

--- a/tools/psf_size.py
+++ b/tools/psf_size.py
@@ -19,10 +19,10 @@ This GUI is adapted from the following code: https://gist.github.com/brikeats/4f
 
 import os
 import json
-from os import path
 import autolens as al
 import autolens.plot as aplt
 import numpy as np
+from pathlib import Path
 
 """
 __Dataset__
@@ -32,10 +32,10 @@ folder `dataset/imaging/no_lens_light/mass_sie__source_sersic`.
 """
 
 dataset_name = "102019586_NEG564463213499964061"
-dataset_path = path.join("dataset", dataset_name)
+dataset_path = Path("dataset") / dataset_name
 
 psf_full = al.Convolver.from_fits(
-    file_path=path.join(dataset_path, "psf_full.fits"), hdu=0, pixel_scales=0.1
+    file_path=Path(dataset_path) / "psf_full.fits", hdu=0, pixel_scales=0.1
 )
 
 print("PSF Shape Before Trimming:")
@@ -48,7 +48,7 @@ print(f"PSF being trimmed to {new_shape}")
 
 psf = psf_full.resized_from(new_shape=new_shape)
 
-psf.output_to_fits(file_path=path.join(dataset_path, "psf.fits"), overwrite=True)
+psf.output_to_fits(file_path=Path(dataset_path) / "psf.fits", overwrite=True)
 
 
 """

--- a/workflow/csv_make.py
+++ b/workflow/csv_make.py
@@ -43,7 +43,6 @@ especially if loading results from hard-disk is slow.
 # print(f"Working Directory has been set to `{workspace_path}`")
 
 from pathlib import Path
-from os import path
 
 import autofit as af
 import autolens as al
@@ -89,7 +88,7 @@ Set up the aggregator which will load results from the output folder of the mode
 """
 from autofit.aggregator.aggregator import Aggregator
 
-agg = Aggregator.from_directory(directory=path.join("output"), completed_only=True)
+agg = Aggregator.from_directory(directory=Path("output"), completed_only=True)
 
 """
 Use a query on the aggregator to only get results for the `mass_total[1]` model-fit, which contains the final lens

--- a/workflow/example/csv/lens_mass.py
+++ b/workflow/example/csv/lens_mass.py
@@ -16,7 +16,6 @@ before reading this example, as the same API is used here.
 # print(f"Working Directory has been set to `{workspace_path}`")
 
 from pathlib import Path
-from os import path
 
 import autofit as af
 import autolens as al
@@ -64,7 +63,7 @@ Set up the aggregator which will load results from the output folder of the mode
 """
 from autofit.aggregator.aggregator import Aggregator
 
-agg = Aggregator.from_directory(directory=path.join("output"), completed_only=True)
+agg = Aggregator.from_directory(directory=Path("output"), completed_only=True)
 
 """
 Use a query on the aggregator to only get results for the `mass_total[1]` model-fit, which contains the final lens

--- a/workflow/example/csv/magnitudes.py
+++ b/workflow/example/csv/magnitudes.py
@@ -16,7 +16,6 @@ before reading this example, as the same API is used here.
 # print(f"Working Directory has been set to `{workspace_path}`")
 
 from pathlib import Path
-from os import path
 
 import autofit as af
 import autolens as al
@@ -64,7 +63,7 @@ Set up the aggregator which will load results from the output folder of the mode
 """
 from autofit.aggregator.aggregator import Aggregator
 
-agg = Aggregator.from_directory(directory=path.join("output"), completed_only=True)
+agg = Aggregator.from_directory(directory=Path("output"), completed_only=True)
 
 """
 Use a query on the aggregator to only get results for the `mass_total[1]` model-fit, which contains the final lens

--- a/workflow/example/png/mge_inspect.py
+++ b/workflow/example/png/mge_inspect.py
@@ -19,7 +19,6 @@ before reading this example, as the same API is used here.
 # print(f"Working Directory has been set to `{workspace_path}`")
 
 from pathlib import Path
-from os import path
 
 import autofit as af
 import autolens as al
@@ -65,7 +64,7 @@ Set up the aggregator which will load results from the output folder of the mode
 """
 from autofit.aggregator.aggregator import Aggregator
 
-agg = Aggregator.from_directory(directory=path.join("output"), completed_only=True)
+agg = Aggregator.from_directory(directory=Path("output"), completed_only=True)
 
 """
 Use a query on the aggregator to only get results for the `mass_total[1]` model-fit, which contains the final lens

--- a/workflow/fits_make.py
+++ b/workflow/fits_make.py
@@ -46,7 +46,6 @@ especially if loading results from hard-disk is slow.
 # %cd $workspace_path
 # print(f"Working Directory has been set to `{workspace_path}`")
 
-from os import path
 from pathlib import Path
 
 import autofit as af
@@ -93,7 +92,7 @@ Set up the aggregator which will load results from the output folder of the mode
 """
 from autofit.aggregator.aggregator import Aggregator
 
-agg = Aggregator.from_directory(directory=path.join("output"), completed_only=True)
+agg = Aggregator.from_directory(directory=Path("output"), completed_only=True)
 
 """
 Use a query on the aggregator to only get results for the `mass_total[1]` model-fit, which contains the final lens
@@ -195,7 +194,7 @@ shape (1, 3).
 
 When we add a single .png, we cannot extract or make it, it simply gets added to the subplot.
 """
-# image_rgb = Image.open(path.join(dataset_path, "rgb.png"))
+# image_rgb = Image.open(Path(dataset_path) / "rgb.png")
 #
 # image = agg_fits.extract_fits(
 #     al.agg.subplot_dataset.data,

--- a/workflow/png_make.py
+++ b/workflow/png_make.py
@@ -49,7 +49,6 @@ especially if loading results from hard-disk is slow.
 # print(f"Working Directory has been set to `{workspace_path}`")
 
 from pathlib import Path
-from os import path
 
 import autofit as af
 import autolens as al
@@ -95,7 +94,7 @@ Set up the aggregator which will load results from the output folder of the mode
 """
 from autofit.aggregator.aggregator import Aggregator
 
-agg = Aggregator.from_directory(directory=path.join("output"), completed_only=True)
+agg = Aggregator.from_directory(directory=Path("output"), completed_only=True)
 
 """
 Use a query on the aggregator to only get results for the `mass_total[1]` model-fit, which contains the final lens


### PR DESCRIPTION
## Summary

Mechanical refactor replacing all `os.path.*` and bare `path.*` (from `from os import path`) usages with `pathlib.Path` in workspace scripts. Follow-up to the library refactor in PyAutoLabs/PyAutoFit#1257 — applies the same convention sweep across this workspace.

## Scripts Changed

See the diff against `main` for the full list (each modified script swaps one or more `os.path.*` / `path.*` calls for the equivalent `pathlib.Path` API). No script logic or behaviour changes — purely a syntactic conversion.

## Upstream PRs (all merged)

- PyAutoLabs/PyAutoConf#104
- PyAutoLabs/PyAutoFit#1258
- PyAutoLabs/PyAutoArray#300
- PyAutoLabs/PyAutoGalaxy#388
- PyAutoLabs/PyAutoLens#497

## Test Plan

- [ ] Smoke tests pass against the use-pathlib worktree (verified locally — 36/36 across 4 main workspaces; euclid passes with `PYAUTO_SKIP_WORKSPACE_VERSION_CHECK=1`, a pre-existing issue unrelated to this PR)
- [ ] No script behaviour change — purely API substitution

Refs PyAutoLabs/PyAutoFit#1257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)