### PR TITLE
feat(latents): re-enable effective_einstein_radius via einstein_radius_jit_from

### DIFF
--- a/util.py
+++ b/util.py
@@ -13,6 +13,7 @@ from autoconf.dictable import output_to_json
 import autofit as af
 import autolens as al
 import autolens.plot as aplt
+from autogalaxy.operate.lens_calc import LensCalc
 
 
 def subplot_rgb(
@@ -311,7 +312,7 @@ class AnalysisImaging(al.AnalysisImaging):
         "latent.total_lensed_source_flux",
         "latent.total_source_flux",
         "latent.magnification",
-        #    "latent_effective_einstein_radius"
+        "latent.effective_einstein_radius",
     ]
 
     def to_ndarray_2d(self, image, xp):
@@ -487,12 +488,34 @@ class AnalysisImaging(al.AnalysisImaging):
 
         # EFFECTIVE EINSTEIN RADIUS
 
-        # try:
-        #     effective_einstein_radius = tracer.einstein_radius_from(
-        #         grid=self.dataset.grids.lp
-        #     )
-        # except Exception:
-        #     effective_einstein_radius = xp.nan
+        try:
+            lens_calc = LensCalc.from_mass_obj(tracer)
+            if self._use_jax:
+                # JIT-friendly path. `AnalysisDataset.LATENT_BATCH_MODE = "jit"`
+                # in PyAutoGalaxy means `Analysis.compute_latent_samples` wraps
+                # this with per-sample `jax.jit`, not `jax.vmap` — the inner
+                # ZeroSolver is vmap-incompatible upstream. A fixed fan of
+                # seeds at ~1 arcsec from the (preprocessed) lens centre
+                # covers the typical Euclid range of Einstein radii.
+                import jax.numpy as jnp
+
+                init_guess = jnp.array(
+                    [
+                        [1.0, 0.0],
+                        [0.0, 1.0],
+                        [-1.0, 0.0],
+                        [0.0, -1.0],
+                    ]
+                )
+                effective_einstein_radius = lens_calc.einstein_radius_jit_from(
+                    init_guess=init_guess,
+                )
+            else:
+                effective_einstein_radius = lens_calc.einstein_radius_from(
+                    grid=self.dataset.grids.lp,
+                )
+        except ValueError:
+            effective_einstein_radius = xp.nan
 
         return (
             total_lens_flux_muJy,
@@ -503,7 +526,7 @@ class AnalysisImaging(al.AnalysisImaging):
             total_lensed_source_flux_muJy,
             total_source_flux_muJy,
             magnification,
-            #    effective_einstein_radius
+            effective_einstein_radius,
         )
 
     def save_results(self, paths: af.DirectoryPaths, result):


### PR DESCRIPTION
## Summary

Re-enables the `effective_einstein_radius` latent in `util.py` (previously commented out because the only available Einstein-radius API was not JAX-traceable under `compute_latent_samples`' vmap+jit wrap). The fix routes through the new JIT-friendly helper added in the companion PyAutoGalaxy PR, combined with `AnalysisDataset.LATENT_BATCH_MODE = "jit"` (also that PR) and `LATENT_BATCH_MODE` machinery in PyAutoFit (separate PR).

Dispatch on `self._use_jax` in `compute_latent_variables`:

- **`use_jax=True`:** `lens_calc.einstein_radius_jit_from(init_guess=...)` with a 4-seed fan at ±1 arcsec from origin on the cardinal axes. Covers the typical Euclid Einstein-radius range (0.5–2.0 arcsec) via Newton's basin of attraction.
- **`use_jax=False`:** legacy `lens_calc.einstein_radius_from(grid=self.dataset.grids.lp)` (marching squares, fast on small grids, no JAX dep).
- **`ValueError`** (no zero-crossing — degenerate model): `xp.nan`.

`LATENT_KEYS` gains `latent.effective_einstein_radius` (renamed from the legacy underscore form for dotted-naming consistency with the surrounding keys). The returned tuple uncomments the corresponding slot.

## Scripts Changed

- `util.py` — `LATENT_KEYS` (uncomment + rename), `AnalysisImaging.compute_latent_variables` (conditional dispatch on `self._use_jax`), returned tuple (uncomment slot). Adds `from autogalaxy.operate.lens_calc import LensCalc` import.

## Upstream PRs

- PyAutoFit: `https://github.com/rhayes777/PyAutoFit/pull/1288` — adds `Analysis.LATENT_BATCH_MODE` attribute (vmap default, jit option).
- PyAutoGalaxy: `https://github.com/PyAutoLabs/PyAutoGalaxy/pull/435` — adds `LensCalc.einstein_radius_jit_from` helper and sets `AnalysisDataset.LATENT_BATCH_MODE = "jit"`.

## Test Plan

- [x] **JAX-branch end-to-end (`start_here.py` with `use_jax=True`, `PYAUTO_TEST_MODE=1`):** Pipeline runs cleanly. Max-LL `latent.effective_einstein_radius = 2.1002 arcsec` (finite, positive, in the expected range). Latent step ~48 s for 100 samples on CPU (≈480 ms/sample after the one-time ZeroSolver compile).
- [x] **Numpy-branch smoke (`/smoke_test euclid_strong_lens_modeling_pipeline` via `PYAUTO_DISABLE_JAX=1`):** 6/6 scripts PASS. Legacy marching-squares path unchanged.
- [ ] After the library PRs ship in a release, confirm `latent.effective_einstein_radius` appears in `latent.csv` / `latent_summary.json` on a full HPC tile run.

Closes #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)