### PR TITLE
fix(readme): autolens_workspace URL points to PyAutoLabs org

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,4 +107,4 @@ The following links are useful for anyone more interested in the **PyAutoLens** 
 
 - [The PyAutoLens readthedocs](https://pyautolens.readthedocs.io/en/latest): which includes [an overview of PyAutoLens's core features](https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautolens.readthedocs.io/en/latest/installation/overview.html).
 - [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb): try **PyAutoLens** in a web browser (without installation).
-- [The autolens_workspace GitHub repository](https://github.com/Jammy2211/autolens_workspace): example scripts and the HowToLens Jupyter notebook lectures.
+- [The autolens_workspace GitHub repository](https://github.com/PyAutoLabs/autolens_workspace): example scripts and the HowToLens Jupyter notebook lectures.


### PR DESCRIPTION
Single-line README fix: line 110's autolens_workspace link pointed to `Jammy2211/autolens_workspace` instead of `PyAutoLabs/autolens_workspace`. This was the pre-existing `url_check` CI failure flagged on PR #15 (latent-jit) — unrelated to that task, fixed standalone here.