### PR TITLE
fix(config): silence autogalaxy cross-library latent warning

### DIFF
--- a/config/latent.yaml
+++ b/config/latent.yaml
@@ -13,3 +13,9 @@ total_lensed_source_flux_mujy: true
 total_source_flux_mujy: true
 magnification: true
 effective_einstein_radius: true
+
+# autogalaxy library default (loaded by autoconf into the same `latent`
+# conf node) — explicitly disabled to silence the cross-library
+# "unknown latent" warning that would otherwise fire on every fit. The
+# Euclid pipeline's µJy latents above remain the canonical output.
+total_galaxy_0_flux: false


### PR DESCRIPTION
## Summary

PyAutoLabs/PyAutoGalaxy#463 adds `total_galaxy_0_flux: true` to the autogalaxy library defaults. autoconf merges the autogalaxy and autolens `latent.yaml` files into the same `latent` conf node, so the autolens dispatcher sees a key it doesn't recognise and logs an "unknown latent" warning on every fit evaluation — noisy on the long-running HPC fits that originally surfaced the bug fixed in #556.

This PR adds one explicit override line to the pipeline's `config/latent.yaml` to silence the warning. The pipeline's existing `_mujy: true` keys remain the canonical photometric output.

## Scripts Changed

- `config/latent.yaml` — Add `total_galaxy_0_flux: false` with a comment explaining the cross-library autoconf merge that motivates it.

## Upstream PR

- PyAutoLabs/PyAutoGalaxy#463 — library change that triggers the warning (must merge first per library-first gate)
- PyAutoLabs/PyAutoLens#557 — sibling lensing library change

## Test Plan

- [x] `python -m py_compile` n/a (yaml-only).
- [x] Pattern verified in `autolens_workspace_test` smoke test re-run: with the autogalaxy default-on key explicitly silenced, no `latent.yaml lists 'total_galaxy_0_flux' but no such latent is registered` warnings fire.

Refs PyAutoLabs/PyAutoLens#556

🤖 Generated with [Claude Code](https://claude.com/claude-code)