### PR TITLE
test(latent): use LatentEuclid.variables/keys (Phase 2 removed the method override)

### DIFF
--- a/tests/test_compute_latent_variable.py
+++ b/tests/test_compute_latent_variable.py
@@ -214,11 +214,12 @@ param_vector = np.array(model.physical_values_from_prior_medians)
 parameters = np.zeros(model.total_free_parameters)
 parameters[:] = param_vector
 
-latent_variables = analysis.compute_latent_variables(
+latent_variables = util.LatentEuclid.variables(
+    analysis,
     parameters=parameters,
     model=model,
 )
 
 
 def test_compute_latent_variables_smoke():
-    assert len(latent_variables) == len(analysis.LATENT_KEYS)
+    assert len(latent_variables) == len(util.LatentEuclid.keys(analysis))


### PR DESCRIPTION
## Summary
Latent redesign cleanup — migrate remaining code/docs off the legacy `compute_latent_variables`/`LATENT_KEYS` override to the `Latent` class. Phase 2 removed the library `AnalysisImaging` overrides, so this lands the stragglers. Back-compat shim + shim tests + z_projects intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

`tests/test_compute_latent_variable.py` used `analysis.compute_latent_variables`/`LATENT_KEYS` → now `util.LatentEuclid.variables/keys`.
## Test Plan
- [x] `pytest tests/test_compute_latent_variable.py` — 1 passed