### PR TITLE
docs: fix science-context pointer PyAutoPaper -> PyAutoMemory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ For the science behind this pipeline — what Euclid is finding, why SIE
 + shear is a reasonable default mass model, what MGE buys, how
 multipoles and external shear affect substructure / cosmography
 downstream — see the lensing sub-wiki at
-[`PyAutoLabs/PyAutoPaper`](https://github.com/PyAutoLabs/PyAutoPaper),
-locally at `../PyAutoPaper/lensing_wiki/`. Most directly relevant:
+[`PyAutoLabs/PyAutoMemory`](https://github.com/PyAutoLabs/PyAutoMemory),
+locally at `../PyAutoMemory/lensing_wiki/`. Most directly relevant:
 `entities/euclid-q1.md`, `concepts/mass-models.md`,
 `concepts/multipoles.md`, `concepts/external-convergence-shear.md`,
 `concepts/lens-finding.md`, `entities/slam-pipeline.md`.


### PR DESCRIPTION
Fixes a dead science-context pointer. The lensing sub-wiki was renamed **PyAutoPaper → PyAutoMemory** (and moved to `../PyAutoMemory/`); this repo's `## Scientific Context` section still referenced the old repo name and `../PyAutoPaper/lensing_wiki/` path, both now broken. Updated the GitHub URL and local path to `PyAutoMemory`.

Part of the context-load / rename-hygiene pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)