### PR TITLE
fix: point the Colab intro link at the canonical notebook at the current tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,5 @@ in using these pipelines sooner please contact James Nightingale on the Euclid c
 The following links are useful for anyone more interested in the **PyAutoLens** software:
 
 - [The PyAutoLens readthedocs](https://pyautolens.readthedocs.io/en/latest): which includes [an overview of PyAutoLens's core features](https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautolens.readthedocs.io/en/latest/installation/overview.html).
-- [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.4.13.6/start_here.ipynb): try **PyAutoLens** in a web browser (without installation).
+- [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.7.6.649/notebooks/imaging/start_here.ipynb): try **PyAutoLens** in a web browser (without installation).
 - [The autolens_workspace GitHub repository](https://github.com/PyAutoLabs/autolens_workspace): example scripts and the HowToLens Jupyter notebook lectures.


### PR DESCRIPTION
## Summary

Part of the Colab link-rot repair (PyAutoLabs/HowToLens#21; phase tracker PyAutoLabs/PyAutoBuild#124). The README's Colab link targeted the root `start_here.ipynb` at the stale `2026.4.13.6` tag (the notebook has since moved); it now targets the canonical `notebooks/imaging/start_here.ipynb` at the current release tag, which the release bumper maintains from here.

## Scripts Changed
None — chapter/root README link fixes and `.url_check_allowlist.txt` purges only; no scripts or notebooks execute differently.

## Validation checklist (--auto run — plan was not pre-approved)
- Effective level: safe (header: safe, cap: feature/maintenance → safe at medium difficulty)
- Plan: on the issue (PyAutoLabs/HowToLens#21), written at launch, unmodified since
- Gate: tests n/a (no test dirs — documentation/tutorial repos) · smoke n/a (README/allowlist-only diff, no script surface) · review CLEAN · Heart YELLOW within launch-acknowledged reason set (5 pre-existing reasons, no new)
- Link-target verification: every Colab URL in the four repos machine-checked — canonical owner, current tag `2026.7.6.649`, target notebook exists; Heart's hardened offline guard (`url_check.sh`, incl. the new phase-1 patterns) exits clean on all four repos
- [ ] Human: plan sound in hindsight?
- [ ] Human: diff matches plan (no scope creep)?
- [ ] Human: merge, amend, or reject — then log the outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)
