### PR TITLE
config: adopt version.minimum_library_version floor (2026.7.9.1)

### DIFF
--- a/config/general.yaml
+++ b/config/general.yaml
@@ -49,5 +49,11 @@ test:
   lh_timeout_seconds:               # If a float is input, the log_likelihood_function call is timed out after this many seconds, to diagnose infinite loops. Default is None, meaning no timeout.
   disable_positions_lh_inversion_check: true
 version:
+  # The compatibility FLOOR: the oldest library release whose API this
+  # workspace's scripts require. Preferred over workspace_version
+  # (autoconf/workspace.py). Bump DELIBERATELY — only when a script
+  # starts needing new API — never per release. Must always name an
+  # INSTALLABLE (non-yanked) release.
+  minimum_library_version: 2026.7.9.1
   workspace_version: 2026.7.9.1
   workspace_version_check: True     # If False, bypass the workspace/library version check. Set to False on `main`-branch clones — `main` updates faster than releases, so mismatches are expected and not actionable.


### PR DESCRIPTION
## Summary

Phase 4 **task 1** of the build-chain campaign (PyAutoBuild#155), from `draft/feature/workspaces/minimum_library_version_adoption.md`: adopt the canonical `version.minimum_library_version` **compatibility floor** in this workspace's `config/general.yaml`, completing the migration off the legacy `workspace_version` key (which releases stopped writing under PyAutoConf#119 / PyAutoBuild#121).

**This is a provable behavioural no-op:** `autoconf.workspace` already resolves the floor as `minimum_library_version` first, else `workspace_version` — and both are `2026.7.9.1`, so the effective floor is unchanged (verified by resolving it old-vs-new). The change just moves the value to the key the check actually prefers, so the legacy key and `version.txt` can later be retired (deferred to after the Heart `version_skew` rework, which still reads `workspace_version` — Phase 4 task 2).

**Floor value = 2026.7.9.1**, chosen deliberately: it is the first release after the floor-model redesign (2026-07-08) and — the constraint the campaign's version-drift bug turned on — it is **installable**. Verified against PyPI: the 2026.6.x–2026.7.6.649 series is *yanked*; 2026.7.9.1 and 2026.7.15.1 are the only non-yanked recent releases. The floor names an installable version, and the co-located comment documents the bump-deliberately rule (moves only when scripts need new API, never per release).

`workspace_version` is intentionally kept for now (removal is coordinated with the `version_skew` rework that reads it).

## API Changes
None — workspace config only.

## Test Plan
- [x] Floor resolves to `2026.7.9.1` via `minimum_library_version` (autoconf `_yaml_version_value`) — same value as the prior `workspace_version` fallback → no behaviour change.
- [x] Library main `__version__` is `2026.7.9.1` (≥ floor) → `check_version` passes.
- [x] This PR's smoke gate is the end-to-end check (scripts run `check_version`).

Generated by the PyAutoLabs agent workflow.
