### PR TITLE
refactor: import config surface from autolens instead of autoconf

### DIFF
--- a/scripts/full_model.py
+++ b/scripts/full_model.py
@@ -319,7 +319,7 @@ def fit(
     sample_name: str = None,
     iterations_per_quick_update: int = 5000,
 ):
-    from autoconf import conf
+    from autolens import conf
 
     project_root = Path(__file__).parent.parent
     conf.instance.push(

--- a/scripts/initial_lens_model.py
+++ b/scripts/initial_lens_model.py
@@ -42,7 +42,7 @@ def fit(
     sample_name: str = None,
     iterations_per_quick_update: int = 5000,
 ):
-    from autoconf import conf
+    from autolens import conf
 
     project_root = Path(__file__).parent.parent
     conf.instance.push(

--- a/scripts/lens_model_waveband.py
+++ b/scripts/lens_model_waveband.py
@@ -34,7 +34,7 @@ def fit_waveband(
     import autofit as af
     import autolens as al
     from astropy.wcs import WCS
-    from autoconf import conf
+    from autolens import conf
 
     project_root = Path(__file__).parent.parent
     conf.instance.push(

--- a/scripts/mge_lens_only.py
+++ b/scripts/mge_lens_only.py
@@ -23,7 +23,7 @@ def fit(
     sample_name: str = None,
     iterations_per_quick_update: int = 50000,
 ):
-    from autoconf import conf
+    from autolens import conf
 
     project_root = Path(__file__).parent.parent
     conf.instance.push(
@@ -95,7 +95,7 @@ def fit_waveband(
     """
     import autofit as af
     import autolens as al
-    from autoconf import conf
+    from autolens import conf
     from pathlib import Path
 
     project_root = Path(__file__).parent.parent

--- a/scripts/sersic_lens_model.py
+++ b/scripts/sersic_lens_model.py
@@ -29,7 +29,7 @@ def fit_sersic(
     mask_radius: float = None,
     iterations_per_quick_update: int = 5000,
 ):
-    from autoconf import conf
+    from autolens import conf
 
     project_root = Path(__file__).parent.parent
     conf.instance.push(

--- a/start_here.py
+++ b/start_here.py
@@ -42,7 +42,7 @@ def fit(
     sample_name: str = None,
     iterations_per_quick_update: int = 5000,
 ):
-    from autoconf import conf
+    from autolens import conf
 
     project_root = Path(__file__).parent
     conf.instance.push(

--- a/util.py
+++ b/util.py
@@ -7,8 +7,8 @@ from PIL import Image
 from typing import List, Optional
 
 import matplotlib.pyplot as plt
-from autoconf import conf as _conf
-from autoconf.dictable import output_to_json
+from autolens import conf as _conf
+from autolens import output_to_json
 
 import autofit as af
 import autolens as al


### PR DESCRIPTION
## What

Rewrite `from autoconf[.sub] import X` → `from autolens import X` across the pipeline scripts, so they import the config/serialization surface through the science library rather than depending on `autoconf` directly.

## Notes

- Any Colab bootstrap `setup_colab` import is intentionally left on `autoconf`.
- Pairs with the `autolens` re-export PR on the same-named branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_