### PR TITLE
docs: link Colab introduction to workspace start

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,5 @@ in using these pipelines sooner please contact James Nightingale on the Euclid c
 The following links are useful for anyone more interested in the **PyAutoLens** software:
 
 - [The PyAutoLens readthedocs](https://pyautolens.readthedocs.io/en/latest): which includes [an overview of PyAutoLens's core features](https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautolens.readthedocs.io/en/latest/installation/overview.html).
-- [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.7.9.1/notebooks/imaging/start_here.ipynb): try **PyAutoLens** in a web browser (without installation).
+- [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.7.9.1/start_here.ipynb): try **PyAutoLens** in a web browser (without installation).
 - [The autolens_workspace GitHub repository](https://github.com/PyAutoLabs/autolens_workspace): example scripts and the HowToLens Jupyter notebook lectures.


### PR DESCRIPTION
## Summary
Route the PyAutoLens introduction link to the autolens workspace-root `start_here.ipynb` instead of the imaging-specific notebook, retaining the existing release pin.

## Scripts Changed
- None — README-only documentation link correction.

## Upstream PR
https://github.com/PyAutoLabs/PyAutoLens/pull/650

## Test Plan
- [ ] Targeted Euclid pipeline smoke tests pass
- [x] The pinned `2026.7.9.1` root notebook exists and contains `setup_colab.for_autolens(...)`
- [x] `git diff --check`

Generated by the PyAutoLabs agent workflow.