### PR TITLE
docs: remove the Finished./Finish. notebook-generation crutch

### DIFF
--- a/tools/extra_galaxies_mask_gui.py
+++ b/tools/extra_galaxies_mask_gui.py
@@ -125,7 +125,3 @@ Output the extra galaxies mask, which will be load and used before a model fit.
 mask.output_to_fits(
     file_path=dataset_main_path / "mask_extra_galaxies.fits", overwrite=True
 )
-
-"""
-Finish.
-"""

--- a/workflow/csv_make.py
+++ b/workflow/csv_make.py
@@ -340,7 +340,3 @@ __Saving the CSV__
 We can now output the results of all our model-fits to the .csv file, using the `save` method.
 """
 agg_csv.save(path=workflow_path / "result_lens_mge__mge_lens_only.csv")
-
-"""
-Finished.
-"""

--- a/workflow/example/png/mge_inspect.py
+++ b/workflow/example/png/mge_inspect.py
@@ -104,7 +104,3 @@ agg_image.output_to_folder(
     name=[search.path_prefix.parts[-1] for search in agg.values("search")],
     subplots=subplots,
 )
-
-"""
-Finished.
-"""


### PR DESCRIPTION
Removes the `Finished.` / `Finish.` notebook-generation crutch from `euclid_strong_lens_modeling_pipeline` — **3 occurrences**: 3 trailing blocks.

Artifacts: no generated artifacts in this repo.


## Why

These trailing docstring blocks were a crutch against notebook generation "cutting off weird" when a script's last cell was not a docstring. That belief is obsolete: deleting the block and running the real `add_notebook_quotes` → `ipynb-py-convert` chain gives a complete, unmangled final code cell, and PyAutoLabs/PyAutoHands#214 adds `test_script_ending_in_code_keeps_a_complete_final_code_cell` to pin it. The crutch rendered as a pointless final markdown cell in every generated notebook.

## Shapes handled

A blanket regex would be wrong — five distinct shapes exist and each needs different handling. The sweep used Python's own `tokenize` to locate the exact string token each occurrence lives in, because a line-based scanner cannot tell a narrative docstring's bare delimiter from a function docstring that opens with text on the delimiter line, and this corpus contains both.

## Verification

- Every changed file compiles.
- `black --check` clean.
- **Env declarations byte-identical before and after.** Removing the word above an `__Env__` section turns the canonical merged form into the standalone-fallback form; both are supported. Checked by running `env_config.read_env_declaration` on the old and new content of all 169 changed files across the series: **169 unchanged, 0 changed, 0 errors**.
- **CRLF preserved.** Several of these repos ship CRLF `.py` files; the first attempt normalised them and rewrote whole files (~6000 line churn). The sweep reads and writes with `newline=""`, so the diff is deletions only.
- No generated notebook contains a code cell with a literal `# %%` or `'''`, and no notebook has a `Finish.` markdown cell.

## Merge order

**PyAutoLabs/PyAutoHands#214 merges first** — this repo invokes `../PyAutoHands/autohands/generate.py` from the local checkout, so the regenerated notebooks here are only correct against that version.

Part of PyAutoLabs/PyAutoHands#211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XzXdQMU3KV2tyZaMNPvsM