### PR TITLE
fix: move the tools/ GUIs off the removed plotter-object API

### DIFF
--- a/tools/extra_galaxies_centres_gui.py
+++ b/tools/extra_galaxies_centres_gui.py
@@ -26,6 +26,7 @@ import numpy as np
 import os
 from pathlib import Path
 from matplotlib import pyplot as plt
+from matplotlib.colors import LogNorm
 
 import autolens as al
 import autolens.plot as aplt
@@ -123,8 +124,7 @@ n_y, n_x = data.shape_native
 hw = int(n_x / 2) * pixel_scales
 ext = [-hw, hw, -hw, hw]
 fig = plt.figure(figsize=(14, 14))
-cmap = aplt.Cmap(cmap="jet", norm="log", vmin=1.0e-3, vmax=np.max(data) / 3.0)
-norm = cmap.norm_from(array=data, use_log10=True)
+norm = LogNorm(vmin=1.0e-3, vmax=np.max(data) / 3.0)
 plt.imshow(data.native, cmap="jet", norm=norm, extent=ext)
 plt.scatter(y=grid[:, 0], x=grid[:, 1], c="k", marker="x", s=10)
 plt.colorbar()
@@ -193,20 +193,15 @@ mask = al.Mask2D.circular(
     shape_native=data.shape_native, pixel_scales=data.pixel_scales, radius=mask_radius
 )
 
-visuals = aplt.Visuals2D(mask=mask, mass_profile_centres=extra_galaxies_centres)
-
-array_2d_plotter = aplt.Array2DPlotter(
+aplt.plot_array(
     array=data,
-    visuals_2d=visuals,
-    mat_plot_2d=aplt.MatPlot2D(
-        mass_profile_centres_scatter=aplt.MassProfileCentresScatter(c="cy"),
-        output=aplt.Output(
-            path=dataset_main_path, filename="extra_galaxies_centres", format="png"
-        ),
-        use_log10=True,
-    ),
+    mask=mask,
+    positions=extra_galaxies_centres,
+    output_path=dataset_main_path,
+    output_filename="extra_galaxies_centres",
+    output_format="png",
+    use_log10=True,
 )
-array_2d_plotter.figure_2d()
 
 """
 Output the extra galaxy centres to the dataset folder of the lens, so that we can load them from a .json file 

--- a/tools/extra_galaxies_mask_gui.py
+++ b/tools/extra_galaxies_mask_gui.py
@@ -47,7 +47,6 @@ import argparse
 import numpy as np
 from pathlib import Path
 import autolens as al
-import autolens.plot as aplt
 
 """
 __Dataset__
@@ -84,8 +83,6 @@ data = al.Array2D(
     values=np.nan_to_num(data, nan=0.0, posinf=0.0, neginf=0.0), mask=data.mask
 )
 
-cmap = aplt.Cmap(cmap="jet", norm="log", vmin=1.0e-3, vmax=np.max(data) / 3.0)
-
 """
 __Mask__
 
@@ -105,7 +102,13 @@ Load the Scribbler GUI for spray painting the scaled regions of the dataset.
 Push Esc when you are finished spray painting.
 """
 scribbler = al.Scribbler(
-    image=data.native, cmap=cmap, brush_width=0.05, mask_overlay=mask
+    image=data.native,
+    cmap="jet",
+    norm="log",
+    vmin=1.0e-3,
+    vmax=np.max(data) / 3.0,
+    brush_width=0.05,
+    mask_overlay=mask,
 )
 mask = scribbler.show_mask()
 mask = al.Mask2D(mask=mask, pixel_scales=pixel_scales)

--- a/tools/psf_size.py
+++ b/tools/psf_size.py
@@ -54,24 +54,18 @@ psf.output_to_fits(file_path=Path(dataset_path) / "psf.fits", overwrite=True)
 """
 __Png output__
 """
-mat_plot_2d = aplt.MatPlot2D(
-    output=aplt.Output(path=dataset_path, filename="psf_full", format="png"),
+aplt.plot_array(
+    array=psf_full,
+    output_path=dataset_path,
+    output_filename="psf_full",
+    output_format="png",
     use_log10=True,
 )
 
-plotter = aplt.Array2DPlotter(
-    array=psf_full,
-    mat_plot_2d=mat_plot_2d,
-)
-plotter.figure_2d()
-
-
-mat_plot_2d = aplt.MatPlot2D(
-    output=aplt.Output(path=dataset_path, filename="psf", format="png"), use_log10=True
-)
-
-plotter = aplt.Array2DPlotter(
+aplt.plot_array(
     array=psf.kernel,
-    mat_plot_2d=mat_plot_2d,
+    output_path=dataset_path,
+    output_filename="psf",
+    output_format="png",
+    use_log10=True,
 )
-plotter.figure_2d()


### PR DESCRIPTION
Closes part of PyAutoLabs/PyAutoGalaxy#585.

> [!IMPORTANT]
> **Merge after PyAutoLabs/PyAutoGalaxy#586.** This branch depends on two API
> changes in that PR (the `Scribbler` signature and the `plot_array` `mask=`
> passthrough). Library-first gate.

All three `tools/` scripts raised `AttributeError` on reaching their plotting
block. `aplt.Output`, `aplt.MatPlot2D`, `aplt.Cmap`, `aplt.Array2DPlotter`,
`aplt.Visuals2D` and `aplt.MassProfileCentresScatter` no longer exist on the
autolens plot namespace.

## Scripts Changed

**`tools/psf_size.py`** — two `MatPlot2D` / `Output` / `Array2DPlotter` triples
collapse to single `aplt.plot_array(...)` calls with flat output arguments.
Purely mechanical.

**`tools/extra_galaxies_centres_gui.py`** — two separate sites:

- The reference PNG now uses `plot_array` with `mask=` / `positions=`. **The
  mask has to be passed explicitly.** `data` comes from `Array2D.from_fits` and
  is unmasked, so the auto-derived outline is empty — verified,
  `auto_mask_edge(data)` returns `None`. The mask being drawn is a *separately
  constructed* circular one whose radius is grown at line 160 to enclose the
  clicked galaxies, so dropping it would have silently deleted the mask radius
  from the figure that exists to show it.
- The inline clicker canvas (a hand-written copy of `Clicker.start()`) builds
  its `LogNorm` from matplotlib directly, since that block already draws with
  raw pyplot. Equivalent output, no PyAuto coupling.

**`tools/extra_galaxies_mask_gui.py`** — `al.Scribbler` now takes the colour
scale as plain values. Its `autolens.plot` import is dropped, having become
unused.

## Behaviour change worth knowing

The extra-galaxy centre markers were cyan via
`MassProfileCentresScatter(c="cy")` and are now the `plot_array` default. The
flat API hardcodes its overlay colour cycle (`autoarray/plot/array.py:258-262`;
`line_colors` at 265-273 applies to `lines`, not `positions`), so the colour
cannot be set. The markers stay visible and are distinguishable from the mask
outline by size and z-order. Restoring the colour would need a PyAutoArray
change.

## Testing

This repo has **no CI workflows**, and these two GUIs need TkAgg plus FITS data
that is not in the repo — so they were **not run end-to-end**. Validation was:

- Alias-aware AST re-scan (aliases resolved from each file's own imports, not a
  hardcoded `aplt`) against the real `autolens.plot` export list: **0 residual
  stale symbols**.
- All **10** changed `aplt.*` / `al.*` calls bound against their real callee
  signatures via `inspect.signature`: 10 ok, 0 failures.
- The `plot_array` calls executed headless against synthetic data, confirming
  the mask outline actually renders (2436 pixels differ vs. the same call
  without `mask=`).
- `compileall` clean.

## Note for a follow-up, not fixed here

All three files are **100% CRLF on `main`**, contradicting this repo's
`AGENTS.md` ("All files must use Unix line endings... CRLF will break shell
scripts on the HPC"). Converting them would produce whole-file diffs and would
not fix the repo-wide problem, so this PR preserves CRLF uniformly instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LN2Qsx6JjVKV45o17EKGtB)_