### PR TITLE
docs: default the Euclid pipeline to the magma colormap (#509)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ python scripts/full_model.py --dataset=EUCLJ174517.55+655612.5 --iterations_per_
 and double source plane lenses. These will be added to this repository in future releases, but if you are interested
 in using these pipelines sooner please contact James Nightingale on the Euclid consortium SLACK.
 
+## Visualization
+
+Every 2D figure the pipeline produces uses the **magma** colormap by default.
+To change it, edit the `colormap` key of `config/visualize/general.yaml`:
+
+```yaml
+colormap: magma   # any matplotlib colormap name, or `autoarray` for the bundled PyAuto colormap
+```
+
+That one key covers imaging data, fits, residual maps and inversion
+reconstructions. A single figure can be overridden without touching config by
+passing `colormap=` to the plot function. See
+[`config/visualize/README.md`](config/visualize/README.md) for the details.
+
 ## Documentation
 
 The following links are useful for anyone more interested in the **PyAutoLens** software:

--- a/config/visualize/README.md
+++ b/config/visualize/README.md
@@ -9,3 +9,41 @@ The `config` folder contains configuration files which customize default **PyAut
 - `mat_wrap.yaml`: Specify the default matplotlib settings when figures and subplots are plotted.
 - `mat_wrap_1d.yaml`: Specify the default matplotlib settings when 1D figures and subplots are plotted.
 - `mat_wrap_2d.yaml`: Specify the default matplotlib settings when 2D figures and subplots are plotted.
+
+# Changing the colormap
+
+Every 2D figure this pipeline produces — imaging data, fits, residual maps,
+inversion reconstructions — draws with the colormap named by the `colormap` key
+of `general.yaml`. This repository ships **magma**:
+
+```yaml
+colormap: magma   # any matplotlib colormap name, or `autoarray` for the bundled PyAuto colormap
+```
+
+Editing that one key changes every 2D figure the pipeline produces. `autoarray`
+is the colormap bundled with **PyAutoArray**; any other value is looked up in
+matplotlib, so `magma`, `viridis`, `inferno`, `plasma`, `jet` and the rest of
+`list(matplotlib.colormaps)` all work.
+
+A name matplotlib does not recognise (a typo, say) raises a `ValueError` naming
+the key and the offending value — it is **not** silently swapped back for the
+default, so a colormap setting never goes quietly ignored.
+
+## One figure at a time
+
+To override the colormap for a single figure without touching config, pass
+`colormap=` to the plot function:
+
+```python
+import autolens.plot as aplt
+
+aplt.plot_array(array=image, colormap="viridis")
+aplt.subplot_fit_imaging(fit=fit, colormap="inferno")
+aplt.subplot_tracer(tracer=tracer, grid=grid, colormap="inferno")
+```
+
+A few figures deliberately fix their colormap because the colormap carries
+meaning a global preference should not override — the `array_overlay` of
+`plot_array` (`Greys`, so it stays legible over the main array), and the
+weak-lensing position-angle (cyclic) and residual (diverging) maps. The full
+list is in **PyAutoArray**'s `autoarray/config/visualize/README.md`.

--- a/config/visualize/general.yaml
+++ b/config/visualize/general.yaml
@@ -29,7 +29,7 @@ units:
   cb_unit: $\,\,\mathrm{e^{-}}\,\mathrm{s^{-1}}$ # The string or latex unit label used for the colorbar of the image, for example electrons per second.
   scaled_symbol: '"'                    # The symbol used when plotting spatial coordinates computed via the pixel_scale (e.g. for Astronomy data this is arc-seconds).
   unscaled_symbol: pix                  # The symbol used when plotting spatial coordinates in unscaled pixel units.
-colormap: autoarray               # Default colormap for 2D plots. Use any matplotlib name to override (e.g. jet, viridis).
+colormap: magma                   # Default colormap for 2D plots. Use any matplotlib name to override (e.g. autoarray, viridis, inferno). See config/visualize/README.md.
 ticks:
   extent_factor_2d: 0.75          # Fraction of half-extent used for 2D tick positions (< 1.0 pulls ticks inward from edges).
   number_of_ticks_2d: 3           # Number of ticks on each spatial axis of 2D plots.


### PR DESCRIPTION
## Summary

The Euclid pipeline now renders in **magma** out of the box, and the colormap lever is documented where a user will actually find it.

- `config/visualize/general.yaml` — `colormap: autoarray` → `colormap: magma`. One key, every 2D figure the pipeline produces: imaging data, fits, residual maps, inversion reconstructions.
- `config/visualize/README.md` — a "Changing the colormap" section: the config key, the per-figure `colormap=` override, and the figures that deliberately fix their colormap because the map carries meaning (cyclic position angles, diverging residuals, the contrasting `array_overlay`).
- `README.md` — a short **Visualization** section pointing at both, so the lever is discoverable without opening the config folder.

PyAutoArray and `autolens_workspace` deliberately keep `colormap: autoarray` — the original request scoped the magma default to the Euclid repo.

## Upstream PR

https://github.com/PyAutoLabs/PyAutoArray/pull/510 — makes a malformed `colormap` value raise instead of silently reverting, and documents the same lever library-side. **This PR merges only after that one** (library-first gate).

The magma default works with or without the upstream PR: `magma` is a valid matplotlib colormap either way. The upstream change only affects what happens to an *invalid* value.

## Scripts Changed

None. Config and documentation only — no script, notebook or pipeline behaviour changes, so no notebook regeneration was needed.

| File | Change |
|------|--------|
| `config/visualize/general.yaml` | `colormap: autoarray` → `colormap: magma` |
| `config/visualize/README.md` | new "Changing the colormap" section |
| `README.md` | new "Visualization" section |

## Test Plan

- [x] `config/visualize/general.yaml` parses as YAML and yields `colormap: magma`
- [x] End-to-end: pushing this repo's `config/` onto `conf.instance` and calling `autoarray.plot.utils._default_colormap()` returns `magma`
- [x] Acceptance demo (on the upstream branch): the same config value rendered an imaging `Array2D` figure and a rectangular-mapper inversion reconstruction, both visually magma
- [x] Every documented API call checked against the installed stack — `aplt.plot_array`, `aplt.subplot_fit_imaging` and `aplt.subplot_tracer` all exist in `autolens.plot` and all take `colormap=`

## API Changes

None — configuration and documentation only.

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXGHBFryzQZMFvAskHe9sQ
