### PR TITLE
docs: restore the narrative prose — start_here.py as the end-to-end guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,310 +1,151 @@
 # Euclid Strong Lens Modeling Pipeline — Agent Guidance
 
-This file is for AI coding agents (Claude Code, Codex, Cursor, etc.) and humans
-working in this repository. It is the agent-agnostic source of truth; Claude Code
-loads it via the `@AGENTS.md` import in `CLAUDE.md`.
+Agent-agnostic instructions for this repository (Claude Code loads them via the
+`@AGENTS.md` import in `CLAUDE.md`). It runs the Euclid strong lens modeling
+pipeline built on **PyAutoLens**: automated lens models (SIE + shear mass, MGE
+light) fitted to Euclid VIS imaging. `scripts/initial_lens_model.py` is the entry
+point; the other `scripts/` pipelines chain off it for pixelized sources, Sersic
+photometry and multi-band SED fits, and `catalogue/` turns finished fits into the
+per-lens inspection bundle. `start_here.py` in the root is a **thin shim** over
+`scripts/initial_lens_model.fit` — read and edit the script, not the shim.
 
-This repository provides the Euclid strong lens modeling pipeline, built on **PyAutoLens**. It fits automated lens models (SIE + shear mass, MGE light) to Euclid VIS imaging data. `scripts/initial_lens_model.py` is the entry point; the other `scripts/` pipelines chain off it for pixelized sources, Sersic photometry and multi-band SED fits, and `catalogue/` turns finished fits into the per-lens inspection bundle.
-
-`start_here.py` in the repository root is a **thin shim** over `scripts/initial_lens_model.fit` — it exists only so older commands and bookmarks keep working. Read and edit `scripts/initial_lens_model.py`.
-
-`docs/drift_report.md` is the durable record of the DR1 pipeline-parity port: what was inherited from the DR1 science runs, what was deliberately not, and why the non-obvious decisions (the Delaunay switch, the latent API, the noise-mask fallback chain) were made. Read it before changing any of them.
-
-## Scientific Context
-
-For the science behind this pipeline — what Euclid is finding, why SIE
-+ shear is a reasonable default mass model, what MGE buys, how
-multipoles and external shear affect substructure / cosmography
-downstream — see the lensing sub-wiki at
-[`PyAutoLabs/PyAutoMemory`](https://github.com/PyAutoLabs/PyAutoMemory),
-locally at `../PyAutoMemory/lensing_wiki/`. Most directly relevant:
-`entities/euclid-q1.md`, `concepts/mass-models.md`,
-`concepts/multipoles.md`, `concepts/external-convergence-shear.md`,
-`concepts/lens-finding.md`, `entities/slam-pipeline.md`.
-
----
+Read before editing: [`README.md`](README.md) (install, script tables, the shared
+CLI arguments, dataset requirements, testing and CI),
+[`scripts/README.md`](scripts/README.md) (what each pipeline, diagnostic and tool
+does) and [`docs/drift_report.md`](docs/drift_report.md) — the record of the DR1
+pipeline-parity port: what was inherited from the science runs, what was
+deliberately not, and why the non-obvious decisions (the Delaunay switch, the
+latent API, the noise-mask fallback chain) were made.
 
 ## Repository Structure
 
 ```
-start_here.py              # Thin shim over scripts/initial_lens_model.fit
-util.py                    # Shared utilities: dataset loading, analysis, latents, arg parsing
-activate.sh                # HPC venv activation (sets PYTHONPATH)
-config/                    # PyAutoLens YAML configuration files
-  latent.yaml              #   Which library latents this pipeline enables
-  build/                   #   Smoke/CI profile (profile_smoke.yaml) and skip list (no_run.yaml)
-dataset/                   # Input data: dataset/<sample>/<dataset_name>/
-  README.md                #   Every shipped dataset, what reads it, how to regenerate it
-output/                    # Results (generated at runtime, not committed)
-docs/drift_report.md       # Record of the DR1 pipeline-parity port
-.github/                   # CI: two workflows + their runners (see "Continuous Integration")
-scripts/                   # The pipelines:
-  initial_lens_model.py    #   ENTRY POINT — SIE + shear, MGE light, MGE source, Delaunay source pix
-  sersic_lens_model.py     #   Sersic lens+source fits for SED photometry (chains off vis_lp)
-  lens_model_waveband.py   #   Non-VIS bands with the VIS lens model fixed
-  sersic_lens_model_waveband.py  # SED chain driver: vis_lp -> Sersic -> every band
-  mge_lens_only.py         #   MGE lens-light-only subtraction
-  full_model.py            #   Full SLaM pipeline (Delaunay source pix + power-law mass)
-  diagnose_latent.py       #   Replay the latent catalogue on one converged result
-  diagnose_latent_vis_pix.py  # The same replay swept over a sample's vis_pix results
-  build_inspect.py         #   Collect the inspection bundle's PNGs from result zips
-  build_inspection_bundle.sh  # Run all seven catalogue stages in order
-  simulator.py             #   The ONLY producer of simulated data (--from-params/--from-result)
-catalogue/                 # Producers of the per-lens inspection bundle and master CSVs
-  README.md                #   13-file -> producer table, run order, upstream fits per stage
-  scripts/                 #   deblending, lens_mass, lens_sersic, source_sersic,
-                           #   multi_wavelength, magnitudes (+ shared catalogue_util.py)
-preprocess/                # Preprocessing tools (all accept --sample):
-  segmentation.py          #   Segmentation diagnostics + positions.json
-  adjust_binary.py         #   GUI binary mask tuning (--object=artefact|source|lens)
-  validation_GUI.py        #   Annotation GUI for segmentation QA
-  move_segmentation_fits.py #  Move segmentation FITS into dataset folders
-workflow/                  # Post-run analysis: csv_make.py, png_make.py, fits_make.py
-tools/                     # GUI utilities (extra galaxies masking, PSF sizing)
-hpc/                       # SLURM submit scripts and sync tooling
-tests/                     # pytest suites (see "Testing")
-  test_util.py             #   The shared helpers in util.py
-  test_compute_latent_variable.py  # Known-answer latent values against truth.json
-  test_catalogue_parity.py #   Catalogue columns vs the DR1 reference headers
-  test_repo_invariants.py  #   The rules CI enforces on new scripts
-  test_latent_run_level.py #   `slow`: a real fit still WRITES the latents
-  data/dr1_headers/        #   The four DR1 CSV header lines, checked in as fixtures
-pytest.ini                 # testpaths + the `slow` marker
-smoke_tests.txt            # Scripts the PyAutoHeart smoke runner executes, in order
+util.py             # Shared: dataset loading, analysis, the latent catalogue, arg parsing
+scripts/            # The fitting pipelines and the simulator  (scripts/README.md)
+  tools/            #   Diagnostics and catalogue tooling, kept out of the pipelines
+catalogue/          # Producers of the inspection bundle and master CSVs  (catalogue/README.md)
+preprocess/         # Segmentation diagnostics, mask-tuning GUIs, FITS movers
+workflow/           # Post-run analysis examples: csv_make.py, png_make.py, fits_make.py
+tools/              # GUI utilities (extra-galaxies masking, PSF sizing)
+hpc/                # SLURM submit scripts, the sync tooling, activate.sh's venv
+config/             # PyAutoLens YAML; build/ holds the smoke profile + the no_run skip list
+dataset/            # Input data: dataset/<sample>/<dataset_name>/  (dataset/README.md)
+output/             # Results (generated at runtime, not committed)
+tests/              # pytest suites, .github/ their CI workflows (see "Testing")
+smoke_tests.txt     # Scripts the PyAutoHeart smoke runner executes, in order
 ```
-
----
 
 ## Running Scripts
 
-Scripts are run from the repository root:
+Everything runs **from the repository root**. The shared argument parser, the two
+environment variables and the per-script tables are in
+[`README.md`](README.md#command-line-arguments) and
+[`scripts/README.md`](scripts/README.md), not duplicated here. What is not there:
 
-```bash
-python scripts/initial_lens_model.py --dataset=102018665_NEG570040238507752998 --sample=q1_walsmley
-
-python scripts/full_model.py --dataset=102018665_NEG570040238507752998 --sample=q1_walsmley
-```
-
-Every fitting pipeline shares one parser, `util.parse_fit_args()`, which returns a
-**6-tuple** `(sample_name, dataset_name, iterations_per_quick_update, number_of_cores, use_cpu, skip_pix)`:
-
-| Argument | Default | Meaning |
-|---|---|---|
-| `--dataset` | *required* | Dataset subdirectory inside `dataset/<sample>/`. |
-| `--sample` | none | Sample subdirectory inside `dataset/`. Omit for a flat layout. |
-| `--iterations_per_quick_update` | `5000` | Sampler iterations between on-the-fly visualisation updates. |
-| `--number_of_cores` | `1` | CPU cores for the non-JAX Nautilus searches. |
-| `--use_cpu` | off | Disables JAX and applies the CPU sparse operator to the pixelized stage. |
-| `--skip_pix` | off | Return after the MGE light-profile fit; skip the pixelized source stage. |
-
-`mask_radius` is never an argument — it is always read from the dataset's `info.json`.
-
-`PYAUTO_OUTPUT_DIR` (default `output`) relocates the results tree relative to the
-repository root. `scripts/sersic_lens_model_waveband.py` exists to be run under
-its own output dir so the many per-band results do not bloat the main tree, and
-the catalogue's stages 6-7 read that separate tree by name.
-
-The diagnostics take their own arguments. `scripts/diagnose_latent.py` accepts
-`--dataset` / `--sample` / `--output_path` / `--unique_tag` / `--search` /
-`--result_hash`; `scripts/diagnose_latent_vis_pix.py` is a population sweep and
-takes **no** `--dataset` (`--sample` / `--limit` / `--traceback` instead).
-
----
-
-## Test Mode Runs
-
-Set `PYAUTO_TEST_MODE=1` to make all non-linear searches complete almost instantly with trivial samples. Use this to verify the full pipeline executes without errors before submitting to the HPC or running a real fit. Set `PYAUTO_TEST_MODE=2` to additionally skip the sampler step entirely — fastest mode, used by the `/smoke_test` skill.
-
-Test-mode results are written under `<output>/test_mode/`, not `<output>/`.
-
-```bash
-D="--dataset=102018665_NEG570040238507752998 --sample=q1_walsmley"
-
-PYAUTO_TEST_MODE=1 python scripts/initial_lens_model.py $D
-PYAUTO_TEST_MODE=1 python scripts/full_model.py $D
-PYAUTO_TEST_MODE=1 python scripts/sersic_lens_model.py $D
-PYAUTO_TEST_MODE=1 python scripts/sersic_lens_model_waveband.py $D
-PYAUTO_TEST_MODE=1 python scripts/mge_lens_only.py $D
-PYAUTO_TEST_MODE=1 python scripts/lens_model_waveband.py $D
-```
-
-The example dataset lives at `dataset/q1_walsmley/102018665_NEG570040238507752998/`;
-swap in `--dataset=euclid_dr1_like --sample=simulated` to run the same commands on
-the committed mock.
-
----
+- `util.parse_fit_args()` returns a **6-tuple**: `(sample_name, dataset_name,
+  iterations_per_quick_update, number_of_cores, use_cpu, skip_pix)`.
+- The diagnostics take their own arguments. `scripts/tools/diagnose_latent.py`
+  accepts `--dataset` / `--sample` / `--output_path` / `--unique_tag` /
+  `--search` / `--result_hash`; `scripts/tools/diagnose_latent_vis_pix.py` is a
+  population sweep taking **no** `--dataset` (`--sample` / `--limit` /
+  `--traceback` instead).
+- `PYAUTO_TEST_MODE=1` makes every search finish almost instantly on trivial
+  samples; `2` also skips the sampler (the `/smoke_test` skill's mode). Results
+  land under `<output>/test_mode/`, never `<output>/`. Use it to check a script
+  executes before a real fit or an HPC submission.
+- From Codex or any restricted environment, point the caches somewhere writable:
+  `NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib`.
 
 ## Testing
 
-```bash
-python -m pytest -q -m "not slow"      # 58 tests, ~4 s — the local default
-python -m pytest -q -m slow            # 3 tests, 10-20 s — one real (non-test-mode) fit
-python -m pytest -q                    # both
-python3 .github/scripts/run_smoke.py   # the 9 scripts in smoke_tests.txt, in test mode
-```
+Commands and the CI job table are in README's "Testing and Continuous
+Integration". `pytest.ini` sets `testpaths = tests` and registers one marker,
+`slow`. The fast suite is deliberately **JAX-free** — no `use_jax=True`, no
+non-linear search — and a few seconds end to end.
 
-`pytest.ini` sets `testpaths = tests` and registers the one marker, `slow`.
-
-### The fast suite (`-m "not slow"`)
-
-Deliberately **JAX-free** — no `use_jax=True`, no non-linear search — and a few
-seconds end to end. Four modules:
-
-- `tests/test_util.py`: the pure helpers in `util.py` — the six-tuple CLI, the
-  noise-scaling mask fallback chain, the `WORST_PSF_*` header contract, the
-  `positions.json` fallback maths, and the latent **key set**.
-- `tests/test_compute_latent_variable.py`: known-answer tests for all 12 latents
-  against `dataset/simulated/euclid_dr1_like/truth.json`. Each latent is asserted
-  **twice**: once that replaying `util.LatentEuclid` on the truth model reproduces
-  `truth["latents"]` (a regression check — bit-identical in practice), and once
-  against the *independent* truth blocks the simulator computed without touching
-  `LatentEuclid`. The second set carries real tolerances, because the two sides
-  differ by documented physical offsets: the latents integrate the **masked** grid
-  (`mask_radius = 3"`) while the truth fluxes integrate the whole 100x100 frame.
-  `truth["conventions"]` spells each offset out — read it before changing a
-  tolerance.
-- `tests/test_catalogue_parity.py`: the four DR1 reference CSV header lines are
-  checked in verbatim under `tests/data/dr1_headers/`, and the header each
-  `catalogue/scripts/` producer would write is reconstructed from its own
-  `add_label_column` / `add_variable` calls (read with `ast`, with the suffix
-  expansion delegated to autofit's own `Column.value`) and compared exactly, order
-  included. To refresh the fixtures, re-copy `head -1` of the four DR1 reference
-  CSVs.
-- `tests/test_repo_invariants.py`: the rules below, enforced.
-
-### The `slow` suite (`-m slow`)
-
-`tests/test_latent_run_level.py` — one real-mode fit, 10-20 s depending on the
-machine, in its own CI job. The fast suite proves the latent *values* are right
-by calling `LatentEuclid.variables` directly, which is an **ungated** path: it
-would keep passing even if the pipeline never wrote a latent again. The write is gated by
-`autonerves.test_mode.skip_latents()` (`is_test_mode() or PYAUTO_SKIP_LATENTS`,
-consumed at one line of PyAutoFit's `updater.py`) and **no environment variable
-forces latents on under test mode** — so only a fit with `PYAUTO_TEST_MODE` unset
-can see it.
-
-Three things about that fit:
-
-- It uses `af.Drawer(total_draws=10)`, not a sampler: the cheapest real search in
-  PyAutoFit, while still running the full post-fit updater path. (The pipeline
-  scripts hard-code `n_live=750` for Nautilus with no override; that is not a CI
-  fit.) `latent_draw_via_pdf_size` is inert for `af.Drawer` — it falls back to all
-  samples — so there is no knob to turn there.
-- The model is **anchored on the truth** with one free parameter. A Drawer over a
-  fully free model draws junk: the source's linear intensity solves to exactly
-  zero and `magnification` becomes `0 / 0`.
-- The assertion is that `files/latent/latent_summary.json` holds exactly the 12
-  keys. **A NaN latent is dropped from that file entirely**, so the key count *is*
-  the NaN check — a latent that failed to compute is a missing key, never a NaN
-  value. (The file is `latent_summary.json` and not `files/latent.csv` because
-  `config/output.yaml` sets `latent_draw_via_pdf: true`, on which branch the
-  updater only calls `save_samples_summary`.)
+- `test_compute_latent_variable.py` — known-answer tests for all 12 latents
+  against `dataset/simulated/euclid_dr1_like/truth.json`, asserted both as a
+  bit-identical replay of `util.LatentEuclid` and against the *independent* truth
+  blocks the simulator computed without it. Those two differ by documented
+  physical offsets (the latents integrate the masked grid, the truth fluxes the
+  whole frame) — read `truth["conventions"]` before changing a tolerance.
+- `test_catalogue_parity.py` — each `catalogue/scripts/` producer's reconstructed
+  CSV header versus the four DR1 reference header lines under
+  `tests/data/dr1_headers/`; refresh those with `head -1` of the DR1 CSVs. Plus
+  `test_util.py` (the pure helpers) and `test_repo_invariants.py` (the rules
+  below).
+- `test_latent_run_level.py` (`slow`, its own CI job) — one real-mode fit proving
+  the pipeline still **writes** latents, which the fast suite cannot: it calls
+  `LatentEuclid.variables` directly, an ungated path, while the write is gated by
+  `autonerves.test_mode.skip_latents()` and nothing forces latents on under test
+  mode. It draws with `af.Drawer(total_draws=10)` on a model anchored to the truth
+  with one free parameter (over a free model a Drawer draws junk) and asserts
+  `files/latent/latent_summary.json` holds exactly the 12 keys — a NaN latent is
+  dropped from that file entirely, so the key count *is* the NaN check.
 
 ### Smoke tests
 
-`smoke_tests.txt` lists the scripts PyAutoHeart's smoke runner executes. Four
-things about that runner are load-bearing when editing the file:
+`smoke_tests.txt` lists what PyAutoHeart's smoke runner executes. Four things are
+load-bearing when editing it:
 
-- Entries run **in order, in one output directory** that is wiped once before the
-  first entry. `scripts/diagnose_latent.py` reads a finished result, so it must
-  stay below the scripts that produce one.
+- Entries run **in order, in one output directory** wiped once before the first.
+  `scripts/tools/diagnose_latent.py` reads a finished result, so it must stay
+  below the scripts that produce one.
 - One `args_default` from `config/build/profile_smoke.yaml` is appended to
-  **every** entry. A script that rejects `--dataset` cannot be listed —
-  `scripts/diagnose_latent_vis_pix.py` is in `config/build/no_run.yaml` for
-  exactly that reason. `scripts/simulator.py` accepts and ignores those two
-  arguments so that it can be listed.
+  **every** entry, so a script rejecting `--dataset` cannot be listed — hence
+  `scripts/tools/diagnose_latent_vis_pix.py` living in `no_run.yaml`, and
+  `scripts/simulator.py` accepting and ignoring those two arguments.
 - Per-script environment goes in `profile_smoke.yaml`'s `overrides:`, matched by
-  path substring. `scripts/diagnose_latent.py` uses one
-  (`PYAUTO_OUTPUT_DIR: output/test_mode`) so it resolves the test-mode results
-  the earlier entries wrote. An in-file declaration, if one is ever needed, is an
-  `__Env__` docstring section opened with a bare `"""` and carrying an `ENV:`
-  line with no leading `#` — the old column-0 `# ENV:` comment form was removed
-  and now **raises**.
-- `config/build/no_run.yaml` is **not** consulted when the runner is given the
-  `smoke_tests.txt` allowlist; it is policy for the release mega-run. A script
-  legitimately appears in both. It carries a reason inline for every entry.
-
----
+  path substring. An in-file declaration is an `__Env__` docstring section opened
+  with a bare `"""` and carrying an `ENV:` line with no leading `#`; the old
+  column-0 `# ENV:` form was removed and now **raises**.
+- `no_run.yaml` is **not** consulted when the runner is given the
+  `smoke_tests.txt` allowlist — it is policy for the release mega-run, so a
+  script legitimately appears in both. Every entry carries an inline reason.
 
 ## Continuous Integration
 
-Two workflows, three jobs, each on the ubuntu x Python 3.12/3.13 matrix with
-`fail-fast: false`. Both are thin callers into PyAutoHeart's reusable
-`smoke-tests.yml@main`, which owns the ceremony — dependency-chain checkout at
-the matching branch, the five-library **source** install, the cache dirs, the
-env-profile validation.
+The workflows, jobs and what each red X means are tabulated in README's "Testing
+and Continuous Integration". Both are thin callers into PyAutoHeart's reusable
+`smoke-tests.yml@main`, which owns the dependency-chain checkout at the matching
+branch and the five-library **source** install. `unit` and `slow` are two jobs on
+purpose: "a latent value is wrong" and "the pipeline stopped writing latents at
+all" should not arrive as the same red X. The smoke runner's `--report-dir` is
+load-bearing — `build_util.execute_script` only records a failure and carries on
+when a report was built, and `run_python.py` only propagates it when one exists;
+without it the gate aborts at the first break *and* exits 0.
 
-| Workflow | Job | Runs | A red X means |
-|---|---|---|---|
-| `.github/workflows/smoke_tests.yml` | `smoke` | Every `smoke_tests.txt` entry under `PYAUTO_TEST_MODE`, via `.github/scripts/run_smoke.py` | **A script broke.** |
-| `.github/workflows/tests.yml` | `unit` | `pytest -m "not slow"`, via `.github/scripts/run_tests.py` | **A latent value is wrong**, a catalogue column drifted from the DR1 reference, or a repository invariant broke. |
-| `.github/workflows/tests.yml` | `slow` | `pytest -m slow`, via `.github/scripts/run_tests.py --slow` | **The pipeline stopped writing latents.** |
-
-`unit` and `slow` are two jobs and not two legs of one on purpose: "a latent value
-is wrong" and "the pipeline stopped writing latents at all" are different failures
-and should not arrive as the same red X.
-
-The smoke runner passes `--report-dir`, which is load-bearing rather than
-cosmetic: `build_util.execute_script` only records a failure and carries on when a
-report was built, and `run_python.py` only propagates the failure when a report
-exists. Without it the gate aborts at the first break *and* exits 0. The report
-directory is `test-results/` (gitignored), uploaded by the reusable workflow as
-the `smoke-timings-<python-version>` artifact.
-
-**PyAutoHeart picks this repository up automatically.** `heart/smoke.py`'s
-`run_workspace` selects the modern runner on `.github/scripts/run_smoke.py`
-existing, so adding that file moved euclid off the `_run_legacy_workspace`
-fallback with no Heart-side change. Making the gate *release-blocking*
-(`required_workflows.pipelines` in `PyAutoHeart/config/repos.yaml`) and adding it
-to the weekly cloud sweep is a separate Heart-repo follow-up, filed at
-`PyAutoMind/draft/test/pyautoheart/euclid_pipeline_release_blocking_gate.md`.
-
-### Rules CI now enforces (`tests/test_repo_invariants.py`)
+### Rules CI enforces (`tests/test_repo_invariants.py`)
 
 1. **Nothing auto-simulates.** Only `scripts/simulator.py` may bring a dataset
    into being — no `SimulatorImaging`, `should_simulate` or `auto_simulate`
    anywhere else. Every fitting script reads a dataset off disk, the way a user
-   with real Euclid data runs it; a script that quietly simulates when it cannot
-   find one turns a broken data path into a green run.
-2. **Every script is accounted for.** Each `*.py` under `scripts/`,
-   `catalogue/scripts/`, `preprocess/`, `tools/`, `workflow/`, `.github/scripts/`
-   and the repository root is either listed in `smoke_tests.txt` or excluded in
-   `config/build/no_run.yaml` **with a written reason**. Adding a script without
-   doing one or the other fails the `unit` job.
+   with real Euclid data runs it; one that quietly simulates when it cannot find
+   a dataset turns a broken data path into a green run.
+2. **Every script is accounted for.** Each `*.py` under `scripts/` (recursively,
+   so `scripts/tools/` included), `catalogue/scripts/`, `preprocess/`, `tools/`,
+   `workflow/`, `.github/scripts/` and the repository root is either listed in
+   `smoke_tests.txt` or excluded in `config/build/no_run.yaml` **with a written
+   reason**. Doing neither fails the `unit` job.
 3. **The allowlist is not stale.** Every `smoke_tests.txt` entry exists on disk.
-
----
-
-## Codex / Sandboxed Runs
-
-When running from Codex or any restricted environment, set writable cache directories so `numba` and `matplotlib` do not fail on unwritable home or source-tree paths:
-
-```bash
-NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python scripts/initial_lens_model.py --dataset=102018665_NEG570040238507752998
-```
-
----
 
 ## Dataset Layout
 
 ```
-dataset/
-└── <sample_name>/
-    └── <dataset_name>/
-        ├── <dataset_name>.fits    # Multi-HDU FITS (VIS + NIR/EXT bands)   [required]
-        ├── info.json              # pixel_scale, mask_radius, mask_centre  [required]
-        ├── segmentation/          # DR1 preprocessing outputs              [optional]
-        │   ├── artefact_binary.fits  #   Preferred noise-scaling mask
-        │   ├── lens_flux.fits        #   Peak gives the mask centre
-        │   └── source_flux.fits      #   Used to derive positions if positions.json is absent
-        ├── mask_extra_galaxies.fits  # Fallback noise-scaling mask         [optional]
-        ├── positions.json         # Multiple-image positions               [optional]
-        ├── segmentation.png       # Collected into the inspection bundle   [optional]
-        └── rgb_0.png / rgb_1.png / rgb_0.jpg  # RGB thumbnails             [optional]
+dataset/<sample_name>/<dataset_name>/
+├── <dataset_name>.fits       # Multi-HDU FITS (VIS + NIR/EXT bands)   [required]
+├── info.json                 # pixel_scale, mask_radius, mask_centre  [required]
+├── segmentation/             # DR1 preprocessing: artefact_binary.fits (noise-scaling
+│                             #   mask), lens_flux.fits (mask centre), source_flux.fits
+│                             #   (positions, if positions.json is absent)  [optional]
+├── mask_extra_galaxies.fits  # Fallback noise-scaling mask            [optional]
+├── positions.json            # Multiple-image positions               [optional]
+├── segmentation.png          # Collected into the inspection bundle   [optional]
+└── rgb_0.png / rgb_1.png / rgb_0.jpg   # RGB thumbnails               [optional]
 ```
 
-`util.load_vis_dataset()` reads all of the above. Everything marked optional
-**degrades gracefully** — the fit still runs, with reduced information:
+`util.load_vis_dataset()` reads all of it. Everything optional **degrades
+gracefully** — the fit still runs, with reduced information:
 
 | Input | Preferred | Falls back to | If neither |
 |---|---|---|---|
@@ -312,154 +153,93 @@ dataset/
 | Mask centre | peak of `segmentation/lens_flux.fits` | `info["mask_centre"]` | Frame centre `(0, 0)`. |
 | Positions | `positions.json` (2+ positions) | derived from `segmentation/source_flux.fits` + the VIS noise map | No positions likelihood. |
 
-The shipped example dataset has no `segmentation/` directory and no
-`positions.json`, so it exercises the fallback branches — which is why they exist
-as a chain and not a replacement.
+The FITS **primary** header must also carry the `WORST_BAND` / `WORST_PSF_*`
+contract for the aperture-flux latents. It is stamped by the upstream Euclid
+cut-out generator — neither this pipeline nor PyAutoReduce writes it — and is
+documented where it is read, in `util.py` (`load_vis_dataset` for `WORST_BAND`
+and its two degradation paths, `psf_fwhm_arcsec_from_primary_header` for the FWHM
+key order and the `-99` sentinel).
 
-The FITS **primary** header must additionally carry `WORST_BAND` and one of
-`WORST_PSF_MER` / `WORST_PSF_HDR` / `WORST_PSF` for the aperture-flux latents.
-These are stamped by the upstream Euclid cut-out generator; neither this pipeline
-nor PyAutoReduce writes them. See the README's "Dataset Requirements" section for
-the full contract and the two degradation paths.
+[`dataset/README.md`](dataset/README.md) is the per-dataset table. Two ship:
+`q1_walsmley/102018665_NEG570040238507752998/`, **real** Q1 imaging and every
+script's default, which ships no `segmentation/` and no `positions.json` and so
+exercises the *fallback* branches above; and `simulated/euclid_dr1_like/`, the
+`scripts/simulator.py` mock, which ships everything the real one lacks and so
+exercises the *preferred* branches, builds a complete 13-of-13 inspection bundle,
+and whose `truth.json` is the known-answer source for the latent tests.
 
-### The two shipped datasets
+Two gotchas before adding a dataset:
 
-[`dataset/README.md`](dataset/README.md) is the per-dataset table — one row each,
-with what reads it and how to regenerate it. In short:
+- `.gitignore` carries `*.fits`, so **new committed FITS need `git add -f`** —
+  without it they silently do not stage and the dataset lands half-committed.
+- `preprocess/segmentation.py` **overwrites `positions.json`** from the local
+  maxima of `segmentation/source_flux.fits`, discarding exact positions a
+  simulator solved for. Back it up, or re-run the simulator (deterministic for a
+  given `--seed`).
 
-- `q1_walsmley/102018665_NEG570040238507752998/` — **real** Euclid Q1 MER
-  imaging, 8 bands, 1.3 MB. Every fitting script's default, the smoke profile's
-  `args_default`, and the catalogue's default sample. It ships no `segmentation/`
-  and no `positions.json`, so it is the dataset that exercises the *fallback*
-  branches above. **It stays the smoke default** — it is what users see, and CI
-  fitting a mock everywhere would not.
-- `simulated/euclid_dr1_like/` — the **simulated** DR1-layout mock written by
-  `scripts/simulator.py`, 4 bands, 900 KB. It ships everything the real dataset
-  lacks, so it exercises the *preferred* branch of every optional-input chain and
-  is the one dataset that builds a complete 13-of-13 inspection bundle. Its
-  `truth.json` is the known-answer source for the latent tests, and it is the
-  dataset the `slow` run-level fit uses.
-
-Two conventions to know before adding a dataset:
-
-- `.gitignore` carries `*.fits`, so **new committed FITS need `git add -f`**.
-  Without it they silently do not stage and the dataset lands half-committed.
-- `preprocess/segmentation.py` is the producer of `segmentation.png`, and it
-  **overwrites `positions.json`** from the local maxima of
-  `segmentation/source_flux.fits` — discarding exact positions a simulator solved
-  for. Back the file up and restore it, or re-run the simulator (deterministic for
-  a given `--seed`).
-
-`dataset/sample_group/` and `dataset/sample_point/` were removed in phase 2: 4.6 MB
-with no consumer anywhere in the repository. Git history keeps them.
-
-### `scripts/simulator.py`
-
-The only producer of simulated data (invariant 1 above), and shared with phase 5 of
-the DR1 prep epic. Two modes:
-
-- `--from-params` — an analytic lens (`Isothermal` + `ExternalShear` mass, `Sersic`
-  lens light, `Sersic` source) from the truth values at the top of the script. This
-  wrote `dataset/simulated/euclid_dr1_like/` with `--from-params --seed 1`.
-- `--from-result` — **phase 5's resimulation contract.** The tracer is rebuilt from
-  a finished fit's `model.json` + maximum-log-likelihood sample (resolved with
-  `diagnose_latent.py::resolve_files_path`, so it takes the same `--sample` /
-  `--dataset` / `--unique_tag` / `--search` / `--result_hash`), and the bands, PSF
-  stamps, zero-points, WCS and noise levels come from the dataset the fit was made
-  on. Two rules are already implemented: a lens-light `sersic_index` at or above
-  `--sersic-index-prior-edge` (5.0) is a pinned prior edge and is replaced by
-  `--sersic-index-replacement` (3.0), with **both** values recorded in
-  `truth.json`; and a single-band fit written to several bands applies the fitted
-  intensities to every band — a **flat SED**, recorded as `sed: "flat"`. Per-band
-  colour needs a per-band fit (`scripts/sersic_lens_model_waveband.py`) simulated
-  band by band; that is phase 5's to change, not a bug here.
-
-Every run writes `truth.json` beside the data: every model parameter, the per-band
-lens / lensed-source / source fluxes in counts and microJansky, the four aperture
-lens fluxes, the true magnification, the true Einstein radius, and the 12 pipeline
-latents evaluated on the truth model.
-
-Under `PYAUTO_TEST_MODE` the output is redirected to
-`$PYAUTO_OUTPUT_DIR/simulator/<sample>/<dataset>/` instead of `dataset/`, so the
-smoke entry for this script can never overwrite the committed dataset;
-`--force-dataset-dir` overrides that.
-
----
+`scripts/simulator.py` is the only producer of simulated data (invariant 1);
+[`scripts/README.md`](scripts/README.md) covers its two modes and the `truth.json`
+it writes. Under `PYAUTO_TEST_MODE` it redirects to
+`$PYAUTO_OUTPUT_DIR/simulator/<sample>/<dataset>/` so the smoke entry can never
+overwrite the committed dataset (`--force-dataset-dir` overrides that).
 
 ## HPC
 
-```
-hpc/
-├── batch_gpu/                      # GPU submit scripts + SLURM logs
-│   ├── submit_initial_lens_model   #   scripts/initial_lens_model.py (array job)
-│   ├── submit_full_model           #   scripts/full_model.py
-│   ├── submit_sersic_waveband      #   scripts/sersic_lens_model_waveband.py (SED chain)
-│   ├── output/                     #   SLURM stdout logs
-│   └── error/                      #   SLURM stderr logs
-├── batch_cpu/                      # CPU submit scripts + SLURM logs
-│   ├── submit_initial_lens_model   #   Same, with --use_cpu --number_of_cores
-│   ├── template                    #   One-off single run, not an array
-│   ├── output/
-│   └── error/
-├── sync                            # Bidirectional sync script (local <-> HPC)
-└── sync.conf.example               # Template config for sync
-```
+`hpc/` holds the `batch_gpu/` / `batch_cpu/` SLURM submit scripts (with their
+`output/` and `error/` logs) and the `sync` script. Setup:
+`cp hpc/sync.conf.example hpc/sync.conf` and edit in your host and paths
+(`sync.conf` is gitignored). `hpc/sync push | pull | sync | status`: `push` sends
+the source trees plus `dataset/` with `--ignore-existing`, `pull` retrieves
+`output/`, `output_sed/` (the SED chain's tree) and `inspect/`, skipping any
+absent on the cluster. Submit from the cluster itself, e.g.
+`sbatch hpc/batch_gpu/submit_initial_lens_model`, with `PROJECT_PATH` exported to
+the remote project root.
 
-Setup: `cp hpc/sync.conf.example hpc/sync.conf` and edit with your HPC host and paths. `sync.conf` is gitignored.
-
-Commands: `hpc/sync push`, `hpc/sync pull`, `hpc/sync sync` (push then pull), `hpc/sync status` (dry run).
-`push` sends `catalogue/ config/ hpc/ preprocess/ scripts/ tests/ tools/ workflow/` plus the root
-source files, and `dataset/` with `--ignore-existing`. `pull` retrieves `output/`,
-`output_sed/` (the SED chain's tree) and `inspect/` (the built bundles); a
-directory that does not exist on the cluster is skipped, not an error.
-
-Submit the SLURM jobs from the cluster itself: `sbatch hpc/batch_gpu/submit_initial_lens_model`
-with `PROJECT_PATH` exported to the remote project root.
-
-### Config settings to change on the cluster
-
-The shipped `config/` is deliberately **laptop-friendly**. Three settings were
-different in the DR1 science runs, and they are cluster choices rather than
-sensible public defaults, so they are documented here instead of being baked in.
-Set them on the cluster; leave the repository defaults alone. There is no
-override mechanism — edit the YAML in your cluster checkout.
-
-All three live in `config/general.yaml`:
-
-| Key | Repo default | Set on the cluster | Why |
-|---|---|---|---|
-| `output.samples_to_csv` | `true` | `false` | At 20,000 tiles a `samples.csv` per search is a lot of disk. Local users want them. (The science runs' config predates the rename and spells this `output.samples`.) |
-| `hpc.hpc_mode` | `false` | `true` | Disables GUI visualization and screen logging, which are not suited to a batch node. Pair it with `hpc.iterations_per_quick_update` — repo `10000`, science runs `100000`. |
-| `numba.cache` | `true` | `false` | Numba's on-disk cache is unreliable on NFS; disabling it trades a little start-up time for not failing. |
-
+The shipped `config/` is deliberately **laptop-friendly**. Three
+`config/general.yaml` keys were different in the DR1 science runs — cluster
+choices rather than sensible public defaults, so change them in your cluster
+checkout (there is no override mechanism) and leave the repository defaults
+alone: `output.samples_to_csv` → `false` (at 20,000 tiles a `samples.csv` per
+search is a lot of disk; local users want them), `hpc.hpc_mode` → `true` (drops
+GUI visualization and screen logging — pair with
+`hpc.iterations_per_quick_update`, repo `10000`, science runs `100000`), and
+`numba.cache` → `false` (Numba's on-disk cache is unreliable on NFS).
 `docs/drift_report.md` §8 records why the rest of the science runs' config was
 **not** adopted: it is stale relative to the installed library, not ahead of it.
-
----
 
 ## Not ported — available in `Science/euclid`
 
 The DR1 science runs were driven from a private tree (`Science/euclid`). Phase 1
-of the DR1 prep ported the analysis chain, `util.py`, the catalogue producers and
-the docs into this repository. The following were deliberately left behind. If
-you need one, it is in that tree — do not re-derive it from scratch without
-checking there first. `docs/drift_report.md` §10 carries the same list with
-fuller reasoning.
+ported the analysis chain, `util.py`, the catalogue producers and the docs here;
+some things were deliberately left behind. **If you need one, it is in that tree
+— do not re-derive it from scratch without checking there first.**
 
-| Left in `Science/euclid` | Reason |
-|---|---|
-| `scripts/sersic_lens_model_pix.py`, `scripts/sersic_lens_model_pix_waveband.py`, `scripts/multi_lens_model_pix_waveband.py` | Pixelized-source SED variants, superseded by the Delaunay Source Pix stages in `scripts/full_model.py`. |
-| `scripts/galaxy_sersic_model.py` | Non-lens galaxy fitting; out of scope for a lens-modelling pipeline. |
-| `scripts/audit_sed_outputs.py`, `scripts/audit_unresolved_hpc.sh`, `scripts/reorganize_normies.py` | Operational one-offs against a private results tree. |
-| `lens_model_waveband.py::fit_waveband_galaxy`, `::fit_waveband_pix` | Waveband variants with no caller in this repository's chain. |
-| The 21 catalogue scripts (paper figures, QA copy tools, superseded precursors) | Listed individually with a reason each in [`catalogue/README.md`](catalogue/README.md#not-ported--available-in-scienceeuclid) — not duplicated here. |
-| `preprocess/recenter_lens_centre.py` | Only needed on the `segmentation/lens_flux.fits` mask-centre path, which the fallback chain handles without it. |
+`docs/drift_report.md` §10 is the full list with a reason for each. In summary:
+the pixelized-source SED variants (`sersic_lens_model_pix*.py`,
+`multi_lens_model_pix_waveband.py`), superseded by the Delaunay Source Pix stages
+in `scripts/full_model.py`; `galaxy_sersic_model.py` (non-lens galaxy fitting,
+out of scope); the one-offs against a private results tree
+(`audit_sed_outputs.py`, `audit_unresolved_hpc.sh`, `reorganize_normies.py`);
+`lens_model_waveband.py::fit_waveband_galaxy` / `::fit_waveband_pix` (no caller
+in this chain); `preprocess/recenter_lens_centre.py` (the mask-centre fallback
+chain handles its case); and 21 catalogue scripts, listed individually in
+[`catalogue/README.md`](catalogue/README.md#not-ported--available-in-scienceeuclid).
 
----
+## Scientific Context
+
+For the science behind this pipeline — what Euclid is finding, why SIE + shear is
+a reasonable default mass model, what MGE buys, how multipoles and external shear
+affect substructure / cosmography downstream — see the lensing sub-wiki at
+[`PyAutoLabs/PyAutoMemory`](https://github.com/PyAutoLabs/PyAutoMemory), locally
+at `../PyAutoMemory/lensing_wiki/`: `entities/euclid-q1.md`,
+`concepts/mass-models.md`, `concepts/multipoles.md`,
+`concepts/external-convergence-shear.md`, `concepts/lens-finding.md`,
+`entities/slam-pipeline.md`.
 
 ## Line Endings — Always Unix (LF)
 
-All files must use Unix line endings (`\n`). CRLF will break shell scripts on the HPC. After creating or editing files, verify with `file <path>` and convert with `dos2unix` if needed.
+All files must use Unix line endings (`\n`); CRLF breaks shell scripts on the
+HPC. Verify with `file <path>` and convert with `dos2unix` if needed.
 
 <!-- repos_sync:history:begin -->
 ## Never rewrite history

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ If key output for your science case is not generated, please contact James Night
 SLACK so it can be added to the pipeline and become a standard output of the Euclid strong lens modeling pipeline
 and therefore data release.
 
+Some scripts used for the DR1 science runs were deliberately left out of this
+repository — see
+[`AGENTS.md`](AGENTS.md#not-ported--available-in-scienceeuclid) for the list and a
+reason for each, and [`docs/drift_report.md`](docs/drift_report.md) for the full
+record of what this pipeline inherited from the DR1 runs and why.
+
 ## Workflow
 
 After running `scripts/initial_lens_model.py` on many lenses, you will begin to build up a large number of results
@@ -84,6 +90,14 @@ efficient workflow to inspect the results and perform scientific analysis.
 The `workflow` folder contains example scripts for creating workflows which enable efficient inspection of
 large lens modeling results. Workflows are designed by creating .png, .csv and .fits files from the results
 in the `output` folder for fast inspection.
+
+## Documentation
+
+The following links are useful for anyone more interested in the **PyAutoLens** software:
+
+- [The PyAutoLens readthedocs](https://pyautolens.readthedocs.io/en/latest): which includes [an overview of PyAutoLens's core features](https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautolens.readthedocs.io/en/latest/installation/overview.html).
+- [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.7.9.1/start_here.ipynb): try **PyAutoLens** in a web browser (without installation).
+- [The autolens_workspace GitHub repository](https://github.com/PyAutoLabs/autolens_workspace): example scripts and the HowToLens Jupyter notebook lectures.
 
 ## The Scripts
 
@@ -106,57 +120,21 @@ python scripts/full_model.py --sample=q1_walsmley --dataset=EUCLJ174517.55+65561
 | `scripts/mge_lens_only.py` | MGE subtraction of the lens light only, revealing the lensed source quickly. | — |
 | `scripts/full_model.py` | The full SLaM chain: MGE source, two Delaunay pixelized-source stages, refined lens light, then a PowerLaw + shear mass model. Uses `al.mesh.Delaunay` with `al.reg.AdaptSplit` (`reg.Adapt` cannot JIT on the Delaunay family) and `pixels=500` in its second stage — the `autolens_workspace` `delaunay.py` example uses 1000, but Euclid VIS cut-outs are small. | — |
 
+**PyAutoLens** also has automated pipelines for modeling group-scale strong lenses, lensed
+point sources (e.g. lensed quasars) and double source plane lenses. They were previously
+in this repository and were removed (commit `fc43be0`, 2025-11-05) when it was narrowed to
+the Euclid VIS chain above; they still live in **PyAutoLens** itself and can be restored
+here on request — contact James Nightingale on the Euclid consortium SLACK.
+
 ### Diagnostics and catalogue
 
 | Script | What it does |
 |---|---|
-| `scripts/diagnose_latent.py` | Replays the Euclid latent catalogue on one converged result and prints every latent value, flagging NaN and zero sentinels. Runs no search. |
-| `scripts/diagnose_latent_vis_pix.py` | The population version: the same replay over every `vis_pix` result in a sample, reporting per-dataset OK/ERR. |
-| `scripts/build_inspect.py` | Collects the inspection bundle's PNGs out of finished result zips. |
+| `scripts/tools/diagnose_latent.py` | Replays the Euclid latent catalogue on one converged result and prints every latent value, flagging NaN and zero sentinels. Runs no search. |
+| `scripts/tools/diagnose_latent_vis_pix.py` | The population version: the same replay over every `vis_pix` result in a sample, reporting per-dataset OK/ERR. |
+| `scripts/tools/build_inspect.py` | Collects the inspection bundle's PNGs out of finished result zips. |
 | `scripts/build_inspection_bundle.sh` | Runs all seven catalogue stages in order for a sample. |
 | `catalogue/` | The producers that turn finished fits into the per-lens inspection bundle and the master CSVs — see [`catalogue/README.md`](catalogue/README.md) for the 13-file to producer table and the run order. |
-
-### Simulating a lens
-
-`scripts/simulator.py` is this repository's **only** producer of simulated data — no
-fitting script auto-simulates a missing dataset, because most users fit real Euclid
-imaging and a silent auto-simulate would hide a broken data path. It writes an
-ordinary dataset of this pipeline, so every fitting script reads it unchanged, plus a
-`truth.json` recording every parameter, per-band flux, aperture flux, magnification
-and Einstein radius that went in.
-
-```bash
-# --from-params: an analytic lens (Isothermal + shear mass, Sersic lens light,
-# Sersic source) from the truth values at the top of the script
-python scripts/simulator.py --from-params --output-dataset=my_lens
-
-# --from-result: resimulate a fit you have already run. The tracer is rebuilt from
-# that result's model.json + maximum-log-likelihood sample; the bands, PSFs,
-# zero-points, WCS and noise come from the dataset it was fitted to.
-python scripts/simulator.py --from-result \
-    --sample=q1_walsmley --dataset=102018665_NEG570040238507752998 \
-    --unique_tag=sersic_lens_model --search=vis \
-    --output-dataset=102018665_resimulated
-```
-
-`python scripts/simulator.py --help` lists the rest (bands, image shape, pixel scale,
-mask radius, seed). Under `PYAUTO_TEST_MODE` the output goes to
-`$PYAUTO_OUTPUT_DIR/simulator/` instead of `dataset/`, so a smoke run can never
-overwrite a committed dataset; `--force-dataset-dir` writes to `dataset/` anyway.
-
-The mock this repository ships is `dataset/simulated/euclid_dr1_like/`. See
-[`dataset/README.md`](dataset/README.md) for every dataset here, what it is, what
-reads it and how to regenerate it.
-
-Some scripts used for the DR1 science runs were deliberately left out of this
-repository — see
-[`AGENTS.md`](AGENTS.md#not-ported--available-in-scienceeuclid) for the list and a
-reason for each, and [`docs/drift_report.md`](docs/drift_report.md) for the full
-record of what this pipeline inherited from the DR1 runs and why.
-
-**PyAutoLens** has automated pipelines for modeling group-scale strong lenses, lensed point sources (e.g. lensed quasars)
-and double source plane lenses. These will be added to this repository in future releases, but if you are interested
-in using these pipelines sooner please contact James Nightingale on the Euclid consortium SLACK.
 
 ## Command-Line Arguments
 
@@ -184,6 +162,32 @@ Two environment variables change where results go:
   `<output>/test_mode/`. Use it to check a script runs before submitting a real
   fit.
 
+## Simulating a lens
+
+`scripts/simulator.py` is this repository's **only** producer of simulated data — no
+fitting script auto-simulates a missing dataset, because most users fit real Euclid
+imaging and a silent auto-simulate would hide a broken data path. It writes an ordinary
+dataset of this pipeline, so every fitting script reads it unchanged, plus a `truth.json`
+recording every parameter, per-band flux, aperture flux, magnification and Einstein
+radius that went in; the mock it produced and this repository ships is
+`dataset/simulated/euclid_dr1_like/` (see [`dataset/README.md`](dataset/README.md) for
+every dataset here and how to regenerate it). `python scripts/simulator.py --help` lists
+the rest of the options — bands, image shape, pixel scale, mask radius, seed.
+
+```bash
+# --from-params: an analytic lens (Isothermal + shear mass, Sersic lens light,
+# Sersic source) from the truth values at the top of the script
+python scripts/simulator.py --from-params --output-dataset=my_lens
+
+# --from-result: resimulate a fit you have already run. The tracer is rebuilt from
+# that result's model.json + maximum-log-likelihood sample; the bands, PSFs,
+# zero-points, WCS and noise come from the dataset it was fitted to.
+python scripts/simulator.py --from-result \
+    --sample=q1_walsmley --dataset=102018665_NEG570040238507752998 \
+    --unique_tag=sersic_lens_model --search=vis \
+    --output-dataset=102018665_resimulated
+```
+
 ## Dataset Requirements
 
 A dataset directory is `dataset/<sample>/<name>/` and holds `<name>.fits` (the
@@ -192,30 +196,11 @@ multi-HDU cut-out) and `info.json` (`pixel_scale`, `mask_radius`, optionally
 dataset this repository ships is listed in [`dataset/README.md`](dataset/README.md),
 with what reads it and how to regenerate it.
 
-### The `WORST_BAND` / `WORST_PSF_*` header contract
-
-The four aperture-flux latent variables (`total_lens_flux_{1,2,3,4}_fwhm_mujy`)
-are matched-aperture photometry: the lens image is convolved to the resolution of
-the **worst-seeing** band across all MER bands, and fluxes are measured at 1, 2, 3
-and 4 times that band's PSF FWHM. Two things in the FITS **primary** header make
-that possible, and both are stamped by the upstream Euclid cut-out generator —
-neither this pipeline nor PyAutoReduce writes them, so they are an input contract
-on the dataset:
-
-- **`WORST_BAND`** names the worst-seeing band (e.g. `DES_G`). Lower-cased it
-  indexes the HDU list to find that band's PSF.
-- **`WORST_PSF_MER`**, **`WORST_PSF_HDR`**, **`WORST_PSF`** hold that PSF's FWHM
-  in arcsec. They are read in that order — the OU-MER measured value first, then
-  the cut-out pipeline's own — skipping Euclid's `-99` "not measured" sentinel.
-
-What happens when they are absent:
-
-- **`WORST_BAND` missing, or naming a band not in the cut-out** — a warning is
-  printed and the four aperture latents are skipped for that dataset. The fit
-  itself is unaffected.
-- **`WORST_BAND` present but all three FWHM keys missing or `-99`** — the load
-  **raises**. This is deliberate: the aperture radii are multiples of this FWHM,
-  so a guessed value would silently corrupt the photometry rather than fail.
+The FITS **primary** header additionally carries the `WORST_BAND` / `WORST_PSF_*`
+input contract that the aperture-flux latents need. It is documented where it is
+read, in `util.py` — `load_vis_dataset` for `WORST_BAND` and the two degradation
+paths, `psf_fwhm_arcsec_from_primary_header` for the FWHM key order and the `-99`
+sentinel.
 
 ## Testing and Continuous Integration
 
@@ -244,7 +229,8 @@ A new script is not automatically covered: `tests/test_repo_invariants.py` fails
 unless every `*.py` under `scripts/`, `catalogue/scripts/`, `preprocess/`, `tools/`,
 `workflow/`, `.github/scripts/` and the repository root is either listed in
 `smoke_tests.txt` or excluded in `config/build/no_run.yaml` with a written reason.
-[`AGENTS.md`](AGENTS.md#continuous-integration) has the full CI section.
+[`AGENTS.md`](AGENTS.md#continuous-integration) carries the runner details and the
+three invariants CI enforces.
 
 ## Visualization
 
@@ -259,11 +245,3 @@ That one key covers imaging data, fits, residual maps and inversion
 reconstructions. A single figure can be overridden without touching config by
 passing `colormap=` to the plot function. See
 [`config/visualize/README.md`](config/visualize/README.md) for the details.
-
-## Documentation
-
-The following links are useful for anyone more interested in the **PyAutoLens** software:
-
-- [The PyAutoLens readthedocs](https://pyautolens.readthedocs.io/en/latest): which includes [an overview of PyAutoLens's core features](https://pyautolens.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautolens.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautolens.readthedocs.io/en/latest/installation/overview.html).
-- [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autolens_workspace/blob/2026.7.9.1/start_here.ipynb): try **PyAutoLens** in a web browser (without installation).
-- [The autolens_workspace GitHub repository](https://github.com/PyAutoLabs/autolens_workspace): example scripts and the HowToLens Jupyter notebook lectures.

--- a/catalogue/README.md
+++ b/catalogue/README.md
@@ -5,12 +5,31 @@ bundle**: one folder per lens holding everything a scientist needs to judge that
 lens, plus master CSVs spanning the whole sample. It is the direct ancestor of
 the exported DR1 catalogue.
 
+### Relation to `workflow/`
+
+Both trees read finished fits out of `output/` through the PyAutoFit aggregator,
+and they differ in purpose rather than in mechanism. `workflow/` holds *general
+examples* of the aggregator export API — `csv_make.py`, `png_make.py` and
+`fits_make.py` teach it step by step, and `workflow/example/` shows it applied to
+real Euclid runs. `catalogue/` holds the *production* producers: the scripts the
+bundle builder actually runs to write the 13 bundle files and the master CSVs.
+
+The clearest way in is to read the two side by side.
+`workflow/example/csv/lens_mass.py` builds the same table as
+`catalogue/scripts/lens_mass.py` — the mass model parameters of every VIS fit,
+scraped through the same `AggregateCSV` API — written as a flat top-to-bottom
+tutorial that explains each call as it makes it, and saved under its own name
+into `workflow/csv/`. The catalogue version is that same scrape wrapped in
+argument parsing, sample-wide path resolution, the extra sigma columns and the
+per-lens split, so it can be driven by `scripts/build_inspection_bundle.sh`.
+Read the tutorial for the API; read the producer for what DR1 actually ships.
+
 Producers live in `catalogue/scripts/`. The two orchestration scripts live in
 `scripts/` beside the pipelines they read from:
 
 ```
 scripts/build_inspection_bundle.sh   # runs the seven stages in order
-scripts/build_inspect.py             # stage 1 — collects the 6 bundle PNGs
+scripts/tools/build_inspect.py             # stage 1 — collects the 6 bundle PNGs
 catalogue/scripts/
   catalogue_util.py                  # shared path resolution + per-lens CSV split
   deblending.py                      # stage 2 — pre_psf.fits, model.fits
@@ -38,12 +57,12 @@ fit already wrote.
 | `pre_psf.fits` | `catalogue/scripts/deblending.py` | generates | `sersic_lens_model` (every waveband) |
 | `model.fits` | `catalogue/scripts/deblending.py` | generates | `sersic_lens_model` (every waveband) |
 | `fit_multi_wavelength.png` | `catalogue/scripts/multi_wavelength.py` | generates | multi-band `sersic_lens_model/<band>` in `output_sed/` |
-| `vis_lp_fit.png` | `scripts/build_inspect.py` | collects `image/fit.png` | `initial_lens_model/vis_lp` |
-| `vis_pix_fit.png` | `scripts/build_inspect.py` | collects `image/fit.png` | `initial_lens_model/vis_pix` |
-| `vis_lp_image_with_positions.png` | `scripts/build_inspect.py` | collects `image/image_with_positions.png` (best-effort) | `initial_lens_model/vis_lp` + the lens's `positions.json` |
-| `rgb.png` | `scripts/build_inspect.py` | collects `image/rgb.png`, else copies `dataset/<sample>/<lens>/rgb_0.jpg` | `initial_lens_model/vis_lp` |
-| `segmentation.png` | `scripts/build_inspect.py` | copies `dataset/<sample>/<lens>/segmentation.png` | `preprocess/segmentation.py` |
-| `fit_sersic.png` | `scripts/build_inspect.py` | collects `image/fit.png` | `sersic_lens_model/vis` |
+| `vis_lp_fit.png` | `scripts/tools/build_inspect.py` | collects `image/fit.png` | `initial_lens_model/vis_lp` |
+| `vis_pix_fit.png` | `scripts/tools/build_inspect.py` | collects `image/fit.png` | `initial_lens_model/vis_pix` |
+| `vis_lp_image_with_positions.png` | `scripts/tools/build_inspect.py` | collects `image/image_with_positions.png` (best-effort) | `initial_lens_model/vis_lp` + the lens's `positions.json` |
+| `rgb.png` | `scripts/tools/build_inspect.py` | collects `image/rgb.png`, else copies `dataset/<sample>/<lens>/rgb_0.jpg` | `initial_lens_model/vis_lp` |
+| `segmentation.png` | `scripts/tools/build_inspect.py` | copies `dataset/<sample>/<lens>/segmentation.png` | `preprocess/segmentation.py` |
+| `fit_sersic.png` | `scripts/tools/build_inspect.py` | collects `image/fit.png` | `sersic_lens_model/vis` |
 
 `build_inspect.py` never re-renders: it streams the image out of the result zip
 PyAutoFit writes when a search finishes, falling back to the unzipped result
@@ -81,7 +100,7 @@ bash scripts/build_inspection_bundle.sh dr1_prelim_grade_ab run250
 
 | Stage | Script | Reads | Writes |
 |---|---|---|---|
-| 1/7 | `scripts/build_inspect.py` | `output/<sample>/` | the 6 collected PNGs |
+| 1/7 | `scripts/tools/build_inspect.py` | `output/<sample>/` | the 6 collected PNGs |
 | 2/7 | `catalogue/scripts/deblending.py` | `output/<sample>/` | `pre_psf.fits`, `model.fits` |
 | 3/7 | `catalogue/scripts/lens_mass.py` | `output/<sample>/` | `lens_mass.csv` |
 | 4/7 | `catalogue/scripts/lens_sersic.py` | `output/<sample>/` | `lens_sersic.csv` |

--- a/catalogue/scripts/catalogue_util.py
+++ b/catalogue/scripts/catalogue_util.py
@@ -119,7 +119,18 @@ def write_per_tile_csv(master_csv: Path, inspect_path: Path, filename: str) -> i
     emitting several rows per lens (``magnitudes``, one per waveband) both work.
     Rows without a ``lens_name`` are skipped.
 
-    Returns the number of per-lens files written.
+    The split reads the master back rather than being handed the rows, so the two
+    can never disagree, and each per-lens file keeps the master's full header —
+    the columns are identical, only the rows are fewer. That is what lets a
+    single lens folder be shipped on its own and still be parsed by anything that
+    reads the master.
+
+    Lens directories are created as needed, so this works on a fresh inspect
+    directory as well as alongside products earlier stages already wrote.
+
+    Returns the number of per-lens files written (i.e. the number of distinct
+    ``lens_name`` values), which for a multi-row producer is smaller than the
+    number of rows in the master.
     """
     with open(master_csv) as f:
         reader = csv.DictReader(f)

--- a/catalogue/scripts/deblending.py
+++ b/catalogue/scripts/deblending.py
@@ -2,6 +2,9 @@
 Euclid Catalogue: Deblended Galaxy Images FITS
 ===============================================
 
+New here? Read ``start_here.py`` for the concepts (the model, the output layout,
+what a fit writes) and ``catalogue/README.md`` for the run order.
+
 Produces the two per-lens FITS bundles of the DR1 catalogue:
 
 - ``pre_psf.fits``  — the model lens-light and lensed-source images *before*
@@ -24,6 +27,41 @@ the bundle can be rebuilt as more fits land without redoing finished work.
 
 Stage 2 of ``scripts/build_inspection_bundle.sh``.
 
+__Why Two Files, Not One__
+
+``pre_psf.fits`` and ``model.fits`` hold the same components and differ only by
+the PSF, and each answers a different question.
+
+``model.fits`` is the model as the telescope would have seen it — the profiles
+convolved with that band's PSF. It is what you overlay on the data, because it
+lives in the data's own resolution: a residual is only meaningful against the
+convolved model.
+
+``pre_psf.fits`` is the model before the instrument touched it, which is the
+astrophysical object rather than the observation. That is the one to measure
+sizes and fluxes from, and the one to compare across bands whose PSFs differ —
+the difference between the two files *is* the seeing, so keeping both means a
+reader never has to guess which they are looking at.
+
+The pair is also what makes "deblending" the right word for this stage. The
+lens's light and the lensed source's light overlap in every band, and nothing
+short of a model separates them; these files are that separation written out per
+band, which is what downstream photometry and SED fitting consume and what a
+viewer opens in DS9 to judge a fit by eye.
+
+__What It Needs Upstream, And Where It Looks__
+
+The HDUs come from the FITS a finished ``sersic_lens_model`` search wrote — so a
+lens needs that fit before it can be bundled, which is the run-order dependency
+``catalogue/README.md`` records for stage 2.
+
+This producer takes *every* search under the tag in whichever results tree it is
+pointed at, with no default filter on the search name. Run against the default
+``output`` it bundles the VIS Sersic fit that ``scripts/sersic_lens_model.py``
+wrote; pointed at ``output_sed``, where the SED chain put one search per band, it
+bundles every band. ``--search_name`` narrows to a single named search when only
+one is wanted.
+
 Usage
 -----
     python catalogue/scripts/deblending.py --sample=q1_walsmley
@@ -42,6 +80,22 @@ sys.path.insert(0, str(Path(__file__).parent))
 import catalogue_util
 
 
+"""
+__The Waveband Order__
+
+FITS extensions have no intrinsic order beyond the one they are written in, and
+whatever order the aggregator happened to find the searches in is not it. The
+list below fixes that: VIS first, then the DECam optical bands blue → red, then
+the three Euclid NIR bands, so walking the extensions of ``pre_psf.fits`` walks
+them in increasing wavelength and a per-band flux read straight off the file is
+already in SED order.
+
+``multi_wavelength.py`` keeps its own, much longer list for the same purpose over
+image columns. The two are deliberately separate — this one names the bands a
+deblending bundle is expected to contain, that one every band an SED run may have
+fitted — and a band missing from either is not dropped: the sort key sends an
+unrecognised name to the end.
+"""
 # Waveband ordering for the FITS extensions: VIS first, then the ground-based
 # optical bands blue → red, then the Euclid NIR bands.
 WAVEBAND_ORDER = [
@@ -83,6 +137,26 @@ def parse_args():
 
 
 def main():
+    """
+    __One Aggregator Per Lens, And The Skip__
+
+    Like ``multi_wavelength.py``, and unlike the CSV producers, this one loops
+    over lens directories and builds an aggregator scoped to each. It has to:
+    the output is one FITS file per lens, gathering that lens's bands into a
+    single HDU list, so the aggregator handed to ``AggregateFITS`` must contain
+    that lens and nothing else.
+
+    The skip at the top of the loop is what makes stage 2 cheap to re-run. A lens
+    whose two bundles already exist is passed over before any result is opened,
+    so rebuilding a sample as more fits land costs roughly the lenses that are
+    new. Note the check is existence only — it does not compare timestamps — so
+    after *re-fitting* a lens, delete its two FITS files (or its whole folder) to
+    force them to be rebuilt.
+
+    Failures are per lens too: a lens with no completed search under the tag
+    makes ``AggregateFITS`` raise ``ValueError``, which is caught, reported and
+    skipped so the rest of the sample still gets bundled.
+    """
     args = parse_args()
     output_path, inspect_path = catalogue_util.resolve_paths(args)
 
@@ -129,6 +203,24 @@ def main():
 
         waveband_list = [search.name for search in agg_query.values("search")]
 
+        """
+        __Which HDUs, And The Lens-Only Branch__
+
+        ``al.agg.fits_galaxy_images`` and ``al.agg.fits_model_galaxy_images``
+        name the same two components — the lens light and the lensed source — in
+        two different files the search wrote: the galaxy images and the model
+        galaxy images. Selecting from the first gives the pre-PSF bundle and from
+        the second the post-PSF one, which is the whole of the difference between
+        the two output files.
+
+        The branch drops the lensed-source HDU when the tag is
+        ``galaxy_sersic_model``, a lens-light-only fit with no lensed source to
+        separate out. No script in this repository writes that tag — the non-lens
+        galaxy pipeline is recorded as out of scope in ``docs/drift_report.md`` —
+        so the branch is reachable only by passing ``--unique_tag`` explicitly at
+        a results tree produced elsewhere. It is kept because the alternative is
+        a confusing failure on results that are otherwise perfectly readable.
+        """
         if args.unique_tag == "galaxy_sersic_model":
             # A lens-light-only fit has no lensed source to deblend.
             pre_psf_hdus = [al.agg.fits_galaxy_images.lens_light_image]
@@ -146,6 +238,25 @@ def main():
         output_dataset_path = inspect_path / dataset_name
         output_dataset_path.mkdir(parents=True, exist_ok=True)
 
+        """
+        __Extension Names, And Writing The Two Bundles__
+
+        ``extract_fits`` walks the aggregator in the order set above and copies
+        the requested HDUs out of each search's FITS into one list, opening an
+        empty primary HDU first as FITS requires.
+
+        ``extname_prefix_list`` is what keeps the result readable. Every search
+        calls its extensions the same thing, so without a prefix a lens fitted in
+        eight bands would produce sixteen identically named extensions. Passing
+        the waveband list — built from the same reordered aggregator, so it lines
+        up index for index — prefixes each with its band, upper-cased, giving
+        names like ``VIS_GALAXY_0`` and ``NIR_H_GALAXY_1``. Extension name alone
+        then says which band and which component an image is.
+
+        Both files are written with ``overwrite=True``, which matters only when
+        one of the pair exists and the other does not: the skip above would not
+        have fired, and the surviving file is replaced rather than erroring.
+        """
         hdu_list = agg_fits.extract_fits(
             hdus=pre_psf_hdus, extname_prefix_list=waveband_list
         )

--- a/catalogue/scripts/lens_mass.py
+++ b/catalogue/scripts/lens_mass.py
@@ -2,6 +2,9 @@
 Euclid Catalogue: Lens Mass CSV
 ================================
 
+New here? Read ``start_here.py`` for the concepts (the model, the output layout,
+latent variables) and ``catalogue/README.md`` for the run order.
+
 Produces ``lens_mass.csv`` — the mass-model half of the DR1 catalogue.
 
 Scrapes the ``initial_lens_model/vis_pix`` results of a whole sample and emits
@@ -19,6 +22,19 @@ The master CSV is also split into one row per lens, dropped in that lens's own
 folder inside the inspect directory, so each folder is self-contained.
 
 Stage 3 of ``scripts/build_inspection_bundle.sh``.
+
+__Its Tutorial Twin__
+
+``workflow/example/csv/lens_mass.py`` builds the same table this file does — the
+mass model parameters of every VIS fit, through the same ``AggregateCSV`` API —
+written as a flat top-to-bottom tutorial that explains each call as it makes it,
+and saved under its own name into ``workflow/csv/``. Read it if you want the API
+explained rather than applied.
+
+This is the production version of that scrape: the same calls wrapped in
+argument parsing, sample-wide path resolution, the full set of sigma columns and
+the per-lens split, so the bundle builder can drive it. Where the two do the same
+thing the sections below point at it rather than repeat it.
 
 Usage
 -----
@@ -59,6 +75,22 @@ def parse_args():
 
 
 def main():
+    """
+    __Paths, Config And Imports__
+
+    ``catalogue_util.resolve_paths`` turns the three common arguments into an
+    absolute results directory and an absolute inspect directory, resolving
+    relative paths against the project root so the producer behaves the same run
+    from the repo root or from ``catalogue/``. It also pushes this pipeline's
+    ``config/`` onto the autoconf stack, so the notation and label configuration
+    used to read the fits is the one they were written under.
+
+    ``autofit`` and ``autolens`` are imported inside ``main`` rather than at the
+    top of the file, so ``--help`` — which never reaches here — does not pay for
+    them. ``autolens`` itself is unused by name; it is imported because the
+    aggregator unpickles PyAutoLens result objects and needs those classes
+    importable.
+    """
     args = parse_args()
     output_path, inspect_path = catalogue_util.resolve_paths(args)
 
@@ -72,15 +104,59 @@ def main():
         print(f"no sample directory at {sample_root}; nothing to do")
         return
 
+    """
+    __Aggregator__
+
+    The aggregator walks a directory of finished fits and hands back one result
+    per search it finds. Pointing it at ``<output>/<sample>`` rather than at
+    ``output`` scopes the whole run to one sample, so lenses from other samples
+    never leak into the catalogue.
+
+    ``completed_only=True`` drops every search that has not written a
+    ``.completed`` marker. This is the whole of the "partial but never corrupt"
+    guarantee in ``catalogue/README.md``: a lens still being fitted is absent
+    from the CSV rather than present with half-written numbers.
+    """
     # One aggregator over the whole sample. completed_only filters out lenses
     # whose search has not produced a `.completed` marker.
     agg = Aggregator.from_directory(directory=sample_root, completed_only=True)
 
+    """
+    __Query: Pipeline Stage And Search__
+
+    Every result under a lens is tagged by the pipeline that wrote it
+    (``unique_tag``) and named by the search within it (``search.name``) — the
+    ``output/<sample>/<dataset>/<pipeline>/<search>/<hash>/`` layout described
+    under "__Reading The Output__" in ``start_here.py``. Two chained queries
+    therefore pick out exactly one search per lens: the ``vis_pix`` search of
+    ``initial_lens_model``, which is the pixelized-source stage and so the one
+    holding the final mass model. Both strings are arguments, so the same script
+    scrapes ``vis_lp`` or another pipeline's stage without editing.
+
+    Note the second query is chained off ``agg_query``, narrowing the already
+    narrowed set. The tutorial twin re-queries the unfiltered ``agg`` at this
+    point; here the results must satisfy both conditions at once, because a lens
+    may well have a ``vis`` search under a different pipeline.
+    """
     agg_query = agg.query(agg.unique_tag == args.unique_tag)
     agg_query = agg_query.query(agg_query.search.name == args.search_name)
 
     agg_csv = af.AggregateCSV(aggregator=agg_query)
 
+    """
+    __The lens_name Column__
+
+    ``add_label_column`` takes a plain list rather than something read out of the
+    model, and pairs it row-for-row with the aggregator's results — so the list
+    has to be built by iterating that same aggregator, in that same order, which
+    is what the comprehension below does.
+
+    The value is the last part of the search's ``path_prefix``, i.e. the dataset
+    directory name, which for DR1 is the tile-derived lens name. It is the only
+    column that identifies which lens a row belongs to, and it is the key
+    ``catalogue_util.write_per_tile_csv`` groups on at the end of this file, so
+    it is written first and never omitted.
+    """
     # lens_name column: the last part of the search's path_prefix, i.e. the
     # dataset (tile) directory name.
     lens_name_list = [
@@ -88,12 +164,47 @@ def main():
     ]
     agg_csv.add_label_column(name="lens_name", values=lens_name_list)
 
+    """
+    __Five Value Flavours Per Variable__
+
+    Every variable added below is written five times over: the median of its
+    posterior under the bare column name, then the values at lower and upper 1σ
+    and at lower and upper 3σ in four suffixed columns.
+
+    Nothing is propagated here. The sampler already explored the posterior, so
+    each of those five numbers is read straight off the stored samples, which is
+    why the errors can be asymmetric and why a parameter pinned against a prior
+    bound shows it. To get a symmetric ± error, subtract the median from the
+    sigma values yourself; the CSV deliberately stores the bounds rather than a
+    single collapsed uncertainty.
+
+    A column whose value is missing from a fit's samples is written empty rather
+    than dropped, so the header is the same width for every sample.
+    """
     value_types_all = [
         ValueType.Median,
         ValueType.ValuesAt1Sigma,
         ValueType.ValuesAt3Sigma,
     ]
 
+    """
+    __The Mass Model Columns__
+
+    The ``argument`` strings are model paths: the same dotted route through the
+    model that ``model.paths`` prints, from the galaxy collection down to the
+    scalar. Tuple parameters such as ``centre`` are reached one component at a
+    time, hence ``centre.centre_0`` and ``centre.centre_1``.
+
+    Seven of them, which is every free parameter of the ``vis_pix`` mass model:
+    the Isothermal (SIE) ellipsoid's centre, elliptical components and Einstein
+    radius, and the two components of the external shear field. ``name``
+    shortens each header — the CSV says ``einstein_radius``, not
+    ``galaxies_lens_mass_einstein_radius`` — and those short names are the DR1
+    catalogue's column names.
+
+    The shear components are ``gamma_1`` and ``gamma_2``, the two parameters of
+    PyAutoLens's ``ExternalShear``.
+    """
     # SIE mass + ExternalShear: all 7 free parameters with median + 1σ + 3σ.
     mass_args = [
         ("galaxies.lens.mass.centre.centre_0", "centre_0"),
@@ -107,6 +218,29 @@ def main():
     for argument, name in mass_args:
         agg_csv.add_variable(argument=argument, name=name, value_types=value_types_all)
 
+    """
+    __The Effective Einstein Radius Latent__
+
+    The eighth column is not a model parameter. The effective Einstein radius is
+    a *latent variable*: derived from the model rather than sampled by it, and —
+    the point of the machinery — recomputed on every sample, so it arrives with a
+    full posterior instead of one number carried over from a best fit. That is
+    why it takes the same five value flavours as everything above.
+
+    The ``latent.`` prefix is what selects it. ``add_variable`` reads a plain
+    ``galaxies...`` argument out of the samples and a ``latent.<name>`` argument
+    out of the latent summary the fit wrote beside them. The name has to match a
+    key of ``util.LatentEuclid``, whose catalogue "__Latent Variables__" in
+    ``start_here.py`` describes and ``config/latent.yaml`` enables —
+    ``effective_einstein_radius`` is one of the library latents that file turns
+    on.
+
+    Two consequences worth knowing before you read a CSV. A fit run in test mode
+    writes no latent summary at all, so these columns are present but blank; and
+    the effective Einstein radius is computed from the fitted tracer's tangential
+    critical curve, which is not the same quantity as the SIE's own
+    ``einstein_radius`` parameter three columns to its left.
+    """
     # Latent: effective Einstein radius, computed by `util.LatentEuclid` on each
     # sample. `add_variable` pulls from latent_summary for a "latent.<name>"
     # argument.
@@ -116,6 +250,23 @@ def main():
         value_types=value_types_all,
     )
 
+    """
+    __Saving, And The Per-Lens Split__
+
+    ``save`` writes the master CSV at the root of the inspect directory: one row
+    per lens, spanning the whole sample, which is the table a population study
+    reads.
+
+    ``write_per_tile_csv`` then re-reads it and drops each lens's own rows into
+    ``<inspect_dir>/<lens_name>/lens_mass.csv``. That is what makes a single lens
+    folder self-contained and shippable on its own — the copy travels with that
+    lens's PNGs and FITS rather than the reader having to carry the master table
+    around. The two files are written from the same rows, so they cannot drift.
+
+    The printed row and file counts differ when a lens contributed more than one
+    row, which for this producer means a duplicate result; ``magnitudes.py`` is
+    the producer where the two counts legitimately differ, one row per waveband.
+    """
     out_csv = inspect_path / "lens_mass.csv"
     agg_csv.save(path=out_csv)
     print(f"wrote {out_csv} ({len(lens_name_list)} rows)")

--- a/catalogue/scripts/lens_sersic.py
+++ b/catalogue/scripts/lens_sersic.py
@@ -2,6 +2,9 @@
 Euclid Catalogue: Lens Light Sersic CSV
 ========================================
 
+New here? Read ``start_here.py`` for the concepts (the MGE, the output layout,
+linear light profiles) and ``catalogue/README.md`` for the run order.
+
 Produces ``lens_sersic.csv`` — the lens-light half of the DR1 catalogue.
 
 Scrapes the ``sersic_lens_model/vis`` results of a whole sample (written by
@@ -19,6 +22,35 @@ Only lenses whose search wrote a ``.completed`` marker are listed. The master
 CSV is also split into one row per lens, dropped in that lens's own folder.
 
 Stage 4 of ``scripts/build_inspection_bundle.sh``.
+
+__Why A Sersic, After The MGE__
+
+This is a different fit from the one ``lens_mass.py`` scrapes, and the reason is
+worth carrying into any table built from it.
+
+``initial_lens_model`` models the lens light as a Multi-Gaussian Expansion —
+tens of Gaussians whose linear amplitudes are solved at every likelihood
+evaluation. As "__Multi Gaussian Expansion__" in ``start_here.py`` explains,
+that is what makes automated lens modeling of a thousand cut-outs possible. What
+it does not give you is a *number to publish*: an effective radius and a Sersic
+index are properties of a Sersic profile, and a basis of Gaussians simply has
+neither.
+
+So ``scripts/sersic_lens_model.py`` runs a second fit that swaps the MGE for a
+single ``lp_linear.Sersic`` per galaxy and enters the mass and shear as
+*instances* of the ``initial_lens_model`` ``vis_lp`` result, so the whole
+parameter space of that search is light. This producer is the scraper for the
+lens half of it; ``source_sersic.py`` is the scraper for the source half of the
+same results. Because the mass was frozen there rather than fitted, this CSV
+carries no mass columns — those live in ``lens_mass.csv``, scraped from the
+``vis_pix`` search that did fit the mass, and joined on ``lens_name``.
+
+__Shared Machinery__
+
+The path resolution, the aggregator, ``completed_only``, the ``lens_name``
+label column, the five value flavours and the per-lens split all work exactly as
+in ``catalogue/scripts/lens_mass.py``, which explains each of them in full;
+the sections below cover only what differs.
 
 Usage
 -----
@@ -59,6 +91,22 @@ def parse_args():
 
 
 def main():
+    """
+    __Query: A Different Pipeline Tag__
+
+    The only structural difference from ``lens_mass.py`` is which fit is
+    selected. There the tag was ``initial_lens_model`` and the search
+    ``vis_pix``; here it is ``sersic_lens_model`` / ``vis``, which is the
+    separate results tree ``scripts/sersic_lens_model.py`` writes beside — not
+    inside — the initial fit's.
+
+    That is the run-order dependency ``catalogue/README.md`` records for stage 4:
+    a lens with no finished ``sersic_lens_model/vis`` search simply does not
+    appear in ``lens_sersic.csv``, because ``completed_only=True`` filtered it
+    out one line below. Everything else on the way to the CSV — path resolution,
+    the deferred heavy imports, the aggregator — is as ``lens_mass.py`` describes
+    it.
+    """
     args = parse_args()
     output_path, inspect_path = catalogue_util.resolve_paths(args)
 
@@ -79,6 +127,15 @@ def main():
 
     agg_csv = af.AggregateCSV(aggregator=agg_query)
 
+    """
+    __Row Identity And Value Flavours__
+
+    Both as in ``lens_mass.py``: ``lens_name`` is the dataset directory name,
+    built by iterating the same aggregator so the list pairs row-for-row with the
+    results, and it is the key the per-lens split groups on. The three value
+    types give five columns per variable — median, then lower/upper 1σ and 3σ —
+    read off the stored posterior rather than propagated from a best fit.
+    """
     lens_name_list = [
         search.path_prefix.parts[-1] for search in agg_query.values("search")
     ]
@@ -90,6 +147,25 @@ def main():
         ValueType.ValuesAt3Sigma,
     ]
 
+    """
+    __The Six Lens Sersic Columns, And The Missing Seventh__
+
+    A Sersic has seven parameters. Six of them are here, reached at
+    ``galaxies.lens.bulge`` — the two centre components, the two elliptical
+    components, the effective radius and the Sersic index.
+
+    The seventh, ``intensity``, is deliberately absent, and its absence is a
+    property of the fit rather than an omission in this file. The profile is an
+    ``lp_linear.Sersic``: its intensity is solved by linear algebra at every
+    likelihood evaluation instead of being sampled, so there is no ``intensity``
+    entry in the samples for ``add_variable`` to find and no posterior to
+    summarise. If you need lens brightness, take it from the flux latents in
+    ``magnitudes.csv``, which are calibrated to µJy and measured per band.
+
+    ``bulge`` is the model component's name, not a morphological claim: the
+    single Sersic here stands for the whole lens galaxy's light, and nothing
+    fitted a separate disc.
+    """
     # Lens Sersic free parameters. Intensity omitted — lp_linear solves it.
     lens_args = [
         ("galaxies.lens.bulge.centre.centre_0", "centre_0"),
@@ -102,6 +178,14 @@ def main():
     for argument, name in lens_args:
         agg_csv.add_variable(argument=argument, name=name, value_types=value_types_all)
 
+    """
+    __Saving, And The Per-Lens Split__
+
+    The master ``lens_sersic.csv`` goes to the root of the inspect directory, one
+    row per lens across the sample; ``write_per_tile_csv`` then drops each lens's
+    row into ``<inspect_dir>/<lens_name>/lens_sersic.csv`` so that folder stays
+    self-contained. Same contract as ``lens_mass.py``, same helper.
+    """
     out_csv = inspect_path / "lens_sersic.csv"
     agg_csv.save(path=out_csv)
     print(f"wrote {out_csv} ({len(lens_name_list)} rows)")

--- a/catalogue/scripts/magnitudes.py
+++ b/catalogue/scripts/magnitudes.py
@@ -2,6 +2,10 @@
 Euclid Catalogue: Multi-band Magnitudes CSV
 ============================================
 
+New here? Read ``start_here.py`` for the concepts (latent variables, the FITS
+header contract, the output layout) and ``catalogue/README.md`` for the run
+order.
+
 Produces ``magnitudes.csv`` — the photometry table the downstream photometric
 redshift / SED fitting works from.
 
@@ -27,6 +31,30 @@ waveband leave more than one result per ``(lens, stage, band)``; the newest is
 kept and the rest dropped.
 
 Stage 7 of ``scripts/build_inspection_bundle.sh``.
+
+__Where These Results Come From__
+
+Stages 1-5 read one search per lens. This one reads a whole chain of them.
+
+``scripts/sersic_lens_model_waveband.py`` is the SED chain: it fits the VIS
+Sersic, then hands that result to ``fit_waveband``, which fits every remaining
+band of the cut-out under the same ``sersic_lens_model`` tag, with the Sersic's
+shape fixed and its intensity re-solved against each band's own data. Each band
+is a search named after the band, so a lens's results end up as
+``<sample>/<lens>/sersic_lens_model/<band>/<hash>/`` — siblings under one tag,
+which is exactly the shape this producer walks.
+
+The chain is run with ``PYAUTO_OUTPUT_DIR=output_sed`` so the per-band folders do
+not bloat the main tree, and that is why ``--output_path`` defaults to
+``output_sed`` here rather than ``output``. When ``output_sed/<sample>/`` does
+not exist, ``scripts/build_inspection_bundle.sh`` skips stages 6 and 7 rather
+than failing.
+
+__Shared Machinery__
+
+Path resolution, ``completed_only``, ``add_label_column``, ``add_variable`` and
+the per-lens split all work as ``catalogue/scripts/lens_mass.py`` describes them
+in full. The sections below cover what is particular to multi-band photometry.
 
 Usage
 -----
@@ -65,10 +93,36 @@ def latest_result_per_lens_band(aggregator, sample_root: Path):
     """
     Keep only the newest completed result for each ``(lens, stage, band)``.
 
-    Re-running a waveband writes a second result directory beside the first;
-    without this the master CSV gains duplicate rows for the same photometry.
-    Recency is taken from the zipped result where one exists (the zip is written
-    when the search finishes) and from the directory otherwise.
+    __Why Duplicates Happen__
+
+    A result folder is named for the model and configuration that produced it, so
+    re-running a band with anything changed writes a *second* completed folder
+    beside the first rather than overwriting it. That is the right behaviour for
+    a fitting pipeline — nothing is silently destroyed — and the wrong behaviour
+    for a catalogue, where it would put two rows of photometry for the same lens
+    and band into ``magnitudes.csv`` with nothing to say which is current.
+
+    Over a long DR1 campaign, where bands get re-run as calibration or priors
+    improve, this is the difference between a usable table and one that has to be
+    de-duplicated by hand downstream.
+
+    __How The Key Is Built__
+
+    The result's directory is taken relative to the sample root, which makes its
+    parts ``<lens>/<stage>/<band>/<hash>/...``; the first three are the key and
+    the fourth is what varies between duplicates. A path with fewer than four
+    parts is not a per-band result folder and is skipped.
+
+    Recency is the zipped result's timestamp where one exists — PyAutoFit writes
+    the zip when the search finishes, so it dates the *completion* rather than
+    any later touch of the directory — and the directory's own timestamp
+    otherwise, which is the unzipped case (an interrupted run, or a test-mode
+    one). The full directory string breaks ties, so the selection is
+    deterministic rather than dependent on iteration order.
+
+    The survivors are wrapped back into an ``Aggregator``, so everything
+    downstream of this call treats the de-duplicated set as an ordinary
+    aggregator; the grid-search outputs are carried across untouched.
     """
     from autofit.aggregator.aggregator import Aggregator
 
@@ -101,6 +155,23 @@ def latest_result_per_lens_band(aggregator, sample_root: Path):
 
 
 def main():
+    """
+    __Query: Every Band Under One Tag__
+
+    Note what is *missing* from ``parse_args`` above: there is no
+    ``--search_name``. ``lens_mass.py`` and the two Sersic producers narrow to
+    one named search per lens; this producer deliberately does not, because the
+    search name here is the waveband and keeping all of them is the entire point.
+
+    So there is a single query, on ``unique_tag``, and it returns every band's
+    search for every lens in the sample — which is why the master CSV has one row
+    per ``(lens, waveband)`` rather than one row per lens.
+
+    ``AggregateCSV`` raises ``ValueError`` when handed an empty aggregator, which
+    is the ordinary case for a sample whose SED chain has not run yet. That is
+    caught and reported rather than raised: stage 7 of the bundle builder should
+    leave a partial bundle alone, not abort it.
+    """
     args = parse_args()
     output_path, inspect_path = catalogue_util.resolve_paths(args)
 
@@ -123,6 +194,25 @@ def main():
         print(f"no completed {args.unique_tag} results: {e}")
         return
 
+    """
+    __Three Label Columns__
+
+    ``lens_name`` is the dataset directory name, as everywhere else, and is what
+    the per-lens split groups on — here gathering the several band rows of one
+    lens into that lens's folder.
+
+    ``waveband`` is ``search.name``, which the SED chain set to the band. It is
+    the column that makes a row identifiable at all: without it the rows of one
+    lens are indistinguishable, and an SED fit has no way to attach a flux to a
+    filter.
+
+    ``crval_ra_deg`` comes from the ``wcs.json`` this pipeline's
+    ``util.AnalysisImaging`` writes beside each result, and reads it back through
+    the aggregator like any other result file. Despite the FITS-style name it is
+    not the cut-out's reference pixel: it is the right ascension of the fitted
+    maximum-likelihood lens light centre, which is what lets a catalogue row be
+    matched back to a position on the sky rather than to a filename.
+    """
     # Label columns: lens_name (the dataset dir), waveband (the search name,
     # e.g. vis / nir_h) and the WCS RA centre for cross-referencing.
     lens_name_list = [
@@ -137,6 +227,20 @@ def main():
     agg_csv.add_label_column(name="waveband", values=waveband_list)
     agg_csv.add_label_column(name="crval_ra_deg", values=crval_ra_deg_list)
 
+    """
+    __Six Columns Per Variable__
+
+    Four value types, and so six columns for every variable below: the
+    maximum-likelihood value, the median, and the lower/upper bounds at 1σ and
+    3σ. This is the one master CSV that carries the max-likelihood value as well
+    as the median — ``lens_mass.csv`` and the two Sersic tables take the same
+    three posterior types without it.
+
+    The extra column is there because photometry is what gets fitted downstream.
+    An SED or photometric-redshift fit wants the flux of the single best model
+    alongside the marginalised one, and the gap between the two is itself a
+    useful warning that a band's posterior is not well behaved.
+    """
     value_types = (
         af.ValueType.MaxLogLikelihood,
         af.ValueType.Median,
@@ -144,6 +248,49 @@ def main():
         af.ValueType.ValuesAt1Sigma,
     )
 
+    """
+    __The Flux Latents, And Why They Are In µJy__
+
+    None of the eight variables below is a model parameter. Each is a latent
+    variable: recomputed from the model on every sample by ``util.LatentEuclid``,
+    so each arrives with a posterior rather than as a number derived once from a
+    best fit. The ``latent.`` prefix is what tells ``add_variable`` to read the
+    latent summary rather than the samples.
+
+    They come in two groups, which is why the argument names look inconsistent.
+    The first are library latents that ``config/latent.yaml`` enables — the total
+    lens, lensed-source and source fluxes, and the magnification. The four
+    ``*_fwhm_mujy`` names are Euclid-only, listed in
+    ``util.LatentEuclid.APERTURE_LATENT_KEYS`` rather than in the library,
+    because they need PSF arguments that only this pipeline supplies. ``name``
+    shortens every header to the DR1 catalogue's form, so the CSV says
+    ``lens_flux`` where the argument says ``latent.total_lens_flux_mujy``.
+
+    The units matter more than anything else here. A fitted flux is in the
+    image's own units, which differ from band to band and are useless for an SED.
+    The ``_mujy`` latents convert through the ``MAGZERO`` zero-point that
+    ``util.load_vis_dataset`` reads out of the FITS header and passes into the
+    fit's info dict, giving microJansky — a physical unit comparable across every
+    instrument in the table. A fit run without ``magzero`` cannot produce these,
+    which is why ``catalogue/README.md`` lists it as a requirement rather than a
+    detail.
+
+    The four aperture fluxes go one step further: they are matched-aperture
+    photometry, the model lens image convolved to the resolution of the
+    worst-seeing band recorded for the cut-out and summed within 1, 2, 3 and 4
+    times *that* band's PSF FWHM. Measuring every band through the same effective
+    aperture is what makes the per-band fluxes comparable at all;
+    "__The FITS Header Contract__" in ``start_here.py`` covers where that
+    worst-band PSF comes from.
+
+    Two ways a value column comes back empty, neither of them a fault in this
+    script. A test-mode fit writes no latent summary at all, so every value
+    column is blank while the header stays the right width. And a fit whose
+    analysis carried no worst-band PSF produces NaN for the four aperture latents
+    alone — they are then dropped from the written latent summary, so those four
+    columns come out blank while the fluxes and magnification beside them are
+    still good.
+    """
     # Latent names are those of `util.LatentEuclid`: the library µJy flux
     # latents enabled in config/latent.yaml, then the four Euclid-only FWHM
     # aperture-flux latents. Column names keep the shorter DR1 catalogue form.
@@ -160,6 +307,19 @@ def main():
     for argument, name in latent_args:
         agg_csv.add_variable(argument=argument, name=name, value_types=value_types)
 
+    """
+    __Saving, And The Per-Lens Split__
+
+    This is the one producer where the two printed counts legitimately differ.
+    The master ``magnitudes.csv`` has a row per ``(lens, waveband)``, so the row
+    count is roughly the lens count times the number of bands fitted, while
+    ``write_per_tile_csv`` returns the number of *lenses* it wrote a file for.
+
+    ``write_per_tile_csv`` handles that without being told: it groups on
+    ``lens_name``, so a lens's whole set of band rows lands together in
+    ``<inspect_dir>/<lens_name>/magnitudes.csv`` — that lens's own small SED
+    table, self-contained beside its ``fit_multi_wavelength.png``.
+    """
     out_csv = inspect_path / "magnitudes.csv"
     agg_csv.save(path=out_csv)
     print(f"wrote {out_csv} ({len(lens_name_list)} rows)")

--- a/catalogue/scripts/multi_wavelength.py
+++ b/catalogue/scripts/multi_wavelength.py
@@ -2,17 +2,23 @@
 Euclid Catalogue: Multi-wavelength Fit PNG
 ===========================================
 
+New here? Read ``start_here.py`` for the concepts (the output layout, what the
+fit subplots show) and ``catalogue/README.md`` for the run order.
+
 Produces ``fit_multi_wavelength.png`` — one image per lens showing the fit in
 every waveband on a single grid, so a reader can judge the multi-band model at a
 glance instead of opening one subplot per band.
 
-Four panels are taken from each waveband's ``subplot_fit.png`` and stacked, one
-row per band, ordered blue → red by ``WAVEBAND_ORDER``:
+Four panels are cropped out of each waveband's ``subplot_fit.png``:
 
 - the data,
 - the lens-light model,
 - the lens-light-subtracted image,
 - the source model image.
+
+They are laid out one **column** per waveband, ordered blue → red left to right
+by ``WAVEBAND_ORDER``, and one row per panel — so reading across a row compares
+the same panel in every band, which is what makes a band that failed obvious.
 
 ``--image_set=fit_x1_plane`` instead reads the single-plane subplot (data, model
 data, lens-light-subtracted image, normalized residual map), which is what a
@@ -22,6 +28,22 @@ The SED chain is run with ``PYAUTO_OUTPUT_DIR=output_sed``, so this producer
 reads ``output_sed`` by default rather than the main ``output``.
 
 Stage 6 of ``scripts/build_inspection_bundle.sh``.
+
+__What It Reads, And What It Does Not Do__
+
+Nothing here re-renders a fit. The panels are cropped straight out of the
+``subplot_fit.png`` that each band's search already wrote, so a band whose fit
+was run with visualization suppressed — ``PYAUTO_FAST_PLOTS=1``, or a test-mode
+run that skipped post-fit visualization — has no panels to contribute. That is
+the same constraint ``scripts/tools/build_inspect.py`` works under at stage 1,
+and ``catalogue/README.md`` describes it under "Building a bundle off a
+test-mode run".
+
+The upstream results are the SED chain's: ``scripts/sersic_lens_model_waveband.py``
+fits every band under the ``sersic_lens_model`` tag with the searches named after
+the bands, which is what makes one lens's bands siblings the aggregator can
+gather. ``magnitudes.py`` turns the same results into numbers; this producer
+turns them into a picture.
 
 Usage
 -----
@@ -42,7 +64,28 @@ sys.path.insert(0, str(Path(__file__).parent))
 import catalogue_util
 
 
-# Waveband ordering for the stacked rows: VIS first, then the ground-based
+"""
+__The Waveband Order__
+
+The list below is the file's one piece of Euclid domain knowledge: the order the
+composed image's columns appear in. It is written down rather than derived
+because band *names* carry no wavelength — nothing about the string ``des_i``
+says it sits between ``des_r`` and ``des_z``.
+
+VIS leads, being the band the lens model was fitted on and the one every other
+band's Sersic is seeded from. Then the ground-based optical surveys by filter
+rather than grouped by survey, so a ``g`` from DES sits beside a ``g`` from
+Pan-STARRS; then the three Euclid NIR bands. The inline comments give each
+filter's approximate pivot wavelength, which is what the ordering is really
+sorting on.
+
+``deblending.py`` keeps its own, much shorter list for the same purpose. The two
+are deliberately not shared: that one orders FITS extensions for the bands a
+deblending bundle contains, this one orders image columns for every band an SED
+run may have fitted, and a band belonging in one is not a reason to add it to the
+other.
+"""
+# Waveband ordering for the composed image's columns: VIS first, then the ground-based
 # optical surveys blue → red, then the Euclid NIR bands. Comments give the
 # approximate pivot wavelength of each filter.
 WAVEBAND_ORDER = [
@@ -104,6 +147,25 @@ def parse_args():
 
 
 def main():
+    """
+    __One Aggregator Per Lens__
+
+    The CSV producers build a single aggregator over the whole sample and let it
+    emit one row per result. This producer cannot: its output is one composed
+    image per lens, and ``AggregateImages`` composes across everything in the
+    aggregator it is given. So the loop below walks the sample's lens
+    directories via ``catalogue_util.dataset_names_from`` and builds a fresh
+    aggregator scoped to ``<sample_root>/<lens>``, whose contents are exactly
+    that lens's band searches.
+
+    That also makes the stage fail softly per lens rather than per sample: a lens
+    with nothing to compose is caught, reported and skipped, and the rest of the
+    sample still gets its images.
+
+    Unlike ``deblending.py``, there is no already-built check here — every lens's
+    PNG is rebuilt on each run, which is what makes a re-run pick up bands that
+    have landed since the last one.
+    """
     args = parse_args()
     output_path, inspect_path = catalogue_util.resolve_paths(args)
 
@@ -124,6 +186,22 @@ def main():
 
         agg_query = agg.query(agg.unique_tag == args.unique_tag)
 
+        """
+        __Ordering The Bands__
+
+        The aggregator returns a lens's searches in whatever order it found them
+        on disk, which has nothing to do with wavelength: band names sort by
+        survey and letter, so ``nir_h`` lands before ``vis`` and the NIR bands
+        are scattered through the optical ones.
+
+        Sorting the aggregator's ``search_outputs`` in place by each band's index
+        in ``WAVEBAND_ORDER`` fixes the column order of the composed image, so
+        wavelength increases left to right and an SED trend can be read off the
+        picture. The key returns ``len(WAVEBAND_ORDER)`` for a name not in the
+        list, so an unrecognised band sorts to the end rather than raising or
+        being dropped — a new survey filter appears in the image, just at the
+        right-hand edge, until it is added to the list above.
+        """
         # Reorder by WAVEBAND_ORDER; unknown wavebands sort to the end.
         agg_query.search_outputs = sorted(
             agg_query.search_outputs,
@@ -140,6 +218,25 @@ def main():
             print(f"skipping {dataset_name}: {e}")
             continue
 
+        """
+        __Which Four Panels__
+
+        ``al.agg.subplot_fit.*`` are coordinates into the subplot PNG the search
+        wrote, not quantities to be recomputed: each names one panel of that
+        grid, and ``extract_image`` crops it out.
+
+        The default set tells the multi-band story in four steps — the data, the
+        lens-light model, the data with that lens light subtracted, and the
+        source model image — so a reader can see, band by band, whether the
+        deblending worked and whether there is source flux left where the arcs
+        are.
+
+        ``--image_set=fit_x1_plane`` reads ``subplot_fit_x1_plane`` instead,
+        which is the subplot a band fitted with no source model produces. Its
+        panels are different (model data and a normalized residual map in place
+        of the source model image), so the choice is per run rather than
+        automatic: pick the one matching how the bands were fitted.
+        """
         if args.image_set == "fit_x1_plane":
             subplots = [
                 al.agg.subplot_fit_x1_plane.data,
@@ -155,6 +252,21 @@ def main():
                 al.agg.subplot_fit.source_model_image,
             ]
 
+        """
+        __Composing And Writing__
+
+        ``extract_image`` lays the crops out as a matrix: one row per result,
+        four panels across. ``transpose=True`` flips that, giving one column per
+        waveband and one row per panel kind — bands increasing in wavelength left
+        to right, the same panel repeated across each row. Panels from bands
+        whose subplots differ in size are normalised to a common panel size
+        before compositing, so the grid lines up.
+
+        The image is written into the lens's own folder in the inspect directory,
+        beside that lens's PNGs, FITS and CSV rows. There is no master version of
+        this product: unlike the CSVs, it is per-lens by nature, so nothing is
+        split afterwards.
+        """
         image = agg_image.extract_image(subplots=subplots, transpose=True)
 
         output_dataset_path = inspect_path / dataset_name

--- a/catalogue/scripts/source_sersic.py
+++ b/catalogue/scripts/source_sersic.py
@@ -2,6 +2,9 @@
 Euclid Catalogue: Source Light Sersic CSV
 ==========================================
 
+New here? Read ``start_here.py`` for the concepts (the MGE, the output layout,
+linear light profiles) and ``catalogue/README.md`` for the run order.
+
 Produces ``source_sersic.csv`` — the source-light half of the DR1 catalogue.
 
 Identical in shape to ``lens_sersic.py``, but reads the *source* galaxy's
@@ -19,6 +22,21 @@ lower/upper 1σ, lower/upper 3σ. Only lenses with a ``.completed`` marker are
 listed, and the master CSV is split into one row per lens folder.
 
 Stage 5 of ``scripts/build_inspection_bundle.sh``.
+
+__The Other Half Of One Fit__
+
+Stages 4 and 5 scrape the *same* results. ``scripts/sersic_lens_model.py`` fits
+one ``lp_linear.Sersic`` to the lens and one to the source in a single search, so
+``sersic_lens_model/vis`` holds both galaxies; ``lens_sersic.py`` walks down
+``galaxies.lens.bulge`` and this file walks down ``galaxies.source.bulge``. They
+are two producers rather than one because the bundle wants two tables, not
+because there are two fits — which also means either can be re-run alone, and
+that a lens present in one CSV is present in the other.
+
+Read ``lens_sersic.py`` for why the pipeline fits a Sersic at all after the MGE,
+and ``lens_mass.py`` for the shared machinery — path resolution, the aggregator,
+``completed_only``, the ``lens_name`` column, the five value flavours and the
+per-lens split. The sections below cover only what is particular to the source.
 
 Usage
 -----
@@ -59,6 +77,14 @@ def parse_args():
 
 
 def main():
+    """
+    __Query__
+
+    ``sersic_lens_model`` / ``vis`` — the same tag and search name
+    ``lens_sersic.py`` uses, because it is the same fit. A lens with no finished
+    search under that tag is filtered out by ``completed_only=True`` and is
+    absent from both CSVs.
+    """
     args = parse_args()
     output_path, inspect_path = catalogue_util.resolve_paths(args)
 
@@ -79,6 +105,14 @@ def main():
 
     agg_csv = af.AggregateCSV(aggregator=agg_query)
 
+    """
+    __Row Identity__
+
+    ``lens_name`` is still the lens's dataset directory name, not the source's —
+    a source has no catalogue identity of its own, and the row is the source *of*
+    that lens. It is what joins this table to ``lens_mass.csv`` and
+    ``lens_sersic.csv``, and what the per-lens split groups on.
+    """
     lens_name_list = [
         search.path_prefix.parts[-1] for search in agg_query.values("search")
     ]
@@ -90,6 +124,30 @@ def main():
         ValueType.ValuesAt3Sigma,
     ]
 
+    """
+    __These Are Source-Plane Numbers__
+
+    The six columns are the same six as ``lens_sersic.csv`` — centre, elliptical
+    components, effective radius, Sersic index — and ``intensity`` is again
+    absent because ``lp_linear`` solves it linearly rather than sampling it.
+
+    What differs is the plane they live in. A lensed source is fitted by placing
+    the profile in the *source* plane and tracing it through the mass model, so
+    every number here describes the source as it would look unlensed: the
+    effective radius is the intrinsic size, not the extent of the arcs, and the
+    ellipticity is the intrinsic shape, not the shape the lensing produced.
+
+    Two consequences. Column for column these values are not comparable with
+    ``lens_sersic.csv``'s — in particular the two centres are positions in
+    different planes, and the source's is not an offset from the lens on the sky.
+    And any *observed* quantity has to be combined with the lensing: the
+    magnification that relates the two is a latent variable, carried per band in
+    ``magnitudes.csv``.
+
+    The source centre priors were seeded from the source's MGE centre in the
+    upstream ``vis_lp`` fit and then left free, so the value here is fitted
+    rather than inherited.
+    """
     # Source Sersic free parameters. Intensity omitted — lp_linear solves it.
     source_args = [
         ("galaxies.source.bulge.centre.centre_0", "centre_0"),
@@ -102,6 +160,14 @@ def main():
     for argument, name in source_args:
         agg_csv.add_variable(argument=argument, name=name, value_types=value_types_all)
 
+    """
+    __Saving, And The Per-Lens Split__
+
+    Master ``source_sersic.csv`` at the root of the inspect directory, one row
+    per lens; then ``write_per_tile_csv`` drops each lens's row into
+    ``<inspect_dir>/<lens_name>/source_sersic.csv``, giving that folder its own
+    copy alongside the lens-light and mass rows.
+    """
     out_csv = inspect_path / "source_sersic.csv"
     agg_csv.save(path=out_csv)
     print(f"wrote {out_csv} ({len(lens_name_list)} rows)")

--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -15,8 +15,8 @@
 #   are broken and parked as a to-do list. Investigate the failure, fix
 #   the underlying bug, and remove the NEEDS_FIX marker.
 
-- scripts/diagnose_latent_vis_pix.py  # Population sweep over every vis_pix result in a sample; it takes no --dataset argument, so the runner's global args_default (--dataset=... --sample=...) is rejected by argparse. Its single-result sibling scripts/diagnose_latent.py is smoked instead.
-- scripts/build_inspect.py  # Collects the six inspection-bundle PNGs out of finished result zips. PYAUTO_FAST_PLOTS=1 in the smoke profile suppresses all PNG output, so there is nothing for it to collect.
+- scripts/tools/diagnose_latent_vis_pix.py  # Population sweep over every vis_pix result in a sample; it takes no --dataset argument, so the runner's global args_default (--dataset=... --sample=...) is rejected by argparse. Its single-result sibling scripts/tools/diagnose_latent.py is smoked instead.
+- scripts/tools/build_inspect.py  # Collects the six inspection-bundle PNGs out of finished result zips. PYAUTO_FAST_PLOTS=1 in the smoke profile suppresses all PNG output, so there is nothing for it to collect.
 - catalogue/scripts/deblending.py  # Catalogue producer: needs a finished sersic_lens_model fit in every waveband to extract the deblended pre_psf.fits / model.fits.
 - catalogue/scripts/lens_mass.py  # Catalogue producer: aggregates converged initial_lens_model/vis_pix samples; test-mode samples carry no meaningful posterior.
 - catalogue/scripts/lens_sersic.py  # Catalogue producer: aggregates converged sersic_lens_model/vis samples.

--- a/config/build/profile_smoke.yaml
+++ b/config/build/profile_smoke.yaml
@@ -36,6 +36,6 @@ overrides:
   # `smoke_tests.txt` entries run sequentially in one un-wiped output dir, so
   # `start_here.py` (entry 1) has already produced the `vis_lp` result this
   # reads.
-  - pattern: scripts/diagnose_latent.py
+  - pattern: scripts/tools/diagnose_latent.py
     set:
       PYAUTO_OUTPUT_DIR: "output/test_mode"

--- a/dataset/README.md
+++ b/dataset/README.md
@@ -21,7 +21,7 @@ dataset/<sample>/<name>/
 
 | Path | Real / simulated | What it is | Read by | Regenerate |
 |---|---|---|---|---|
-| `q1_walsmley/102018665_NEG570040238507752998/` | **real** | A Euclid Q1 MER cut-out of a Walmsley et al. lens candidate: 8 bands (DES *griz* + VIS + NIR *YJH*), 100x100 at 0.1"/pixel, 1.3 MB. Ships no `segmentation/` and no `positions.json`, so it is the dataset that exercises the *fallback* branches of the optional-input chain. | Every fitting script's default; `config/build/profile_smoke.yaml`'s `args_default`; `scripts/diagnose_latent.py` and `scripts/diagnose_latent_vis_pix.py` defaults; `tests/test_util.py`; `tests/test_compute_latent_variable.py`; `catalogue/`'s default sample. | Not regenerable — real observed data, committed as-is. |
+| `q1_walsmley/102018665_NEG570040238507752998/` | **real** | A Euclid Q1 MER cut-out of a Walmsley et al. lens candidate: 8 bands (DES *griz* + VIS + NIR *YJH*), 100x100 at 0.1"/pixel, 1.3 MB. Ships no `segmentation/` and no `positions.json`, so it is the dataset that exercises the *fallback* branches of the optional-input chain. | Every fitting script's default; `config/build/profile_smoke.yaml`'s `args_default`; `scripts/tools/diagnose_latent.py` and `scripts/tools/diagnose_latent_vis_pix.py` defaults; `tests/test_util.py`; `tests/test_compute_latent_variable.py`; `catalogue/`'s default sample. | Not regenerable — real observed data, committed as-is. |
 | `simulated/euclid_dr1_like/` | **simulated** | A DR1-layout mock: 4 bands (VIS + NIR *YJH*) at the real zero-points, PSF widths and noise levels, 100x100 at 0.1"/pixel, ~880 KB. An `Isothermal` + `ExternalShear` mass with `einstein_radius=1.2"`, a `Sersic` lens light and a `Sersic` source, producing four multiple images. Ships the inputs the real dataset lacks — `segmentation/`, `positions.json`, `mask_extra_galaxies.fits`, `rgb_0.png`/`rgb_1.png`, `segmentation.png` — so it exercises the *preferred* branch of every optional-input chain and is the one dataset that builds a complete 13-of-13 inspection bundle. `truth.json` holds every parameter, flux, aperture flux, magnification and Einstein radius that went in. | The latent known-answer unit tests; TEST-mode CI runs of the fitting chain. | `python scripts/simulator.py --from-params --seed 1`, then `python preprocess/segmentation.py --sample=simulated` for `segmentation.png` (restore `positions.json` afterwards — see below) |
 
 ---
@@ -46,7 +46,7 @@ python scripts/simulator.py --from-result \
 Then commit the FITS with `git add -f`, and add a row to the table above.
 
 `segmentation.png` is not written by the simulator — `preprocess/segmentation.py` is its producer,
-for simulated and real datasets alike, and `scripts/build_inspect.py` copies it into the
+for simulated and real datasets alike, and `scripts/tools/build_inspect.py` copies it into the
 inspection bundle. Run it after the simulator:
 
 ```bash

--- a/docs/drift_report.md
+++ b/docs/drift_report.md
@@ -71,7 +71,7 @@ meant to run under a dedicated `PYAUTO_OUTPUT_DIR` so the per-band SED
 outputs don't bloat the main results tree; each upstream stage
 cache-short-circuits if its result zip already exists.
 
-`scripts/diagnose_latent.py` and `scripts/diagnose_latent_vis_pix.py` are the
+`scripts/tools/diagnose_latent.py` and `scripts/tools/diagnose_latent_vis_pix.py` are the
 human-inspection route for the Euclid latent catalogue — the former replays
 it on one converged result, the latter sweeps a population of `vis_pix`
 results, reporting per-dataset OK/ERR so one bad tile cannot truncate the
@@ -81,7 +81,7 @@ The `catalogue/` producer tree (`catalogue/scripts/{deblending, lens_mass,
 lens_sersic, source_sersic, multi_wavelength, magnitudes}.py`, plus the
 shared `catalogue_util.py`) turns a directory of finished fits into the
 inspection bundle described in `catalogue/README.md`.
-`scripts/build_inspect.py` collects the bundle's image outputs, and
+`scripts/tools/build_inspect.py` collects the bundle's image outputs, and
 `scripts/build_inspection_bundle.sh` runs the full seven-stage order.
 
 ## 2. `start_here.py` collapsed to a shim

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,7 +1,8 @@
-The `scripts` folder contains the pipelines that fit Euclid data, the simulator
-that makes data to fit, plus the diagnostics and the two orchestrators that
-build the catalogue's inspection bundle. Everything here is run from the
-**repository root**, not from this folder:
+The `scripts` folder contains the pipelines that fit Euclid data and the
+simulator that makes data to fit. The diagnostics and the catalogue-bundle
+tooling live one level down in `scripts/tools/`, keeping the model-running
+scripts separate from the things that inspect their results. Everything here is
+run from the **repository root**, not from this folder:
 
 ```bash
 python scripts/initial_lens_model.py --sample=q1_walsmley --dataset=<name>
@@ -59,7 +60,7 @@ All fitting pipelines share one argument parser (`util.parse_fit_args`) —
     `tests/test_compute_latent_variable.py`.
   - `--from-result` resimulates a fit you have already run: the tracer is rebuilt
     from that result's `model.json` + maximum-log-likelihood sample (resolved with
-    `diagnose_latent.py::resolve_files_path`, so the arguments are the same
+    `tools/diagnose_latent.py::resolve_files_path`, so the arguments are the same
     `--sample` / `--dataset` / `--unique_tag` / `--search` / `--result_hash`) and
     the bands, PSF stamps, zero-points, WCS and noise levels come from the dataset
     it was fitted to. A single-band fit written to multiple bands applies the
@@ -78,18 +79,18 @@ All fitting pipelines share one argument parser (`util.parse_fit_args`) —
 
 # Diagnostics
 
-- `diagnose_latent.py`: Replays the Euclid latent catalogue
+- `tools/diagnose_latent.py`: Replays the Euclid latent catalogue
   (`util.LatentEuclid`) on one converged result and prints every latent value,
   flagging NaN and zero sentinels, plus the Einstein radius in isolation. Runs no
   search. Test-mode results live under `<output>/test_mode/`, so pass
   `--output_path=output/test_mode` to inspect a smoke run.
-- `diagnose_latent_vis_pix.py`: The population version — the same replay over
+- `tools/diagnose_latent_vis_pix.py`: The population version — the same replay over
   every `vis_pix` result in a sample, reporting per-dataset OK/ERR plus a
   summary. Takes `--sample`, not `--dataset`.
 
 # Catalogue orchestration
 
-- `build_inspect.py`: Collects the inspection bundle's PNGs out of the result
+- `tools/build_inspect.py`: Collects the inspection bundle's PNGs out of the result
   zips PyAutoFit writes (falling back to an unzipped result directory).
 - `build_inspection_bundle.sh`: Runs all seven catalogue stages in order for a
   sample. See [`../catalogue/README.md`](../catalogue/README.md) for the

--- a/scripts/build_inspection_bundle.sh
+++ b/scripts/build_inspection_bundle.sh
@@ -81,8 +81,8 @@ cd "$PROJECT_ROOT"
 
 mkdir -p "$INSPECT_DIR"
 
-echo "==> [1/7] inspection PNGs (scripts/build_inspect.py)"
-python "$PROJECT_ROOT/scripts/build_inspect.py" \
+echo "==> [1/7] inspection PNGs (scripts/tools/build_inspect.py)"
+python "$PROJECT_ROOT/scripts/tools/build_inspect.py" \
     --sample="$SAMPLE" \
     --output_path="$OUTPUT_DIR" \
     --inspect_dir="$INSPECT_DIR" \

--- a/scripts/full_model.py
+++ b/scripts/full_model.py
@@ -2,18 +2,170 @@
 Full SLaM Pipeline
 ==================
 
-Runs the complete Source, Light and Mass (SLaM) pipeline on a Euclid VIS dataset:
+Runs the complete Source, Light and Mass (SLaM) pipeline on a Euclid VIS dataset::
 
-  SOURCE LP      — parametric MGE source + isothermal mass (fast initialisation)
-  SOURCE PIX 1   — pixelised source initialisation, Delaunay mesh on an
-                   Overlay image-plane grid
-  SOURCE PIX 2   — refined Delaunay mesh on a Hilbert-weighted grid
-  LIGHT LP       — lens light refinement with source/mass fixed
-  MASS TOTAL     — final PowerLaw mass model
+    python scripts/full_model.py --dataset=<name> --sample=<sample>
 
-For a detailed walkthrough of every step see ``scripts/initial_lens_model.py``,
-which fits the SOURCE LP and a single pixelised stage in isolation with full
-inline documentation.
+__Before You Start__
+
+If you are new to this pipeline, read ``start_here.py`` first. Installation and the
+command line, the dataset contract, masking and over-sampling, what a Multi Gaussian
+Expansion (MGE) is, the SIE + shear initial mass model, the Nautilus / JAX / GPU
+basics, the idea of a pixelized source and the layout of ``output/`` are all covered
+there, and are deliberately *not* repeated here.
+
+For a line-by-line walkthrough of every step of a fit, read
+``scripts/initial_lens_model.py``: it fits one light-profile search (``vis_lp``)
+followed by one pixelized search (``vis_pix``) with full inline documentation. This
+script is that same idea generalised into five chained searches.
+
+This script accepts the shared pipeline arguments (``util.parse_fit_args``), but its
+``fit`` function uses only ``--dataset``, ``--sample`` and
+``--iterations_per_quick_update``. Every stage here runs on JAX and every stage is
+run, so ``--use_cpu``, ``--number_of_cores`` and ``--skip_pix`` have no effect.
+
+__SLaM (Source, Light and Mass)__
+
+This script is an introduction to the Source, (lens) Light and Mass (SLaM) pipelines.
+These are advanced modeling pipelines which use many aspects of core PyAutoLens
+functionality to automate the modeling of strong lenses.
+
+The idea is simple: rather than throwing a complex model at the data in one go and
+hoping the sampler finds the global maximum, each search solves one part of the
+problem with everything else simplified or held fixed, and hands its result to the
+next search as priors or as a fixed instance.
+
+__Prerequisites__
+
+Before reading this script, it helps to be familiar with the following key concepts.
+The references are scripts in the ``autolens_workspace`` repository
+(https://github.com/PyAutoLabs/autolens_workspace):
+
+- **Non-linear search chaining** (``scripts/guides/modeling/chaining.py``): linking
+  models together in a sequence, such as transitioning from a light profile source to
+  a pixelized source. This is the mechanism the whole script is built on.
+
+- **Pixelizations** (``scripts/imaging/features/pixelization/modeling.py``, and
+  ``.../pixelization/delaunay.py`` for the mesh family used here): structures which
+  reconstruct the source galaxy on a pixel grid rather than with an analytic profile.
+
+- **Adaptive pixelizations** (``scripts/imaging/features/pixelization/adaptive.py``):
+  pixelizations whose source pixels and regularization weights adapt to the unlensed
+  morphology of the source.
+
+- **Multi Gaussian Expansions (MGE)**
+  (``scripts/imaging/features/multi_gaussian_expansion/modeling.py``): galaxy light
+  modeled as a sum of Gaussians. Used here for the lens light throughout, and for the
+  source in the first search before the pixelization takes over. ``start_here.py``
+  gives the short version.
+
+- The generic PyAutoLens introduction to these pipelines is
+  ``scripts/guides/modeling/slam_start_here.py``. Read it for the concepts, not the
+  settings: its worked example uses a different mesh family to the Delaunay meshes
+  used here.
+
+If any of these concepts are unfamiliar you can still run the script, but reviewing
+the referenced examples later will deepen your understanding of how and why SLaM
+pipelines are structured as they are.
+
+__Overview__
+
+The SLaM pipelines strategically chain together sequential searches, each designed to
+exploit the results of the last. This provides a fully automated framework for fitting
+large samples of strong lenses with complex models.
+
+Each stage targets a specific aspect of the strong lens model:
+
+- **Source**: establish a robust source model. For a pixelized source this means
+  finding accurate mesh and regularization parameters, and building the "adapt image"
+  the mesh adapts to.
+- **Light**: model the lens light, with the source and mass models fixed from the
+  source stages.
+- **Mass**: fit a detailed, higher-complexity mass model, using the source and lens
+  light models established earlier.
+
+Models set up in earlier stages guide those used in later ones. The Delaunay mesh and
+``AdaptSplit`` regularization chosen for the source stages are what the final mass
+measurement is made against.
+
+__Pipeline Structure__
+
+This script implements five searches, each as a function below with its own
+documentation block, called in order by ``fit`` at the bottom of the file. All five
+are written to the ``slam`` unique tag of the dataset's output folder:
+
+1. **SOURCE LP** (``source_lp[1]``) — MGE lens light (2 x 20 Gaussians),
+   ``Isothermal`` + ``ExternalShear`` mass and an MGE source (1 x 20 Gaussians), all
+   free. Fast, well-conditioned, and the origin of everything that follows: the mass
+   priors, the multiple-image positions and the first adapt image.
+
+2. **SOURCE PIX 1** (``source_pix[1]``) — the source becomes a ``Delaunay``
+   pixelization on a uniform ``Overlay`` image-plane grid, with the lens light fixed
+   to SOURCE LP and the mass and shear chained forward as models. Its purpose is not
+   the mass model but the reconstruction itself, which becomes the adapt image for the
+   next stage.
+
+3. **SOURCE PIX 2** (``source_pix[2]``) — the same Delaunay mesh, but the image-plane
+   grid is now drawn by a ``Hilbert`` mesh weighted by that adapt image. The lens
+   light, mass and shear are all fixed instances, so the only free parameters are
+   those of the ``AdaptSplit`` regularization. This is the source model used by every
+   later stage.
+
+4. **LIGHT LP** (``light[1]``) — the lens light is refit from scratch (2 x 20
+   Gaussians) against a source and mass that are now accurate enough for a clean
+   lens-light subtraction.
+
+5. **MASS TOTAL** (``mass_total[1]``) — the ``Isothermal`` mass is promoted to a
+   ``PowerLaw``, with priors initialized from SOURCE PIX 1, the lens light fixed from
+   LIGHT LP and the source fixed from SOURCE PIX 2.
+
+__Design Choices__
+
+There are many design choices that go into the SLaM pipelines, which we discuss now.
+
+The SLaM pipelines are designed around pixelized source modeling. Pixelized sources
+are necessary for fitting complex mass models, which the SLaM pipelines automate the
+fitting of. The design considerations below all follow from that:
+
+- **Source First**: the pipeline starts with the source, because complex mass models
+  (e.g. a ``PowerLaw``, or composite models with stars and dark matter) require
+  pixelized source modeling rather than simple light profiles. This step establishes a
+  robust pixelized source using a simpler mass model (``Isothermal`` with
+  ``ExternalShear``).
+
+- **Image Positions**: for pixelized source modeling, specifying the positions of the
+  multiple images of the lensed source is crucial to prevent unphysical
+  reconstructions, where the mass model demagnifies the source into a blob that fits
+  the data with no lensing at all. The positions are not input by hand: they are
+  estimated automatically from the previous stage's mass and source result.
+
+- **Adapt Images**: an adaptive pixelization uses an "adapt image" — a lens-light
+  subtracted image in which only the lensed source emission remains — to place source
+  pixels and set regularization weights according to the source's morphology. The
+  adapt image is therefore only set once a good model of the source is available.
+
+- **Lens Light Before Mass**: modeling the lens light accurately requires deblending
+  the lens and source emission, which a robust pixelized source model makes possible.
+  The lens light is refined while the mass model is still the simple ``Isothermal``,
+  so the harder mass fit begins from a clean lens-light subtraction.
+
+- **Mass Model Last**: the most complex mass model fitting is saved for last, and
+  benefits from the prior refinement of both the source and the lens light.
+
+These design choices enable the SLaM pipelines to deliver precise and automated lens
+modeling while optimizing each stage for robustness and efficiency.
+
+__This Script__
+
+Using a SOURCE LP, two SOURCE PIX, a LIGHT LP and a MASS TOTAL search, this script
+fits a Euclid VIS ``Imaging`` dataset of a strong lens where in the final model:
+
+ - The lens galaxy's light is a bulge with a Multi Gaussian Expansion (MGE) light
+   profile [fixed from LIGHT LP].
+ - The lens galaxy's total mass distribution is a ``PowerLaw`` plus an
+   ``ExternalShear``.
+ - The source galaxy's light is a ``Pixelization``: a ``Delaunay`` mesh with
+   ``AdaptSplit`` regularization [fixed from SOURCE PIX 2].
 """
 
 import os
@@ -38,6 +190,22 @@ source galaxy's light:
 
 The mass and source models from this search initialize the SOURCE PIX PIPELINE
 searches that follow.
+
+Everything is fit with light profiles here, and nothing is held fixed. That is
+the point of the stage: the MGE's intensities are solved linearly, so the
+non-linear parameter space stays small and well-conditioned and the search is
+very likely to find the global maximum. A pixelized source started from nothing
+is not — it needs a mass model that is already roughly right, and an adapt image
+of the source, neither of which exist until this search has run.
+
+__Settings__:
+
+ - Mass Centre: the ``Isothermal`` centre is given a uniform prior spanning
+   +/- 0.05" of the dataset centre (the brightest central pixel), rather than
+   being left fully free. The mass centre is expected to lie very close to the
+   lens light centre, and restricting it this tightly keeps the initial search
+   stable. Later stages chain the mass forward from this result rather than
+   setting it up again from scratch.
 """
 
 
@@ -92,6 +260,18 @@ __SOURCE PIX PIPELINE 1__
 Delaunay mesh + AdaptSplit regularization.  Creates the adapt image for the
 refined pixelisation in SOURCE PIX 2.
 
+This is the first of two pixelized searches, and it exists because of a
+chicken-and-egg problem. An adaptive pixelization needs an "adapt image" — a
+lens-light subtracted image containing only the lensed source emission — to
+decide where to put source pixels and how strongly to regularize them. The
+SOURCE LP result can supply one, but not a good one: the true source is often
+more complex than the MGE fitted to it, so the emission it predicts is smoother
+than the real thing. This search therefore fits a pixelization whose real
+product is its own reconstruction, which SOURCE PIX 2 then adapts to.
+
+The lens light is fixed to the SOURCE LP instance; the mass and shear are
+chained forward as models, so they are re-fit against the pixelized source.
+
 The Delaunay source pixels are the traced positions of an image-plane grid,
 which is built here (uniform ``Overlay`` grid over the mask, plus a ring of
 edge points) and handed to the analysis via ``AdaptImages``.  The number of
@@ -102,9 +282,25 @@ requires statically shaped arrays.
 Delaunay neighbours come from a ``scipy.spatial.Delaunay`` call on the traced
 source-plane grid, which cannot be traced under ``jit``/``grad``.
 
+__Positions__
+
 Image positions are computed automatically from the SOURCE LP result to prevent
-unphysical source reconstructions.  An adapt image is computed from the SOURCE
-LP result and passed to the analysis.
+unphysical source reconstructions — those where the mass model demagnifies the
+source so heavily that a featureless blob reproduces the data. They are not
+input by hand; deriving them from the previous result is a key part of what
+makes these pipelines automatic.
+
+__Adapt Images__
+
+An adapt image is computed from the SOURCE LP result and passed to the analysis,
+together with the image-plane mesh grid the Delaunay source pixels are traced
+from (both are built in ``fit`` below).
+
+__Mass Chaining__
+
+``unfix_mass_centre=True`` is passed to ``mass_from`` for consistency with the
+standard SLaM API. It has nothing to unfix here: the SOURCE LP mass centre was
+already free within its +/- 0.05" prior rather than fixed to a value.
 """
 
 
@@ -168,6 +364,16 @@ grid is now drawn by a ``Hilbert`` image mesh weighted by that adapt image, so
 Delaunay source pixels concentrate where the source is bright, and
 ``reg.AdaptSplit`` adapts the regularization weights to the source's
 morphology.
+
+The lens light, mass and shear are all passed as instances — the lens light from
+SOURCE LP, the mass and shear from SOURCE PIX 1 — so the only free parameters in
+this search are those of the regularization scheme. It is a small, cheap search
+(hence its low ``n_live``) whose job is to settle the source reconstruction that
+LIGHT LP and MASS TOTAL are then fit against.
+
+Because the mass is fixed here, this result carries no mass posterior worth
+chaining. The MASS TOTAL priors are therefore taken from SOURCE PIX 1, the last
+search in which the mass was free.
 """
 
 
@@ -220,11 +426,23 @@ def source_pix_2(
 """
 __LIGHT LP PIPELINE__
 
-Refines the lens light (2×20 Gaussians) with mass and source fixed.
+Refines the lens light (2 x 20 Gaussians) with mass and source fixed:
+
+ - The lens light is a new MGE, fit from scratch [free].
+ - The ``Isothermal`` mass and ``ExternalShear`` are fixed from SOURCE PIX 1.
+ - The source is fixed from SOURCE PIX 2, passed through by
+   ``source_custom_model_from`` with ``source_is_model=False``.
 
 The lens light model is fit from scratch (not seeded from SOURCE LP) because the
 earlier mass and source models may not have been precise enough for an accurate
-lens-light subtraction.
+lens-light subtraction. The lens light and the lensed source overlap on the sky,
+so a source that is even slightly wrong pushes its residuals into the lens light
+model; now that the source is a converged pixelized reconstruction, the
+deblending is trustworthy and the light model is worth refitting properly.
+
+This ordering is what makes the final mass fit possible: MASS TOTAL takes this
+lens light as a fixed instance, so it never has to fit light and a ``PowerLaw``
+at the same time.
 """
 
 
@@ -273,11 +491,33 @@ def light_lp(
 """
 __MASS TOTAL PIPELINE__
 
-PowerLaw + ExternalShear mass model, priors seeded from SOURCE PIX result.
+The final search, fitting the mass model the whole pipeline exists to measure:
 
-Positions are computed from the SOURCE PIX 2 result for more precise multiple
-image positions.  The shear prior is reset to broad uniform priors because the
-``PowerLaw`` model can absorb azimuthal structure previously captured by shear.
+ - The lens light is the MGE fixed from LIGHT LP.
+ - The mass is a ``PowerLaw`` with an ``ExternalShear``, with priors initialized
+   from the ``Isothermal`` fit of SOURCE PIX 1 via ``al.util.chaining.mass_from``
+   (the ``PowerLaw`` adds a ``slope``, which the ``Isothermal`` fixed at 2.0).
+ - The source is carried through from SOURCE PIX 2 by
+   ``al.util.chaining.source_from``, so the mass is measured against the source
+   reconstruction those stages settled on.
+
+__Positions__
+
+Positions are computed from the SOURCE PIX 2 result rather than reused from
+SOURCE LP. The pixelized source reconstructs the source plane far better than
+the MGE did, so the multiple image positions it predicts are more precise, and
+the position threshold they impose on this search is correspondingly tighter.
+
+__Shear__
+
+``fit`` calls this stage with ``reset_shear_prior=True``, which replaces the
+chained shear with a fresh ``ExternalShear`` model: the search starts from the
+broad uniform priors of ``config/priors``, not from the SOURCE PIX posterior.
+Chaining a narrow shear prior into this search would be a mistake: the
+``PowerLaw`` slope changes how much azimuthal structure the mass profile itself
+can produce, so shear values that were the best fit alongside an ``Isothermal``
+are not the ones that best fit alongside a ``PowerLaw``. The shear has to be free
+to move.
 """
 
 
@@ -353,11 +593,30 @@ def fit(
     import autofit as af
     import autolens as al
 
+    """
+    __Dataset__
+
+    ``util.load_vis_dataset`` performs all standard dataset preparation in one
+    call: FITS layout, noise scaling, mask, over-sampling, PSF, WCS and zero-point.
+    Every step is documented individually in ``scripts/initial_lens_model.py``, and
+    the dataset contract it reads — including ``info.json``, which is where the mask
+    radius comes from — is described in ``start_here.py``.
+
+    The sparse operator is then applied on top. It speeds up the linear algebra of
+    the pixelized searches, which is where this pipeline spends most of its time.
+    """
     d = util.load_vis_dataset(dataset_name, sample_name=sample_name)
 
     # full_model uses a sparse operator for faster pixelisation fits
     dataset = d.dataset.apply_sparse_operator()
 
+    """
+    __Settings AutoFit__
+
+    Controls output paths and search behaviour. ``unique_tag="slam"`` places all five
+    searches of this pipeline together in ``output/<sample>/<dataset>/slam/``, one
+    folder per search name (``source_lp[1]``, ``source_pix[1]``, and so on).
+    """
     settings_search = af.SettingsSearch(
         path_prefix=(
             Path(sample_name) / dataset_name
@@ -369,14 +628,27 @@ def fit(
         session=None,
     )
 
+    """
+    __Redshifts__
+
+    For a single-plane lens, PyAutoLens units are dimensionless so the redshifts do
+    not affect the lens model. These are placeholders; photometric redshifts are
+    estimated after modeling via SED fitting of the latent-variable fluxes.
+    """
     redshift_lens = 0.5
     redshift_source = 1.0
 
     """
     __SOURCE LP PIPELINE__
 
-    Isothermal mass + MGE lens + MGE source.  Provides the initial model and
-    adapt image for the pixelised source stages that follow.
+    Isothermal mass + MGE lens + MGE source, all free.  Provides the initial model
+    and adapt image for the pixelised source stages that follow.
+
+    The analysis uses the multiple-image positions that came with the dataset:
+    ``util.load_vis_dataset`` reads ``positions.json`` if it is present, and
+    otherwise derives positions from the segmentation source flux map, leaving them
+    unused if neither is available. Later stages replace them with positions derived
+    from the previous search's result.
     """
     analysis = util.AnalysisImaging(
         dataset=dataset,
@@ -434,6 +706,17 @@ def fit(
     (``zeroed_pixels``) so the reconstruction is not distorted by the mask
     boundary.  ``pixels`` is therefore fixed by the grid rather than a free
     parameter: JAX requires statically shaped arrays.
+
+    The grid is uniform at this stage because the only adapt image available is the
+    one predicted by the SOURCE LP MGE source, which is too smooth to be worth
+    weighting a mesh by.  SOURCE PIX 2 does that, using this search's own
+    reconstruction.
+
+    The positions handed to the analysis are recomputed from the SOURCE LP result
+    with ``positions_likelihood_from``. Its threshold is not a hand-chosen number: it
+    is set by how closely the positions trace to one another in the source plane
+    under the best-fit mass model, multiplied by ``factor=3.0`` so plausible mass
+    models are not rejected, and floored at ``minimum_threshold=0.2``.
     """
     mask = dataset.mask
     edge_pixels_total = 30
@@ -510,7 +793,16 @@ def fit(
     Refined pixelisation using the adapt image from SOURCE PIX 1.  The
     image-plane grid is redrawn by a ``Hilbert`` image mesh weighted by that
     adapt image, so Delaunay source pixels concentrate on the bright parts of
-    the source.
+    the source and its faintest regions are reconstructed with far fewer pixels.
+    ``weight_power=3.5`` sets how sharply the point density follows the adapt
+    image, and ``weight_floor=0.01`` keeps the faint outskirts from being left
+    with no pixels at all.
+
+    Like the ``Overlay`` grid before it, this grid is computed here, before the
+    search, and stays fixed for its duration — which is why the lens light, mass
+    and shear are all fixed instances in this search: with the mesh frozen, the
+    only thing left to fit is the regularization, and freeing the mass alongside
+    it would reintroduce degeneracies that are slow and difficult to sample.
 
     ``pixels=500`` follows the Euclid sibling ``scripts/initial_lens_model.py``
     rather than the ``autolens_workspace`` ``delaunay.py`` example, which uses
@@ -575,7 +867,13 @@ def fit(
     """
     __LIGHT LP PIPELINE__
 
-    Refines the lens light (2×30 Gaussians) with mass and source fixed.
+    Refines the lens light (a fresh MGE of 2 x 20 Gaussians) with the mass fixed from
+    SOURCE PIX 1 and the source fixed from SOURCE PIX 2.
+
+    The analysis reuses the ``adapt_images`` built for SOURCE PIX 2, so the fixed
+    source instance is evaluated on the mesh grid it was fitted with. No positions
+    likelihood is needed: the mass model is not being varied here, so there are no
+    unphysical mass solutions to guard against.
     """
     analysis = util.AnalysisImaging(
         dataset=dataset,
@@ -608,7 +906,13 @@ def fit(
     """
     __MASS TOTAL PIPELINE__
 
-    PowerLaw + ExternalShear mass model, priors seeded from SOURCE LP result.
+    ``PowerLaw`` + ``ExternalShear`` mass model, with the mass priors seeded from
+    SOURCE PIX 1 — the last search in which the mass was free — the lens light fixed
+    from LIGHT LP and the source fixed from SOURCE PIX 2.
+
+    The positions likelihood is rebuilt from SOURCE PIX 2, whose pixelized source
+    gives a better source-plane reconstruction, and therefore more precise multiple
+    image positions, than the SOURCE LP fit used earlier.
     """
     analysis = util.AnalysisImaging(
         dataset=dataset,

--- a/scripts/initial_lens_model.py
+++ b/scripts/initial_lens_model.py
@@ -5,28 +5,25 @@ Euclid Pipeline: Initial Lens Model
 This script fits an initial lens model to a Euclid strong lens dataset. It is the
 recommended entry point — run this first before any of the pipelines in ``scripts/``.
 
-**Installation:** see https://github.com/PyAutoLabs/euclid_strong_lens_modeling_pipeline
-
-**Running as a black box:** pass it the dataset name and it fits automatically. Results
-and visualisations are written to ``output/``. For small samples, browsing ``output/``
-directly is sufficient. For large samples use the ``workflow/`` scripts to export
-.csv, .fits, and .png summaries via the database aggregator.
-
-**Questions:** contact James Nightingale on the Euclid Consortium Slack.
+It is also the implementation behind ``start_here.py``, which imports ``fit`` from
+here. Read that file for everything this one deliberately does not repeat:
+installation and the GPU setup ("__Installation__", "__JAX And GPUs__"), running the
+pipeline as a black box ("__Running The Pipeline__"), what lands in ``output/`` and how
+to summarise a large sample with ``workflow/`` ("__Reading The Output__", "__Where To Go
+Next: Workflow__"), and the science concepts the code below implements — the Multi
+Gaussian Expansion, the mass model, and pixelized sources.
 
 __Initial Lens Model__
 
-Fits a Multi Gaussian Expansion (MGE) for the lens and source light together with a
-Singular Isothermal Ellipsoid (SIE) + shear mass model. The MGE decomposes each galaxy
-into ~15–100 Gaussians whose intensities are solved via linear algebra ("inversion"),
-keeping the non-linear parameter space small (~15 parameters) and well-conditioned. This
-makes the fit fast and highly likely to reach the global maximum, especially on a GPU.
+Two searches, described in ``start_here.py``, "__The Two Searches__": ``vis_lp`` fits an
+MGE lens light, an SIE + shear mass model and an MGE source together; ``vis_pix`` then
+fixes the lens light, frees the mass centre, and replaces the source with a pixelized
+Delaunay reconstruction. The prose below documents how each is built, line by line.
 
-__SLaM Overview__
+``scripts/full_model.py`` extends this fit with the full Source, Light and Mass (SLaM)
+chain — see ``start_here.py``, "__SLaM: Source, Light And Mass__".
 
-``scripts/full_model.py`` extends this fit using the Source, Light and Mass (SLaM)
-pipeline: a sequence of chained searches that progressively build up a complex lens model.
-Each stage is seeded from the previous result, ensuring robust convergence.
+**Questions:** contact James Nightingale on the Euclid Consortium Slack.
 """
 
 import os
@@ -81,21 +78,18 @@ def fit(
     """
     __Dataset__
 
-    ``util.load_vis_dataset`` performs all standard dataset preparation in one call:
+    ``util.load_vis_dataset`` performs all standard dataset preparation in one
+    call — HDU discovery, header metadata, noise scaling, the circular mask at the
+    ``info.json`` radius, over-sampling, and the multiple-image positions. The ten
+    steps are listed in ``start_here.py``, "__How A Dataset Is Loaded__", and
+    documented per-parameter on the function itself in ``util.py``.
 
-    1. Resolves paths — ``dataset/<dataset_name>/<dataset_name>.fits``
-    2. Reads the multi-HDU FITS file and maps wavebands to HDU indices
-    3. Loads the VIS image, noise-map, and PSF (pixel scale 0.1"/px)
-    4. Finds the brightest central pixel to anchor model priors
-    5. Loads ``info.json`` metadata (mask radius/centre, redshifts, …)
-    6. Reads the FITS header for the photometric zero-point (MAGZERO) and WCS
-    7. Applies noise scaling from ``segmentation/artefact_binary.fits``, falling
-       back to ``mask_extra_galaxies.fits``, if either is present
-    8. Applies a circular mask (radius from argument, info.json, or 3.0" default)
-    9. Applies standard adaptive over-sampling (4/2/1× in radial bins)
-    10. Loads the lowest-resolution band PSF + FWHM for aperture photometry
-
-    See ``util.load_vis_dataset`` for full parameter documentation.
+    What matters for the code below is the single ``EuclidDataset`` it returns,
+    whose attributes this script reads rather than re-deriving: ``d.dataset`` is
+    the masked, over-sampled imaging; ``d.dataset_centre`` (the brightest central
+    pixel) and ``d.mask_radius`` anchor the model priors; and
+    ``d.positions_likelihood_list``, ``d.magzero``, ``d.pixel_wcs`` and the
+    lowest-resolution PSF are handed to the analysis.
     """
     d = util.load_vis_dataset(dataset_name, sample_name=sample_name)
 
@@ -196,8 +190,7 @@ def fit(
     ``util.AnalysisImaging`` extends the built-in PyAutoLens analysis to compute
     latent variables (aperture fluxes, magnification) and output RGB visualisations.
 
-    JAX accelerates likelihood evaluation on GPUs; without a GPU it falls back to
-    multithreaded CPU execution (slower but still functional).
+    ``use_jax`` follows ``--use_cpu``; see ``start_here.py``, "__JAX And GPUs__".
     """
     analysis = util.AnalysisImaging(
         dataset=d.dataset,
@@ -216,7 +209,7 @@ def fit(
     __Search__
 
     Nautilus nested sampling.  ``n_live=750`` balances accuracy and speed for this
-    15-parameter model.  ``batch_size=50`` controls GPU parallelism.
+    15-parameter model.
     ``n_like_max`` stops runaway fits (most complete well under 200 000 evaluations).
     """
     search = af.Nautilus(
@@ -237,22 +230,114 @@ def fit(
 
     """
     __Source Pix__
+
+    The second search, ``vis_pix``, replaces the MGE source with a pixelized
+    reconstruction on a Delaunay mesh and re-fits the mass against it.
+    ``start_here.py``, "__Pixelized Sources__", gives the reason: high-redshift
+    sources are typically clumpy, asymmetric and multi-component, a sum of
+    concentric Gaussians cannot represent that, and a source model too rigid to
+    fit the source is compensated for by distorting the *mass* model — the thing
+    the pipeline exists to measure. Reconstructing the source pixel by pixel
+    removes that bias, so the mass model improves even though nothing about the
+    mass model itself has changed.
+
+    Everything from here to the end of ``fit`` builds that one search, and it is
+    the most intricate part of the pipeline, so it is documented step by step
+    below. The ``vis_lp`` result is used four times over: it supplies the lens
+    light to hold fixed, the adapt image that decides where source pixels go, the
+    shear priors, and the multiple-image positions that veto unphysical
+    solutions.
+
+    The standalone tutorial for this mesh, outside the Euclid context, is
+    ``scripts/imaging/features/pixelization/delaunay.py`` in the
+    `autolens_workspace <https://github.com/PyAutoLabs/autolens_workspace>`_. The
+    code below follows its adaptive-Delaunay section, with the Euclid-specific
+    settings noted as they appear.
     """
     dataset = d.dataset
     mask = dataset.mask
     mask_radius = d.mask_radius
 
+    """
+    __Sparse Operator__
+
+    A pixelized fit solves a large linear system at every likelihood evaluation,
+    and the expensive ingredient in it is the PSF: the mapping between image
+    pixels and source pixels has to be convolved before the source can be solved
+    for. The sparse operator precomputes the PSF-and-noise-map products that
+    convolution needs, once, when the dataset is built. Each likelihood evaluation
+    then reuses them instead of recomputing them. The operator is attached to the
+    returned dataset and picked up automatically by the fit, and it is applied
+    only here, because only a pixelized fit performs that inversion — ``vis_lp``
+    above runs on the plain ``d.dataset``.
+
+    The two calls build the same operator by different routes.
+    ``apply_sparse_operator`` uses JAX, which is the GPU path;
+    ``apply_sparse_operator_cpu`` uses a Numba CPU implementation. ``--use_cpu``
+    selects the latter, and is the same switch that sets ``use_jax=False`` on the
+    analysis below — so it does not merely move the same arithmetic to another
+    device, it changes which implementation of the linear algebra is used.
+    """
     if use_cpu:
         dataset = dataset.apply_sparse_operator_cpu()
     else:
         dataset = dataset.apply_sparse_operator()
 
+    """
+    __Image Mesh__
+
+    A Delaunay source mesh is not laid down in the source plane. Its vertices are
+    (y, x) points defined in the *image* plane, which are ray-traced to the source
+    plane by whichever mass model the sampler is currently trying, and
+    triangulated there. That image-plane grid therefore has to be built before the
+    search starts, and it stays fixed for the whole search.
+
+    The ``Hilbert`` image mesh draws those points from the source's own light. It
+    turns an adapt image (next section) into a weight map and runs a Hilbert curve
+    over it, so points cluster where the weight is high: the source's bright
+    clumps get many source pixels and blank sky gets few. ``weight_power=3.5`` is
+    the power the weights are raised to, and controls how aggressively points
+    migrate into the brightest regions; ``weight_floor=0.01`` sets a minimum
+    weight, so the faint outskirts still receive some pixels rather than none.
+
+    ``pixels=500`` is the total drawn. The autolens_workspace ``delaunay.py``
+    example uses 1000 on its simulated data; 500 is the right number here because
+    Euclid VIS cut-outs are small — a postage stamp a few arcseconds across at
+    0.1"/pixel, so the analysis mask contains only a few thousand image pixels.
+    Drawing 1000 source pixels into that would over-resolve the data, making every
+    likelihood evaluation more expensive while inviting the reconstruction to fit
+    noise.
+    """
     hilbert_pixels = 500
 
     image_mesh = al.image_mesh.Hilbert(
         pixels=hilbert_pixels, weight_power=3.5, weight_floor=0.01
     )
 
+    """
+    __Adapt Image__
+
+    An adapt image is the previous fit's view of one galaxy on its own.
+    ``galaxy_name_image_dict_via_result_from`` takes the maximum likelihood
+    ``vis_lp`` model and, for each galaxy, subtracts the model images of every
+    other galaxy from the data and divides by the noise map. The entry keyed
+    ``"('galaxies', 'source')"`` is therefore a signal-to-noise map of the
+    lens-light-subtracted lensed source: an image of where the source's light
+    actually falls, with the lens removed. A floor at a small fraction of its peak
+    is applied so that no pixel is zero or negative, which would break the
+    weighting downstream.
+
+    That image steers three things. Here it is the ``adapt_data`` the Hilbert mesh
+    weights its points by; below it sets the per-pixel over-sampling; and in the
+    model it is what ``reg.AdaptSplit`` uses to vary the regularization strength
+    across the source.
+
+    This is why the two searches must run in this order. The ``vis_lp`` MGE fit is
+    not the final answer, but it is a good enough deblending of lens and source to
+    say where the source is bright, which is all the adaptation needs.
+    ``image_plane_mesh_grid_from`` combines it with the mask and returns the 500
+    image-plane points.
+    """
     galaxy_image_name_dict = al.galaxy_name_image_dict_via_result_from(
         result=source_lp_result
     )
@@ -261,6 +346,24 @@ def fit(
         mask=dataset.mask, adapt_data=galaxy_image_name_dict["('galaxies', 'source')"]
     )
 
+    """
+    __Edge Zeroing__
+
+    Source pixels at the edge of the mesh are the ones most likely to go wrong.
+    Nothing constrains them from outside, so the solver is free to give them
+    bright values that mop up residuals from the lens-light subtraction at the
+    mask boundary, and that corruption then spreads inwards through the
+    regularization.
+
+    The fix is to include such pixels deliberately and force them to zero.
+    ``append_with_circle_edge_points`` appends a ring of 30 points to the
+    image-plane grid, placed just outside the mask edge — at ``mask_radius`` plus
+    half a pixel. They are ray-traced and triangulated along with all the others,
+    so the mesh has a proper boundary, and ``zeroed_pixels=edge_pixels_total`` on
+    the ``Delaunay`` mesh below tells the inversion to hold their reconstructed
+    values at zero. The reconstruction is then bounded by pixels that are known to
+    be blank rather than by pixels free to absorb whatever is left over.
+    """
     edge_pixels_total = 30
 
     image_plane_mesh_grid = al.image_mesh.append_with_circle_edge_points(
@@ -270,6 +373,23 @@ def fit(
         n_points=edge_pixels_total,
     )
 
+    """
+    __Handing The Mesh To The Fit__
+
+    ``AdaptImages`` is the object that carries all of the above into the
+    model-fit. It pairs the source galaxy's model path with two things: the adapt
+    image, which the regularization adapts to, and the image-plane mesh grid built
+    above, which the ``Delaunay`` mesh uses as its vertices. Both travel to the
+    analysis as one argument, so nothing has to be recomputed per sample.
+
+    With the ring appended the grid is final, and its length is the number of
+    source pixels: 500 Hilbert points plus 30 edge points. That length is what is
+    passed to the mesh below as ``pixels``, rather than the pixel count being a
+    free parameter of the model — and it has to be fixed, because JAX compiles the
+    likelihood function against statically shaped arrays. A source-pixel count
+    that varied from sample to sample would change those shapes and force a
+    recompile on every evaluation.
+    """
     adapt_images = al.AdaptImages(
         galaxy_name_image_dict=galaxy_image_name_dict,
         galaxy_name_image_plane_mesh_grid_dict={
@@ -277,6 +397,21 @@ def fit(
         },
     )
 
+    """
+    __Pixelization Over Sampling__
+
+    ``load_vis_dataset`` sets over-sampling for the light profiles only, in radial
+    bins around the lens centre. The pixelization needs its own, and it wants it
+    somewhere else: not where the lens light is steep, but where the *lensed
+    source* is bright, because that is where a coarse image grid would smear the
+    mapping between image pixels and source pixels.
+
+    The source adapt image is already a signal-to-noise map, so the rule is a
+    single threshold. Image pixels where the source's signal-to-noise exceeds 3
+    are over-sampled 4x; everywhere else 2x. ``apply_over_sampling`` writes that
+    map onto the dataset as ``over_sample_size_pixelization``, passing the
+    existing light-profile over-sampling straight through unchanged.
+    """
     import numpy as np
 
     signal_to_noise_threshold = 3.0
@@ -294,6 +429,33 @@ def fit(
         over_sample_size_pixelization=over_sample_size_pixelization,
     )
 
+    """
+    __Analysis And Positions__
+
+    The analysis is rebuilt on the over-sampled dataset, with ``adapt_images``
+    attached and with a tightened positional constraint. Everything else — the
+    latent variables, the RGB visualisation, the WCS — is as it was for
+    ``vis_lp``.
+
+    A pixelized source has a failure mode a parameterised one does not. A mass
+    model that demagnifies the source heavily can reproduce the data with a
+    bright, featureless blob and score a high likelihood while being physically
+    wrong. The defence is the multiple images.
+    ``source_lp_result.positions_likelihood_from`` takes the maximum likelihood
+    ``vis_lp`` mass model, solves for where it places the source's multiple
+    images, and returns a likelihood penalty that rejects any model which cannot
+    ray-trace them back to a common point in the source plane.
+
+    ``factor=3.0`` multiplies the threshold that model implies, widening it so a
+    mass model merely somewhat different from ``vis_lp``'s is not vetoed;
+    ``minimum_threshold=0.2`` rounds the threshold up if it comes out below 0.2",
+    so a ``vis_lp`` fit that happened to trace its positions very precisely cannot
+    hand the next search an impossibly tight constraint. Note that this replaces
+    ``d.positions_likelihood_list``, which ``vis_lp`` used: the constraint is now
+    derived from a converged mass model rather than from the dataset's own
+    positions. Deriving it rather than requiring it by hand is a large part of
+    what makes the pipeline automatic.
+    """
     analysis = util.AnalysisImaging(
         dataset=dataset,
         adapt_images=adapt_images,
@@ -312,6 +474,37 @@ def fit(
         **settings_search.info,
     )
 
+    """
+    __Model: Fixed Lens Light + Free Mass Centre + Pixelized Source__
+
+    The lens light is no longer fitted. ``bulge`` is the ``vis_lp`` *instance* —
+    the 40-Gaussian MGE frozen at its maximum likelihood parameters — because
+    deblending the lens is a solved problem by this point, and freezing it keeps
+    the search's whole budget on the mass and the source.
+
+    The mass is a fresh ``Isothermal`` whose centre is now free, given a uniform
+    prior spanning ±0.1" of ``d.dataset_centre``. In ``vis_lp`` that centre was
+    pinned exactly to ``d.dataset_centre``, the brightest pixel; with a reliable
+    source reconstruction in hand, the small offset between the light centroid and
+    the mass centroid can be measured rather than assumed, and the box keeps that
+    freedom from turning back into a degeneracy. The shear is chained forward as a
+    *model*, so it is re-fitted, but from the priors ``vis_lp`` inferred.
+
+    The source becomes a ``Pixelization``: a ``Delaunay`` mesh whose ``pixels`` is
+    the fixed length of the image-plane grid and whose ``zeroed_pixels`` is the
+    edge ring, regularized by ``reg.AdaptSplit``.
+
+    ``reg.AdaptSplit`` — not ``reg.Adapt`` — is mandatory for the Delaunay family:
+    ``reg.Adapt`` cannot JIT on it, because Delaunay neighbours come from a
+    ``scipy.spatial.Delaunay`` call on the traced source-plane grid, which cannot
+    be traced under ``jit``/``grad``. Both pixelized stages of
+    ``scripts/full_model.py`` use the same pairing for the same reason.
+
+    The "adapt" half is doing scientific work as well as satisfying the compiler:
+    it uses the adapt image to vary the regularization strength across the source,
+    so the bright, well-constrained regions are smoothed less than the faint ones
+    instead of the whole reconstruction being smoothed uniformly.
+    """
     mass = af.Model(al.mp.Isothermal)
     mass.centre.centre_0 = af.UniformPrior(
         lower_limit=d.dataset_centre[0] - 0.1, upper_limit=d.dataset_centre[0] + 0.1
@@ -346,6 +539,24 @@ def fit(
         ),
     )
 
+    """
+    __Search: vis_pix__
+
+    Nautilus again, with settings that reflect how much more each likelihood
+    evaluation now costs. ``n_live=300``, against ``vis_lp``'s 750: the space is
+    both smaller (the lens light is fixed, and the pixelization contributes only
+    its regularization parameters) and far more expensive per evaluation, since
+    every one solves an inversion. ``n_batch=15`` is the number of likelihood
+    evaluations Nautilus requests per step, kept low so the memory those
+    inversions need in parallel stays manageable. ``n_like_max=100000`` caps a
+    pathological fit at half the ``vis_lp`` ceiling, for the same reason.
+
+    ``number_of_cores`` is added to the search dict here and only here. ``vis_lp``
+    takes its parallelism from the batch of models it evaluates on the device,
+    whereas this search is the one that benefits from a multiprocessing pool —
+    which is why ``--use_cpu`` and ``--number_of_cores`` are usually passed
+    together.
+    """
     vis_pix_search_dict = {
         **settings_search.search_dict,
         "number_of_cores": number_of_cores,

--- a/scripts/lens_model_waveband.py
+++ b/scripts/lens_model_waveband.py
@@ -2,13 +2,66 @@
 Multi-Waveband Lens Model Pipeline
 ====================================
 
-Fits all non-VIS wavebands in the dataset with the full lens model (lens light,
-mass, source) fixed to the VIS result.  A sub-pixel astrometric offset
-(``DatasetModel``) is a free parameter for each secondary band to correct for
-any residual alignment offsets between wavebands.
+__Why Fit The Other Bands At All__
 
-Called by ``sersic_lens_model.py`` and ``mge_lens_only.py`` after their
-respective VIS fits.
+A Euclid cut-out is not one image. Alongside VIS it carries the NISP
+near-infrared bands and, over most of the sky, external ground-based imaging
+(DES, CFIS, HSC, Pan-STARRS and others), each stored as its own
+``(<BAND>_BGSUB, <BAND>_PSF, <BAND>_RMS)`` HDU triplet in the same FITS file.
+
+The lens model is derived from VIS, because VIS is the sharpest data and
+therefore the data that constrains geometry. But a lens model on its own does
+not give you a spectral energy distribution. To place the lens and the lensed
+source on an SED — and from there estimate photometric redshifts and stellar
+masses — you need the flux of *each galaxy separately* in *each band*, and in a
+strong lens the two galaxies overlap on the sky. Aperture photometry cannot
+separate them; a lens model can. So this script goes back to every non-VIS band
+and measures its flux with the lens model already known.
+
+__What Is Fixed And What Is Free__
+
+Everything geometric is fixed to the VIS result handed in as ``vis_result``:
+the lens light, the mass, the external shear and the source light all enter the
+model as ``instance`` objects, not free model components. The only parameters
+the sampler varies are the two components of a ``DatasetModel`` grid offset,
+which absorbs any residual astrometric misalignment between this band's pixel
+grid and VIS.
+
+That leaves the question of where the per-band photometry comes from, given
+that nothing in the model is free to change brightness. The answer is that
+brightness was never a sampled parameter in the first place: the lens and source
+light profiles are *linear* light profiles (the MGE Gaussians of
+``initial_lens_model.py``, or the ``lp_linear.Sersic`` of
+``sersic_lens_model.py``), whose intensities are solved by linear algebra at
+every likelihood evaluation. Fixing the instance fixes the shapes; the
+intensities are re-solved against this band's own data. The shape comes from
+VIS, the flux comes from the band.
+
+__Running It__
+
+Run as a script it does the whole chain: an ``initial_lens_model`` ``vis_lp``
+fit on VIS, then one search per remaining band under the same tag::
+
+    python scripts/lens_model_waveband.py --sample=<sample> --dataset=<name>
+
+``fit_waveband`` is also imported by ``scripts/sersic_lens_model_waveband.py``,
+the SED chain driver, which passes the Sersic VIS result and
+``unique_tag="sersic_lens_model"`` instead.
+
+__Downstream__
+
+The per-band results are the input to two catalogue producers:
+``catalogue/scripts/magnitudes.py`` scrapes their latent fluxes into
+``magnitudes.csv``, the photometry table the SED fitting works from, and
+``catalogue/scripts/multi_wavelength.py`` stacks one row per band into
+``fit_multi_wavelength.png`` for visual inspection. Both default to reading
+``output_sed``, the output tree the SED chain is run under.
+
+New to the pipeline? Read ``start_here.py`` in the repository root first: it
+covers installation, the dataset and FITS header contracts, masking and
+over-sampling, the MGE, Nautilus and JAX, and how to read ``output/``. This
+script assumes all of it and explains only what is specific to fitting a second
+waveband.
 """
 
 import os
@@ -36,6 +89,20 @@ def fit_waveband(
     from astropy.wcs import WCS
     from autolens import conf
 
+    """
+    __Configs__
+
+    The pipeline's own ``config/`` directory is pushed onto the configuration
+    stack, and results are written to the directory named by
+    ``PYAUTO_OUTPUT_DIR`` (default ``output/``). The SED chain sets that
+    variable to ``output_sed``, because this script writes one search per band
+    per lens and would otherwise bury the main output tree.
+
+    ``cb_unit`` is the colour bar label used by every figure the run produces.
+    VIS imaging is in ADU per second while the NISP and external bands are in
+    electrons per second (see ``util.ab_mag_via_flux_from``), so the label is
+    set to match the data being fitted here.
+    """
     project_root = Path(__file__).parent.parent
     conf.instance.push(
         new_path=project_root / "config",
@@ -46,18 +113,55 @@ def fit_waveband(
         "cb_unit"
     ] = r"$\,\,\mathrm{e^{-}}\,\mathrm{s^{-1}}$"
 
+    """
+    __Dataset__
+
+    The same dataset directory the VIS fit read:
+    ``dataset/<sample>/<name>/<name>.fits``, with ``<sample>`` omitted for a
+    flat layout. Nothing new is downloaded or prepared here — the other bands
+    were always in that one file.
+
+    ``util.load_vis_dataset`` is not used below, because it is the *VIS* loader:
+    it picks the ``vis`` HDU, applies that band's mask and over-sampling and
+    returns a single prepared dataset. This script needs the same preparation
+    repeated for every other band, so it opens the FITS file directly.
+    """
     if sample_name is not None:
         dataset_main_path = project_root / "dataset" / sample_name / dataset_name
     else:
         dataset_main_path = project_root / "dataset" / dataset_name
     dataset_fits_name = f"{dataset_name}.fits"
 
+    """
+    __Dataset Wavebands__
+
+    Which bands a cut-out contains is discovered, not configured. Every HDU name
+    ending in ``_BGSUB`` is an image HDU, and the band name is what remains once
+    the tag is stripped: ``des_g``, ``vis``, ``nir_y`` and so on. The dictionary
+    maps each band to its *position* in that list of image HDUs, counting from
+    zero.
+
+    Because the FITS contract is a repeating
+    ``(<BAND>_BGSUB, <BAND>_PSF, <BAND>_RMS)`` triplet after the PRIMARY header,
+    a band at position ``i`` has its image at HDU ``i * 3 + 1``, its PSF at
+    ``i * 3 + 2`` and its RMS noise map at ``i * 3 + 3``. That is the arithmetic
+    used throughout the loop below — you never write an HDU index by hand.
+    """
     dataset_index_dict = util.dataset_instrument_hdu_dict_via_fits_from(
         dataset_path=dataset_main_path,
         dataset_fits_name=dataset_fits_name,
         image_tag="_BGSUB",
     )
 
+    """
+    __Mask Metadata__
+
+    The mask radius and centre come from the dataset's ``info.json`` — they are
+    never command-line arguments, so every band of a lens is masked exactly as
+    its VIS fit was, and the fluxes measured here are comparable to the VIS
+    fluxes. If the file or a key is missing the fallbacks are a 3.0" radius
+    centred on the frame.
+    """
     try:
         with open(dataset_main_path / "info.json") as f:
             info = json.load(f)
@@ -67,7 +171,28 @@ def fit_waveband(
     mask_radius = info.get("mask_radius") or 3.0
     mask_centre = info.get("mask_centre") or (0.0, 0.0)
 
-    # Lowest-resolution PSF is the same for all bands — load once.
+    """
+    __Lowest Resolution PSF__
+
+    The four aperture-flux latent variables are matched-aperture photometry: the
+    model lens image is convolved to the resolution of the *worst-seeing* band
+    in the cut-out and summed within 1, 2, 3 and 4 times that band's PSF FWHM,
+    so that a VIS flux and a ground-based flux can be compared like for like in
+    an SED fit.
+
+    That reference band is named by the ``WORST_BAND`` key of the PRIMARY
+    header, and its FWHM by the ``WORST_PSF_*`` keys — both stamped by the
+    upstream Euclid cut-out generator, not by this pipeline. The PSF is the same
+    for every band being fitted, so it is loaded once here rather than inside
+    the loop.
+
+    If ``WORST_BAND`` is missing, or names a band this cut-out does not contain,
+    the aperture latents are skipped with a warning and the fits themselves are
+    unaffected. A missing FWHM is treated far more harshly inside
+    ``util.psf_fwhm_arcsec_from_primary_header``, which raises: the aperture
+    radii are multiples of it, so a guessed value would silently corrupt the
+    photometry this whole script exists to produce.
+    """
     header_primary = al.header_obj_from(
         file_path=dataset_main_path / dataset_fits_name, hdu=0
     )
@@ -108,10 +233,40 @@ def fit_waveband(
                 dataset_name=dataset_name,
             )
 
+    """
+    __Waveband Loop__
+
+    One independent fit per band, VIS skipped because it has already been
+    fitted — its result is the ``vis_result`` every one of these fits is
+    conditioned on. Each iteration repeats the whole dataset preparation for its
+    band: load, centre, header, noise scaling, mask, over-sampling, then the
+    search.
+    """
     for dataset_waveband, dataset_index in dataset_index_dict.items():
         if dataset_waveband == "vis":
             continue
 
+        """
+        __Dataset (This Band)__
+
+        Image, PSF and noise map for this band, from the triplet arithmetic
+        described above.
+
+        The pixel scale is 0.1"/pixel for *every* band, which is why it is
+        hard-coded here rather than read per band: a MER cut-out resamples the
+        NISP and external imaging onto the same grid as VIS. "Lower resolution"
+        therefore does not mean bigger pixels — the NIR and ground-based data
+        are blurrier, not coarser, and that blurring is carried entirely by each
+        band's own PSF, loaded from its own HDU and convolved with the model at
+        every likelihood evaluation.
+
+        This is also the deeper reason the lens model is held fixed. A band
+        whose PSF is two or three times wider than VIS simply does not resolve
+        the arcs well enough to constrain an Einstein radius or a light profile
+        shape; asked to fit them it would return a poorly constrained model and
+        contaminate the photometry. Given the geometry, the same data constrain
+        flux perfectly well.
+        """
         dataset = al.Imaging.from_fits(
             data_path=dataset_main_path / dataset_fits_name,
             data_hdu=dataset_index * 3 + 1,
@@ -123,13 +278,31 @@ def fit_waveband(
             check_noise_map=False,
         )
 
-        # Search around the lens centre, not the frame centre, so offset
-        # lenses anchor their priors on the right pixel.
+        """
+        __Lens Centre__
+
+        The brightest sub-pixel is searched for in a small box around the *lens*
+        centre from ``info.json``, not around the centre of the frame, so a lens
+        that sits off-centre in its cut-out still anchors the over-sampling on
+        the right pixel. In this band the brightest pixel can land a fraction of
+        a pixel away from where it falls in VIS, which is exactly the
+        misalignment the grid offset below is there to absorb.
+        """
         cy, cx = mask_centre
         dataset_centre = dataset.data.brightest_sub_pixel_coordinate_in_region_from(
             region=(cy - 0.3, cy + 0.3, cx - 0.3, cx + 0.3), box_size=2
         )
 
+        """
+        __Zero Point And WCS__
+
+        ``MAGZERO`` is the photometric zero-point of *this* band's image HDU. It
+        is passed into the analysis below and is what turns a fitted flux in
+        image units into an AB magnitude and then microJansky — without it the
+        µJy latents cannot be computed, and a band's photometry is not
+        comparable with any other band's. The WCS is carried through so the
+        fitted lens centre can be written back out in sky coordinates.
+        """
         try:
             header = al.header_obj_from(
                 file_path=dataset_main_path / dataset_fits_name,
@@ -142,10 +315,20 @@ def fit_waveband(
 
         pixel_wcs = WCS(header).celestial if header is not None else None
 
-        # Noise-scaling mask: DR1 preprocessing writes
-        # `segmentation/artefact_binary.fits`; older datasets ship
-        # `mask_extra_galaxies.fits`. Try both, and only apply a mask cut out
-        # at the same size as this band's image.
+        """
+        __Noise Scaling__
+
+        Neighbouring galaxies and artefacts inside the mask are not modelled;
+        their pixels are instead given a large noise value so the likelihood
+        stops caring about them. DR1 preprocessing writes that map as
+        ``segmentation/artefact_binary.fits`` and older datasets as
+        ``mask_extra_galaxies.fits``, so both names are tried in that order, and
+        neither being present is fine.
+
+        The map is applied only if it was cut out at the same size as this
+        band's image; one made for a differently sized frame is skipped rather
+        than forced on.
+        """
         for noise_mask_path in (
             dataset_main_path / "segmentation" / "artefact_binary.fits",
             dataset_main_path / "mask_extra_galaxies.fits",
@@ -162,6 +345,14 @@ def fit_waveband(
                 dataset = dataset.apply_noise_scaling(mask=mask_extra_galaxies)
             break
 
+        """
+        __Mask__
+
+        The same circular mask as the VIS fit: same radius, same centre, read
+        from the same ``info.json``. Using one aperture across all bands is what
+        makes the fluxes that come out of them a colour rather than a collection
+        of unrelated numbers.
+        """
         mask = al.Mask2D.circular(
             shape_native=dataset.shape_native,
             pixel_scales=dataset.pixel_scales,
@@ -170,6 +361,25 @@ def fit_waveband(
         )
         dataset = dataset.apply_mask(mask=mask)
 
+        """
+        __Over Sampling__
+
+        Two schemes, chosen by ``use_sersic_over_sampling``.
+
+        The default (``False``, how the ``initial_lens_model`` chain runs) is
+        the standard radial scheme: 4x4 sub-pixels within 0.1" of the lens
+        centre, 2x2 out to 0.3", 1x1 beyond.
+
+        The Sersic chain passes ``True``. A Sersic profile diverges at its
+        centre, so evaluating it on one point per pixel is not accurate enough
+        near either galaxy's core. This branch therefore builds two maps — one
+        concentrated on the *source* centre, computed on the grid traced back to
+        the source plane by the VIS tracer, and one concentrated on the lens
+        centre in the image plane — and keeps the larger sub-grid of the two at
+        every pixel. It reads ``tracer.galaxies[1].bulge.centre``, which is why
+        it is only ever passed by the Sersic chain: it needs a source bulge that
+        is a single profile with a centre.
+        """
         if not use_sersic_over_sampling:
             over_sample_size = (
                 al.util.over_sample.over_sample_size_via_radial_bins_from(
@@ -209,6 +419,22 @@ def fit_waveband(
             over_sample_size = al.Array2D(values=over_sample_size, mask=mask)
             dataset = dataset.apply_over_sampling(over_sample_size_lp=over_sample_size)
 
+        """
+        __Settings AutoFit__
+
+        Results land at::
+
+            <PYAUTO_OUTPUT_DIR>/<sample>/<dataset>/<unique_tag>/<band>/<hash>/
+
+        The search is named after the band, so all of a lens's bands sit side by
+        side under one tag — ``initial_lens_model`` when this script is run
+        directly, ``sersic_lens_model`` when the SED chain calls it. That layout
+        is what the catalogue producers walk, and their ``--unique_tag``
+        argument selects which stage they read.
+
+        ``magzero`` rides along in ``info``, from where the analysis picks it up
+        to convert fitted fluxes into microJansky.
+        """
         settings_search = af.SettingsSearch(
             path_prefix=(
                 Path(sample_name) / dataset_name
@@ -220,6 +446,20 @@ def fit_waveband(
             session=None,
         )
 
+        """
+        __Analysis__
+
+        The pipeline's ``AnalysisImaging``, so each band's fit computes the
+        Euclid latent catalogue — the lens, lensed-source and source fluxes in
+        µJy and the four matched aperture fluxes — which is the actual product
+        of this script.
+
+        ``title_prefix`` labels every figure with the band so the outputs are
+        not interchangeable at a glance, and ``skip_rgb_plot=True`` suppresses
+        the RGB subplot: it is built from the dataset's colour thumbnails and is
+        identical for every band, so it is worth plotting once with the VIS fit
+        rather than again in every band's output folder.
+        """
         analysis = util.AnalysisImaging(
             dataset=dataset,
             use_jax=True,
@@ -232,6 +472,20 @@ def fit_waveband(
             **settings_search.info,
         )
 
+        """
+        __Dataset Model__
+
+        The one thing that is genuinely free. A ``DatasetModel`` extends the
+        model with a (y, x) offset between this band's grid and the grid the VIS
+        model was fitted on, given a uniform prior of ±0.2" — two pixels at
+        0.1"/pixel.
+
+        It is needed because astrometric registration between instruments is
+        rarely perfect at the precision a lens model works to, and an
+        unmodelled shift of even a fraction of a pixel would be absorbed as
+        residuals around the lens centre and arcs, biasing the very fluxes this
+        fit is measuring. Two parameters is a cheap price for removing that.
+        """
         dataset_model = af.Model(al.DatasetModel)
         dataset_model.grid_offset.grid_offset_0 = af.UniformPrior(
             lower_limit=-0.2, upper_limit=0.2
@@ -240,6 +494,21 @@ def fit_waveband(
             lower_limit=-0.2, upper_limit=0.2
         )
 
+        """
+        __Model: VIS Lens Model, Fixed__
+
+        Lens light, mass, shear and source light are all taken from
+        ``vis_result.instance`` — fitted values, not priors, so the sampler
+        cannot move any of them. Combined with the two offset parameters above,
+        the whole model has two non-linear dimensions, which is why a band
+        finishes in a fraction of the time the VIS fit took.
+
+        What is *not* frozen is brightness. Both bulges are linear light
+        profiles, so their intensities never were sampled parameters; they are
+        solved by linear algebra against whichever data the analysis is given.
+        Handing the same shapes to this band's data therefore produces this
+        band's fluxes, and doing that across every band produces an SED.
+        """
         model = af.Collection(
             galaxies=af.Collection(
                 lens=af.Model(
@@ -258,6 +527,15 @@ def fit_waveband(
             dataset_model=dataset_model,
         )
 
+        """
+        __Search__
+
+        Nautilus again, but a much smaller one than the VIS fit: ``n_live=75``
+        is ample for a two-parameter space, and ``n_like_max=50000`` stops a
+        band that refuses to converge from stalling the rest of the sample's SED
+        chain. ``iterations_per_quick_update`` sets how often the on-the-fly
+        figures are refreshed while it runs.
+        """
         search = af.Nautilus(
             name=dataset_waveband,
             **settings_search.search_dict,
@@ -280,6 +558,20 @@ if __name__ == "__main__":
         skip_pix,
     ) = util.parse_fit_args()
 
+    """
+    __Running Standalone__
+
+    Run directly, this script is self-contained: it produces the VIS result it
+    needs, then fits every other band against it. The arguments are the ones
+    every pipeline here takes — ``--dataset``, ``--sample``,
+    ``--iterations_per_quick_update`` and the rest. ``mask_radius`` is not among
+    them; it always comes from the dataset's ``info.json``.
+
+    Both stages write under the same ``initial_lens_model`` tag, VIS as
+    ``vis_lp`` and each other band under its own name. For the SED chain proper
+    — where the bands are fitted against a Sersic VIS model instead — run
+    ``scripts/sersic_lens_model_waveband.py``.
+    """
     # `skip_pix=True` is forced (the `--skip_pix` flag is not consulted here):
     # the multi-band model takes `vis_result.instance.galaxies.source.bulge`,
     # which only exists on the `vis_lp` result — `vis_pix` replaces the source

--- a/scripts/mge_lens_only.py
+++ b/scripts/mge_lens_only.py
@@ -2,12 +2,64 @@
 MGE Lens-Only Pipeline
 ======================
 
-Fits a Multi Gaussian Expansion (MGE) to the lens light only — no mass model,
-no source.  Provides a clean lens light subtraction for visual inspection of the
-lensed arcs and as an input to downstream pipelines.
+__What This Is For__
 
-``fit()``          — VIS band only.
-``fit_waveband()`` — all non-VIS bands, with the lens model fixed to the VIS result.
+Sometimes the question is not "what is the lens model?" but "is there a lensed
+source here at all?". In a Euclid cut-out the lens galaxy is the bright thing in
+the middle and the arcs sit on top of it, so a candidate is hard to grade by eye
+until the lens light has been taken away.
+
+This script takes it away. It fits a Multi Gaussian Expansion (MGE) to the lens
+light and to nothing else — there is no mass model and no source in the model at
+all — and the fit's lens-light-subtracted image is the thing you look at. Use it
+to eyeball a candidate or triage a sample; use ``scripts/initial_lens_model.py``
+when you want an Einstein radius, a source reconstruction, or photometry to
+publish.
+
+__Why It Is Fast__
+
+Two reasons, both consequences of what has been left out.
+
+Nothing is lensed. With no mass profile the model has a single plane, so a
+likelihood evaluation is a light profile evaluated on a grid and convolved with
+the PSF — no ray tracing, no source plane, no pixelization.
+
+And the MGE is cheap to sample. The lens light is 40 Gaussians (two sets of 20),
+but every Gaussian's ``intensity`` is solved by linear algebra at each
+evaluation rather than sampled, leaving only a handful of non-linear parameters
+for the search to explore. That combination is what makes a subtraction you can
+run over a whole candidate list.
+
+__What To Watch Out For__
+
+The MGE is deliberately flexible, and here it is the *only* thing in the model.
+Nothing represents the lensed source, so any source flux the Gaussians can
+absorb, they will — most of all where the arcs sit closest to the lens light.
+``scripts/initial_lens_model.py`` guards against a related failure by narrowing
+its MGE ellipticity priors, so that the Gaussians cannot form the multi-blob
+shape that eats lensed-source flux; this script does not, because it is not
+trying to measure anything.
+
+So read the subtracted image as an indication of where the source emission is,
+not as a measurement of how much of it there is. If it looks promising, fit it
+properly.
+
+__What It Fits__
+
+- ``fit()`` — the VIS band. Returns the result the second stage is conditioned
+  on.
+- ``fit_waveband()`` — every other band in the cut-out, with the VIS lens light
+  held fixed and only a small astrometric offset free, giving the same
+  subtraction band by band.
+
+Run it as::
+
+    python scripts/mge_lens_only.py --sample=<sample> --dataset=<name>
+
+New to the pipeline? Read ``start_here.py`` in the repository root first: it
+covers installation, the dataset contract, masking and over-sampling, what an
+MGE is, Nautilus and JAX, and how to read ``output/``. This script assumes all
+of it.
 """
 
 import os
@@ -26,6 +78,14 @@ def fit(
 ):
     from autolens import conf
 
+    """
+    __Configs__
+
+    The pipeline's ``config/`` directory is pushed onto the configuration stack
+    — priors, visualisation settings and the latent toggles all come from there
+    — and results are written under the directory named by ``PYAUTO_OUTPUT_DIR``
+    (default ``output/``).
+    """
     project_root = Path(__file__).parent.parent
     conf.instance.push(
         new_path=project_root / "config",
@@ -35,8 +95,37 @@ def fit(
     import autofit as af
     import autolens as al
 
+    """
+    __Dataset__
+
+    One call does the whole VIS preparation: finds the FITS file, locates the
+    VIS HDU triplet, loads image, noise map and PSF, reads ``info.json`` and the
+    header, applies the extra-galaxy noise scaling and the circular mask, sets
+    the standard over-sampling and loads the worst-seeing band's PSF for the
+    aperture-flux latents. ``start_here.py`` walks through what each of those
+    steps is for; ``util.load_vis_dataset`` documents the returned fields.
+
+    The mask radius comes from the dataset's ``info.json`` and is never a
+    command-line argument. It matters more than it looks: it sets the outer
+    extent of the Gaussians the MGE is built from, so it is a modeling choice
+    and not just a crop.
+    """
     d = util.load_vis_dataset(dataset_name, sample_name=sample_name)
 
+    """
+    __Settings AutoFit__
+
+    Results land at::
+
+        <PYAUTO_OUTPUT_DIR>/<sample>/<dataset>/mge_lens_only/vis/<hash>/
+
+    The ``mge_lens_only`` tag keeps this subtraction beside, rather than on top
+    of, any full lens model of the same lens, and is the string the ``workflow/``
+    aggregator examples query on to collect these fits across a sample.
+
+    ``magzero``, the photometric zero-point from the VIS header, rides along in
+    ``info`` so the analysis can express fluxes in physical units.
+    """
     settings_search = af.SettingsSearch(
         path_prefix=(
             Path(sample_name) / dataset_name
@@ -48,6 +137,18 @@ def fit(
         session=None,
     )
 
+    """
+    __Analysis__
+
+    The pipeline's ``AnalysisImaging``, which adds the RGB visualisation and the
+    Euclid latent catalogue on top of the library analysis, and runs the
+    likelihood through JAX.
+
+    No ``positions_likelihood_list`` is passed, unlike the full pipelines. That
+    likelihood penalty exists to reject mass models that fail to trace the
+    multiple images back to a common source position — and there is no mass
+    model here for it to act on.
+    """
     analysis = util.AnalysisImaging(
         dataset=d.dataset,
         use_jax=True,
@@ -59,6 +160,23 @@ def fit(
         **settings_search.info,
     )
 
+    """
+    __Model: Lens Light Only__
+
+    One galaxy, one component: an MGE bulge of 40 Gaussians, built as two sets
+    of 20 by ``mge_model_from``, sharing a centre initialised on the brightest
+    pixel found near the lens centre. Each Gaussian's intensity is solved
+    linearly, so the search sees only the handful of non-linear parameters that
+    set the shape of the two sets.
+
+    There is no ``mass`` and no ``source`` in this collection, and that absence
+    is the entire design of this script: it is what makes the fit quick, and
+    what means the residual image is a look at the source rather than a model of
+    it.
+
+    The redshift is a label. With no mass profile nothing is lensed, so no
+    distance-dependent quantity is computed and the value never enters the fit.
+    """
     bulge = al.model_util.mge_model_from(
         mask_radius=d.mask_radius,
         total_gaussians=20,
@@ -73,6 +191,14 @@ def fit(
         ),
     )
 
+    """
+    __Search__
+
+    Nautilus nested sampling, named ``vis`` after the band, with ``n_live=75``
+    — a small live-point count is enough for a parameter space this shallow.
+    ``iterations_per_quick_update`` sets how often the figures on disk are
+    refreshed, so the subtraction can be watched as it improves.
+    """
     search = af.Nautilus(
         name="vis",
         **settings_search.search_dict,
@@ -81,6 +207,19 @@ def fit(
         iterations_per_quick_update=iterations_per_quick_update,
     )
 
+    """
+    __Result: What To Look At__
+
+    The result folder's ``image/`` directory is refreshed throughout the fit.
+    Because this model has one plane, the fit subplot written there is the
+    single-plane one — data, model data, lens-light-subtracted image, normalized
+    residual map — and the third of those panels is why you ran the script: the
+    data with the fitted lens light removed, in which the arcs should stand out
+    if they are there.
+
+    ``files/`` alongside it holds the machine-readable result, and the returned
+    object is what ``fit_waveband`` below conditions every other band on.
+    """
     return search.fit(model=model, analysis=analysis, **settings_search.fit_dict)
 
 
@@ -91,15 +230,34 @@ def fit_waveband(
     iterations_per_quick_update: int = 50000,
 ):
     """
-    Fit all non-VIS wavebands in the dataset, with the lens model fixed to the
-    VIS result.  A sub-pixel astrometric offset (DatasetModel) is fitted for
-    each secondary band.
+    Subtract the lens light from every non-VIS band of the cut-out.
+
+    The cut-out's other bands — NISP near-infrared, and the external
+    ground-based imaging where it exists — each get their own fit, with the MGE
+    from the VIS result frozen as an instance and only a small astrometric
+    offset between the two pixel grids left free. The Gaussian intensities are
+    still solved linearly against each band's own data, so the subtraction
+    adapts to how bright the lens is in that band even though its shape does
+    not change.
+
+    As in ``fit`` above there is no mass model and no source: this produces a
+    lens-light-subtracted image per band for inspection, not a multi-band lens
+    model. For fitted multi-band photometry, run
+    ``scripts/sersic_lens_model_waveband.py``, the SED chain.
     """
     import autofit as af
     import autolens as al
     from autolens import conf
     from pathlib import Path
 
+    """
+    __Configs__
+
+    The configuration push is repeated because this function is also usable on
+    its own, given a VIS result. ``cb_unit`` relabels the figure colour bars in
+    electrons per second, the units of the NISP and external imaging, where VIS
+    is in ADU per second (see ``util.ab_mag_via_flux_from``).
+    """
     project_root = Path(__file__).parent.parent
     conf.instance.push(
         new_path=project_root / "config",
@@ -110,8 +268,21 @@ def fit_waveband(
         "cb_unit"
     ] = r"$\,\,\mathrm{e^{-}}\,\mathrm{s^{-1}}$"
 
-    # Re-use the dataset index dict from any waveband load; we only need the
-    # path and HDU mapping here so load without full over-sampling overhead.
+    """
+    __Dataset Wavebands__
+
+    ``util.load_vis_dataset`` is the VIS loader — it prepares one band and
+    returns it ready to fit. Here every *other* band has to be prepared in turn,
+    so the FITS file is opened directly and only the path and the band-to-HDU
+    mapping are taken from it.
+
+    That mapping is discovered from the HDU names: anything ending in ``_BGSUB``
+    is an image HDU, and the band name is what is left when the tag is stripped.
+    A band's position in that list gives its three HDUs, because the file is a
+    repeating ``(<BAND>_BGSUB, <BAND>_PSF, <BAND>_RMS)`` triplet after the
+    PRIMARY header — image at ``i * 3 + 1``, PSF at ``i * 3 + 2``, noise map at
+    ``i * 3 + 3``.
+    """
     project_root = Path(__file__).parent.parent
     if sample_name is not None:
         dataset_main_path = project_root / "dataset" / sample_name / dataset_name
@@ -127,6 +298,14 @@ def fit_waveband(
 
     import json
 
+    """
+    __Mask Metadata__
+
+    ``mask_radius`` is read from the dataset's ``info.json`` — it is a required
+    key, not a command-line argument, and a dataset without it raises here
+    rather than being masked at some invented default. Every band is then masked
+    exactly as VIS was, which is what makes their subtractions comparable.
+    """
     try:
         with open(dataset_main_path / "info.json") as f:
             info = json.load(f)
@@ -135,7 +314,20 @@ def fit_waveband(
 
     mask_radius = info["mask_radius"]
 
-    # Load lowest-resolution PSF once — it is the same for all bands.
+    """
+    __Lowest Resolution PSF__
+
+    The aperture-flux latent variables are matched-aperture photometry, measured
+    on the lens image convolved to the resolution of the worst-seeing band in
+    the cut-out. That band is named by the PRIMARY header's ``WORST_BAND`` key
+    and its FWHM by the ``WORST_PSF_*`` keys, both stamped by the upstream
+    Euclid cut-out generator rather than by this pipeline.
+
+    It is the same reference PSF for every band, so it is loaded once here
+    instead of inside the loop. If ``WORST_BAND`` is missing or names a band the
+    cut-out does not contain, the aperture latents are skipped with a warning
+    and the fits themselves proceed unaffected.
+    """
     header_primary = al.header_obj_from(
         file_path=dataset_main_path / dataset_fits_name, hdu=0
     )
@@ -176,10 +368,35 @@ def fit_waveband(
                 dataset_name=dataset_name,
             )
 
+    """
+    __Waveband Loop__
+
+    One independent fit per band, VIS skipped because it has already been
+    fitted and is what the rest are conditioned on. Each pass repeats the whole
+    preparation for its band — load, centre, header, noise scaling, mask,
+    over-sampling — then runs its own short search.
+    """
     for dataset_waveband, dataset_index in dataset_index_dict.items():
         if dataset_waveband == "vis":
             continue
 
+        """
+        __Dataset (This Band)__
+
+        Image, PSF and noise map for this band, from the triplet arithmetic
+        above.
+
+        The pixel scale is 0.1"/pixel for every band and so is hard-coded: a MER
+        cut-out puts the NISP and external imaging on the same grid as VIS. The
+        NIR and ground-based data are therefore blurrier rather than coarser,
+        and that blurring is carried by each band's own PSF, loaded from its own
+        HDU. It is also the reason the lens light shape is taken from VIS and
+        not refitted here — a broader PSF smooths out exactly the structure an
+        MGE would need in order to be constrained.
+
+        The brightest sub-pixel is searched for in a box around the centre of
+        the frame, and is used to concentrate the over-sampling below.
+        """
         dataset = al.Imaging.from_fits(
             data_path=dataset_main_path / dataset_fits_name,
             data_hdu=dataset_index * 3 + 1,
@@ -195,6 +412,14 @@ def fit_waveband(
             region=(-0.3, 0.3, -0.3, 0.3), box_size=2
         )
 
+        """
+        __Zero Point And WCS__
+
+        ``MAGZERO`` is this band's photometric zero-point, passed into the
+        analysis so fluxes can be expressed as magnitudes and microJansky; the
+        WCS is carried through so the fitted lens centre can be written out in
+        sky coordinates.
+        """
         try:
             header = al.header_obj_from(
                 file_path=dataset_main_path / dataset_fits_name,
@@ -209,6 +434,15 @@ def fit_waveband(
 
         pixel_wcs = WCS(header).celestial if header is not None else None
 
+        """
+        __Noise Scaling__
+
+        Neighbouring galaxies and artefacts inside the mask are not modelled.
+        Where the dataset ships ``mask_extra_galaxies.fits``, those pixels are
+        given a large noise value instead, so the likelihood stops trying to fit
+        them and the MGE is not pulled off the lens by a bright neighbour. A
+        dataset without the file simply skips this.
+        """
         try:
             mask_extra_galaxies = al.Mask2D.from_fits(
                 file_path=dataset_main_path / "mask_extra_galaxies.fits",
@@ -219,6 +453,13 @@ def fit_waveband(
         except FileNotFoundError:
             pass
 
+        """
+        __Mask__
+
+        The same circular aperture as the VIS fit — same radius, same centre,
+        both from ``info.json`` — so the lens light being subtracted here is
+        constrained over the same region it was in VIS.
+        """
         mask_centre = info.get("mask_centre") or (0.0, 0.0)
         mask = al.Mask2D.circular(
             shape_native=dataset.shape_native,
@@ -228,6 +469,14 @@ def fit_waveband(
         )
         dataset = dataset.apply_mask(mask=mask)
 
+        """
+        __Over Sampling__
+
+        The standard radial scheme: 4x4 sub-pixels within 0.1" of the lens
+        centre, 2x2 out to 0.3", 1x1 beyond. Light profiles change fastest in
+        the galaxy's core, so that is where evaluating one point per pixel would
+        be inaccurate — and it is where all of this model's light is.
+        """
         over_sample_size = al.util.over_sample.over_sample_size_via_radial_bins_from(
             grid=dataset.grid,
             sub_size_list=[4, 2, 1],
@@ -236,6 +485,16 @@ def fit_waveband(
         )
         dataset = dataset.apply_over_sampling(over_sample_size_lp=over_sample_size)
 
+        """
+        __Settings AutoFit__
+
+        Each band is a search named after itself, under the same tag as the VIS
+        fit::
+
+            <PYAUTO_OUTPUT_DIR>/<sample>/<dataset>/mge_lens_only/<band>/<hash>/
+
+        so a lens's whole set of subtractions sits in one folder, VIS included.
+        """
         settings_search = af.SettingsSearch(
             path_prefix=(
                 Path(sample_name) / dataset_name
@@ -247,6 +506,15 @@ def fit_waveband(
             session=None,
         )
 
+        """
+        __Analysis__
+
+        ``title_prefix`` stamps the band onto every figure, so subtractions from
+        different bands cannot be confused once they are out of their folders.
+        ``skip_rgb_plot=True`` drops the RGB subplot, which is built from the
+        dataset's colour thumbnails and is the same picture for every band — it
+        is already in the VIS output.
+        """
         analysis = util.AnalysisImaging(
             dataset=dataset,
             use_jax=True,
@@ -259,6 +527,16 @@ def fit_waveband(
             **settings_search.info,
         )
 
+        """
+        __Dataset Model__
+
+        The only free part of the model: a (y, x) offset between this band's
+        pixel grid and the grid the VIS fit was performed on, with a uniform
+        prior of ±0.2" — two pixels at 0.1"/pixel. Registration between
+        instruments is not perfect at that scale, and an unmodelled shift would
+        show up as a ring of residuals around the lens centre in the subtracted
+        image, which is exactly the region being inspected.
+        """
         dataset_model = af.Model(al.DatasetModel)
         dataset_model.grid_offset.grid_offset_0 = af.UniformPrior(
             lower_limit=-0.2, upper_limit=0.2
@@ -267,6 +545,20 @@ def fit_waveband(
             lower_limit=-0.2, upper_limit=0.2
         )
 
+        """
+        __Model: VIS Lens Light, Fixed__
+
+        The lens bulge is taken straight from ``vis_result.instance``, so every
+        Gaussian's shape, size and position is fixed to what VIS measured, and
+        the search is left with the two offset parameters. Still no mass and no
+        source.
+
+        The lens's brightness in this band is not inherited: an MGE is built
+        from linear light profiles, whose intensities are solved by linear
+        algebra at each likelihood evaluation, so they are re-solved against
+        this band's data. The shape comes from VIS, the amount of light comes
+        from the band being fitted.
+        """
         model = af.Collection(
             galaxies=af.Collection(
                 lens=af.Model(
@@ -278,6 +570,14 @@ def fit_waveband(
             dataset_model=dataset_model,
         )
 
+        """
+        __Search__
+
+        A two-parameter search, so it is short. Its output folder carries the
+        same single-plane fit subplot as the VIS fit — data, model data,
+        lens-light-subtracted image, normalized residual map — which is the
+        subtraction to look at for this band.
+        """
         search = af.Nautilus(
             name=dataset_waveband,
             **settings_search.search_dict,
@@ -299,6 +599,20 @@ if __name__ == "__main__":
         skip_pix,
     ) = util.parse_fit_args()
 
+    """
+    __Running Standalone__
+
+    VIS first, then every other band against it — the two stages of this script
+    in the order they have to run.
+
+    The shared argument parser is used so that one command line works across all
+    the pipelines, but this script only acts on ``--sample``, ``--dataset`` and
+    ``--iterations_per_quick_update``. ``--number_of_cores``, ``--use_cpu`` and
+    ``--skip_pix`` are accepted and ignored: there is no pixelized stage to skip
+    and no CPU-parallel search to size, because every search here runs under
+    JAX on a model with a handful of parameters. ``mask_radius`` is not an
+    argument at all — it comes from the dataset's ``info.json``.
+    """
     vis_result = fit(
         dataset_name=dataset_name,
         sample_name=sample_name,

--- a/scripts/sersic_lens_model.py
+++ b/scripts/sersic_lens_model.py
@@ -2,14 +2,70 @@
 Sersic Lens Model Pipeline
 ===========================
 
-Fits a linear Sersic bulge to both the lens and source galaxy, with the mass
-model fixed to the result of ``scripts/initial_lens_model.py`` (the initial MGE fit).
+__What This Script Is For__
 
-``fit_sersic()``   — VIS band, Sersic light profiles, fixed mass from ``initial_lens_model``.
-``fit_waveband()`` — all non-VIS bands with the Sersic result fixed.
+``fit_sersic`` refits a VIS dataset that has already been modeled by
+``scripts/initial_lens_model.py``, replacing both galaxies' light with a single
+linear ``Sersic`` profile each and holding the mass model fixed at the values that
+fit found.
 
-The Sersic profile diverges at the galaxy centre, so this pipeline uses a
-higher-order over-sampling scheme derived from the tracer of the prior fit.
+The initial fit describes each galaxy with a Multi Gaussian Expansion: 40 Gaussians
+for the lens, 20 for the source. That is the right tool for *lens modeling* — it is
+flexible, its intensities solve linearly, and it keeps the non-linear parameter
+space small. It is not what a photometry catalogue wants. A catalogue row needs
+standard structural parameters for each galaxy — a centre, an ellipticity, an
+effective radius and a Sersic index — and a basis of Gaussians has none of those
+as parameters. So this script fits the profile that does.
+
+Those six parameters per galaxy are exactly what
+``catalogue/scripts/lens_sersic.py`` and ``catalogue/scripts/source_sersic.py``
+scrape out of these results into ``lens_sersic.csv`` and ``source_sersic.csv``.
+Intensity is not among them: an ``lp_linear.Sersic`` has its intensity solved by
+linear algebra at every likelihood evaluation, so it never enters the non-linear
+samples. That is also what makes the profile portable across bands —
+``scripts/lens_model_waveband.py`` fixes this Sersic's *shape* and re-solves its
+intensity against each band's own data, which is where the matched multi-band
+photometry for SED fitting and photometric redshifts comes from.
+
+__Why The Mass Model Is Fixed__
+
+The lens mass and external shear enter the model as instances of the ``vis_lp``
+result, not as free components. The geometry was already solved, on the same VIS
+data, by a fit built for the job; freeing it again would spend this search's
+budget re-deriving a known answer, and would leave the light parameters this
+script exists to measure marginalised over a mass uncertainty the initial fit had
+already resolved. With the mass fixed, the whole twelve-parameter space is light.
+
+__Why It Chains Off vis_lp, Not vis_pix__
+
+``initial_lens_model.fit`` is called with ``skip_pix=True``, so this script chains
+off the light-profile search ``vis_lp`` rather than the pixelized search
+``vis_pix``. This is not an optimisation. The source Sersic's centre priors are
+read from ``galaxies.source.bulge``, and the pixelized stage replaces the source
+bulge with a ``Pixelization`` — there is no bulge left in that result to seed a
+prior from. A pixelized source reconstruction is also not a Sersic and cannot be
+converted into one.
+
+__Running It__
+
+Run as a script, it does the ``vis_lp`` fit and then the Sersic fit::
+
+    python scripts/sersic_lens_model.py --sample=<sample> --dataset=<name>
+
+Results are written to ``sersic_lens_model/vis`` inside the dataset's output
+folder. The multi-waveband follow-on is deliberately not run from here; use
+``scripts/sersic_lens_model_waveband.py``, the SED chain driver, which runs the
+same two stages and then ``fit_waveband`` over every remaining band.
+
+Of the shared pipeline arguments, ``--number_of_cores`` and ``--use_cpu`` are
+forwarded to the upstream ``vis_lp`` fit; the Sersic search itself always runs on
+JAX. ``--skip_pix`` is ignored: it is forced to ``True`` regardless, for the reason
+above.
+
+New to the pipeline? Read ``start_here.py`` in the repository root first: it covers
+installation, the dataset contract, masking and over-sampling, the MGE, Nautilus
+and JAX, and how to read ``output/``. This script assumes all of it and explains
+only what is specific to the Sersic fit.
 """
 
 import os
@@ -40,14 +96,43 @@ def fit_sersic(
     import autofit as af
     import autolens as al
 
+    """
+    __Dataset__
+
+    The same VIS dataset the ``vis_lp`` fit was run on, loaded the same way:
+    ``util.load_vis_dataset`` handles the FITS layout, noise scaling, mask, PSF, WCS
+    and zero-point in one call. Its steps are documented individually in
+    ``scripts/initial_lens_model.py``, and the dataset contract it reads is described
+    in ``start_here.py``.
+    """
     d = util.load_vis_dataset(dataset_name, sample_name=sample_name)
 
     """
     __Over Sampling (Sersic)__
 
-    The Sersic profile diverges at its centre; we replace the standard over-
-    sampling with a tracer-derived scheme that concentrates sub-pixels near both
-    the lens and source centres.
+    The standard over-sampling applied by ``load_vis_dataset`` (4x4 sub-pixels within
+    0.1" of the lens centre, 2x2 out to 0.3", 1x1 beyond) is replaced here for two
+    reasons. A Sersic profile diverges at its centre, so 4x4 is not fine enough there:
+    the flux in the central pixels comes out wrong, and that error propagates straight
+    into the effective radius and Sersic index this script exists to measure. And the
+    standard scheme is built around the lens centre alone — it knows nothing about
+    where the lensed source's light falls.
+
+    Two maps are built and the larger sub-grid is kept at every pixel:
+
+    - The *source* map, computed on the grid traced back to the source plane by the
+      ``vis_lp`` tracer, and centred on the source. The source centre is taken from
+      the first Gaussian of the MGE source basis, which stands in for the centre of
+      the whole basis. Sub-sizes 16 / 4 / 2.
+    - The *lens* map, computed on the image-plane grid and centred on the dataset
+      centre (the brightest central pixel). Sub-sizes 16 / 4 / 1.
+
+    The source map has to be built on the traced grid because the source's centre is
+    a source-plane position: it is the *lensed* image of that centre, wherever the
+    arcs land, that needs the fine sub-grid in the image plane.
+
+    ``scripts/lens_model_waveband.py`` applies the identical scheme to the other
+    bands when the SED chain passes it ``use_sersic_over_sampling=True``.
     """
     tracer = vis_result.max_log_likelihood_tracer
 
@@ -74,6 +159,15 @@ def fit_sersic(
     over_sample_size = al.Array2D(values=over_sample_size, mask=d.dataset.mask)
     dataset = d.dataset.apply_over_sampling(over_sample_size_lp=over_sample_size)
 
+    """
+    __Settings AutoFit__
+
+    ``unique_tag="sersic_lens_model"`` keeps this fit beside, rather than inside, the
+    ``initial_lens_model`` results of the same dataset. With the search named ``vis``
+    below, results land in
+    ``output/<sample>/<dataset>/sersic_lens_model/vis/`` — the path the catalogue
+    Sersic scrapers look for.
+    """
     settings_search = af.SettingsSearch(
         path_prefix=(
             Path(sample_name) / dataset_name
@@ -88,8 +182,33 @@ def fit_sersic(
     """
     __Model__
 
-    Linear Sersic for lens and source; mass and shear fixed from ``initial_lens_model``.
-    Centre priors seeded from the MGE result.
+    A linear ``Sersic`` for the lens and a linear ``Sersic`` for the source, with the
+    lens mass and external shear fixed:
+
+     - Lens light: ``lp_linear.Sersic`` [6 free parameters — centre, elliptical
+       components, effective radius, Sersic index].
+     - Source light: ``lp_linear.Sersic`` [6 free parameters].
+     - Lens mass: ``Isothermal`` + ``ExternalShear``, both passed as instances of the
+       ``vis_lp`` result [0 free parameters].
+
+    Twelve non-linear parameters in total. Each profile's ``intensity`` is absent from
+    that count by design: ``lp_linear`` profiles solve intensity by linear algebra at
+    every likelihood evaluation, so brightness costs the sampler nothing and is never
+    a prior that can be got wrong.
+
+    The two centres are not fixed, but neither do they start from the broad config
+    default. ``vis_result.model_centred`` is the ``vis_lp`` model with its priors
+    re-centred on that fit's maximum likelihood values, so taking ``centre_0`` and
+    ``centre_1`` from it anchors each Sersic on the position the MGE already found
+    for that galaxy — the lens's on the image-plane centre, the source's on its
+    source-plane centre — while leaving them free to move.
+
+    This is also the reason a pixelized result cannot be used here: the source's two
+    centre priors are read from ``galaxies.source.bulge``, which the ``vis_pix``
+    search replaces with a ``Pixelization``.
+
+    The redshifts below are the same dimensionless placeholders the initial fit uses:
+    for a single-plane lens they do not affect the model.
     """
     lens_bulge = af.Model(al.lp_linear.Sersic)
     lens_bulge.centre.centre_0 = (
@@ -120,6 +239,19 @@ def fit_sersic(
         )
     )
 
+    """
+    __Analysis & Search__
+
+    No positions likelihood is passed, unlike the fits in
+    ``scripts/initial_lens_model.py``. Positions exist to reject mass models that
+    demagnify the source into an unphysical reconstruction, and there is no mass
+    model to reject here — it is fixed.
+
+    Nautilus settles this twelve-parameter space with a much smaller live-point set
+    than the ``vis_lp`` fit needs (``n_live=100`` against 750), and ``n_like_max``
+    caps a runaway fit. ``batch_size`` controls how many models are evaluated
+    simultaneously on the GPU; JAX is always on for this search.
+    """
     analysis = util.AnalysisImaging(
         dataset=dataset,
         use_jax=True,

--- a/scripts/simulator.py
+++ b/scripts/simulator.py
@@ -46,7 +46,7 @@ Fit it exactly like the real example dataset::
 
 __Resimulating a fit__
 
-``--from-result`` resolves a result directory the same way ``scripts/diagnose_latent.py``
+``--from-result`` resolves a result directory the same way ``scripts/tools/diagnose_latent.py``
 does (and reuses its ``resolve_files_path`` helper), so the arguments are the same::
 
     python scripts/simulator.py --from-result \
@@ -109,7 +109,7 @@ from PIL import Image
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import util
-from diagnose_latent import resolve_files_path
+from scripts.tools.diagnose_latent import resolve_files_path
 
 
 SIMULATOR_VERSION = "1.0"
@@ -209,6 +209,24 @@ TRUTH = {
     },
 }
 
+"""
+__Frame__
+
+The simulation frame, shared by both modes and overridable on the command line (``--shape``,
+``--pixel-scale``, ``--mask-radius``):
+
+- ``100x100`` pixels at ``0.1"/pixel`` is a 10" cut-out — the size and sampling of the Euclid
+  MER cut-outs this pipeline fits, so a simulated dataset drops into the fitting scripts with
+  nothing else changed.
+- ``mask_radius`` masks nothing here: the simulator writes the whole frame. It is a value
+  written into ``info.json``, and it is the fitting scripts that read it back and build their
+  circular analysis mask from it. 3.0" comfortably contains the arcs of a 1.2" Einstein radius
+  lens while staying inside the 5" half-frame.
+
+The two constants below the frame are conventions the *format* demands rather than choices the
+lens depends on — the nominal VIS exposure time and the sky position the TAN WCS is anchored
+on — and each carries its own note.
+"""
 DEFAULT_SHAPE_NATIVE = (100, 100)
 DEFAULT_PIXEL_SCALE = 0.1
 DEFAULT_MASK_RADIUS = 3.0
@@ -224,6 +242,25 @@ EXPOSURE_TIME = 565.0
 # (`util.load_vis_dataset` builds `WCS(header).celestial`, and `AnalysisImaging.save_results`
 # converts the lens centre to sky coordinates for the catalogue's `crval_ra_deg` column).
 WCS_CRVAL = (57.38288, -51.0)
+
+
+"""
+__Conversions and Headers__
+
+Three small helpers, and they are all in the same business: speaking the *pipeline's* dialect
+rather than PyAutoLens's.
+
+- ``json_number`` is the guard on everything written into ``truth.json``. A truth file is only
+  useful if it can be read back by any JSON parser, and a non-finite float cannot be.
+- ``gaussian_psf_from`` is the idealised PSF of ``--from-params``: a circular Gaussian of the
+  right FWHM, unit-normalised, returned as a ``Convolver`` so the same object can both blur the
+  simulated band and, later, degrade the lens light to the worst band's seeing for the aperture
+  fluxes. ``--from-result`` never calls it — it reuses the real PSF stamps of the fitted data.
+- ``image_wcs_header_from`` writes a band's image header. Two cards on it are read downstream
+  rather than decorative: ``MAGZERO``, which every flux-to-magnitude conversion in the pipeline
+  needs, and the TAN WCS, which becomes the ``pixel_wcs`` a fit uses to write its lens centre
+  out in sky coordinates.
+"""
 
 
 def json_number(value):
@@ -286,6 +323,20 @@ def image_wcs_header_from(shape_native, pixel_scale, magzero, band):
     header["FILTER"] = (band, "Euclid filter for flux image")
 
     return header
+
+
+"""
+__Dataset Writers__
+
+The three functions that put a simulation on disk: the multi-extension FITS, the segmentation
+maps and the RGB thumbnails. Each exists because a named consumer in this repository reads what
+it writes, so their docstrings name that consumer instead of describing the format in the
+abstract — the file layout is not a matter of taste, it is the contract that
+``util.load_vis_dataset`` and the optional-inputs chain are written against.
+
+They are called together, in order, by ``__Write The Dataset__`` inside :func:`simulate`, which
+lists the complete set of files a dataset directory holds.
+"""
 
 
 def write_dataset_fits(file_path, band_data, worst_band, worst_psf_fwhm, pixel_scale):
@@ -405,7 +456,7 @@ def write_rgb_thumbnails(dataset_path, band_images):
 
     Two consumers want them, and both degrade silently without them:
     ``util.VisualizerImaging.visualize_before_fit`` needs **both** to write the fit's
-    ``image/rgb.png`` (which ``scripts/build_inspect.py`` collects into the inspection bundle as
+    ``image/rgb.png`` (which ``scripts/tools/build_inspect.py`` collects into the inspection bundle as
     ``rgb.png``), and ``preprocess/segmentation.py`` draws ``rgb_0.png`` in the top-left panel of
     its diagnostic figure.
 
@@ -437,6 +488,19 @@ def write_rgb_thumbnails(dataset_path, band_images):
         )
 
 
+"""
+__Multiple Images__
+
+Where the source's multiple images fall in the image plane. On real data they have to be marked
+by eye, or picked out of a segmentation source-flux map, because the mass model is exactly what
+is unknown. On a simulation the mass model is known, so the images can be solved for by
+ray-tracing — the one measurement in this file that a real dataset can only approximate.
+
+They matter because every fit reads them back as a constraint on the mass model; see
+``__Positions__`` inside :func:`simulate` for what happens to the file that is written.
+"""
+
+
 def positions_from_tracer(tracer, grid, source_centre, source_flux_2d, pixel_scale):
     """
     The true multiple-image positions of the source centre.
@@ -464,6 +528,28 @@ def positions_from_tracer(tracer, grid, source_centre, source_flux_2d, pixel_sca
         pixel_scale=pixel_scale,
     )
     return al.Grid2DIrregular(values=fallback)
+
+
+"""
+__Building The Tracer__
+
+A tracer is the lens: the galaxies, their light and mass profiles, and the redshifts that order
+them into planes. Four functions build or adjust one — the two modes, and the two corrections
+applied around them:
+
+- ``tracer_from_params`` assembles the analytic lens from the ``TRUTH`` block above, at unit
+  intensity. Nothing here knows about bands; the per-band scaling happens in :func:`simulate`.
+- ``tracer_from_result`` rebuilds a lens that was *fitted*, from a finished search's
+  ``model.json`` and its maximum-log-likelihood sample. Whatever that fit inferred is what gets
+  simulated — an MGE lens light resimulates as an MGE, a Sersic fit as a Sersic — which is
+  why this script needs no model of its own for the resimulation mode.
+- ``apply_sersic_index_prior_edge_rule`` runs only on a ``--from-result`` tracer, and only on
+  the lens light: an inferred value pinned against its prior edge is an artefact of the fit
+  rather than a measurement, and simulating it would bake the artefact into the mock.
+- ``scaled_tracer_from`` runs last, once the per-band intensity scalings are known, so that the
+  model recorded in ``truth.json`` describes the pixels that were actually written rather than
+  the unit-intensity profiles they were built from.
+"""
 
 
 def tracer_from_params():
@@ -589,7 +675,7 @@ def tracer_from_result(args, output_path):
     Rebuild the tracer of a finished fit from its ``model.json`` and maximum-log-likelihood
     sample.
 
-    This is the same resolution ``scripts/diagnose_latent.py`` performs — its
+    This is the same resolution ``scripts/tools/diagnose_latent.py`` performs — its
     ``resolve_files_path`` is imported rather than reimplemented, so "the newest converged
     result" means the same thing in both scripts.
     """
@@ -618,6 +704,20 @@ def tracer_from_result(args, output_path):
     galaxies = list(instance.galaxies)
 
     return al.Tracer(galaxies=galaxies), files_path
+
+
+"""
+__Bands From A Real Dataset__
+
+A tracer says nothing about instruments; the *bands* carry the zero-point, the PSF, the noise
+level and the seeing. ``--from-params`` takes those from the ``BANDS`` table at the top of this
+file, which is the idealised mock. ``--from-result`` takes them from the dataset the fit was
+made on, which is the resimulation: same tracer, but the real PSF stamps, the real zero-points,
+the real per-band noise and the real worst-seeing band of that field.
+
+Both paths hand :func:`simulate` the same shape of dictionary, so the per-band loop below only
+ever has to ask one question — was a real PSF stamp supplied, or should a Gaussian be built?
+"""
 
 
 def band_setup_from_dataset(dataset_path, dataset_name, band_names):
@@ -666,6 +766,23 @@ def band_setup_from_dataset(dataset_path, dataset_name, band_names):
         worst_band = str(worst_band).strip().upper()
 
     return setup, worst_band, worst_psf_fwhm
+
+
+"""
+__Known Answers__
+
+The last two helpers simulate nothing. They compute what a *perfect* fit of this simulation
+would report, so that ``truth.json`` holds not just the parameters that went in but the derived
+quantities a fit is judged on.
+
+``latents_via_truth_from`` gets there by loading the written dataset back off disk exactly as a
+fitting script would and evaluating the pipeline's own latent catalogue on the truth model —
+the same code path a real fit takes, on a model with every parameter fixed. That is deliberate:
+a known answer computed by a parallel implementation would only prove the two implementations
+agree. ``aperture_lens_fluxes_from`` is the considered exception, recomputing the four aperture
+fluxes independently on the full frame so the masked latents have something to be compared
+against. ``tests/test_compute_latent_variable.py`` asserts the pipeline against both.
+"""
 
 
 def latents_via_truth_from(dataset_name, output_sample, tracer, magzero, loadable):
@@ -762,6 +879,28 @@ def simulate(args):
     """
     Build the tracer, simulate every band, write the dataset and write ``truth.json``.
     """
+
+    """
+    __Configuration and Output Paths__
+
+    Everything below builds PyAutoLens objects, so the repository's own ``config/`` is pushed
+    onto the configuration stack first — the same push every fitting script performs, and for
+    the same reason: the profile, search and analysis defaults in play must be this pipeline's,
+    not whatever configuration is otherwise active. The push also names the output root
+    (``PYAUTO_OUTPUT_DIR``, ``output/`` by default), which is where ``--from-result`` then goes
+    looking for the finished fit it has been asked to resimulate.
+
+    Where the *dataset* is written is a separate, protective decision. ``smoke_tests.txt`` runs
+    this script first of all, with the smoke profile's arguments and its default output names;
+    without a redirect every smoke run would therefore rewrite
+    ``dataset/simulated/euclid_dr1_like/``, silently replacing a committed dataset the unit
+    tests assert known answers against. So ``PYAUTO_TEST_MODE`` sends the write into the
+    gitignored output tree instead, and only ``--force-dataset-dir`` overrides that.
+
+    ``--bands`` is normalised here to a list of upper-case band names, or ``None``, which the
+    two modes read as "all four bands of the ``BANDS`` table" and "every band of the input
+    dataset" respectively.
+    """
     from autolens import conf
 
     project_root = Path(__file__).parent.parent
@@ -793,6 +932,31 @@ def simulate(args):
 
     """
     __Tracer__
+
+    The lens itself, and with it every band convention the simulation needs. The two modes
+    converge on the same three things: a ``tracer`` whose first galaxy is the lens and whose
+    last is the source (the ordering every block below relies on), a ``band_setup`` mapping each
+    band to its zero-point, PSF stamp (or ``None``, meaning "build a Gaussian"), PSF FWHM and
+    noise sigma, and the worst-seeing band that the aperture photometry is defined against.
+
+    ``--from-result`` rebuilds the tracer from the finished fit, and then reads the band
+    conventions off the dataset that fit was made on (``dataset/<sample>/<dataset>``, or
+    ``dataset/<dataset>`` when no ``--sample`` is given), so the mock inherits that field's real
+    PSF stamps and noise levels. The lens light's
+    ``sersic_index`` passes through the prior-edge rule on the way in. The worst-seeing band is
+    the one that dataset's primary header names — but if the header carries no ``WORST_BAND``,
+    or names a band that is not among the ones being written, it falls back to the widest PSF
+    of the bands actually simulated: the four aperture latents need *some* FWHM to set their
+    radii, and the widest simulated PSF is the honest choice for the data on disk. The fitted
+    intensities are then used unchanged in every band, which is a flat SED, and ``truth.json``
+    records that.
+
+    ``--from-params`` builds the analytic lens from the ``TRUTH`` block instead and takes its
+    conventions from the ``BANDS`` table, where the worst-seeing band is simply the widest of
+    the FWHMs being simulated. Here each band has its own target AB magnitude, so the mock has
+    a real colour and ``sed`` says so rather than "flat". Nothing was inferred in this mode, so
+    ``sersic_index_inferred`` stays ``None`` while ``sersic_index_simulated`` is the value that
+    went in.
     """
     sersic_index_inferred = None
     sersic_index_simulated = None
@@ -1019,6 +1183,37 @@ def simulate(args):
 
     """
     __Write The Dataset__
+
+    The simulation is now a set of arrays in memory. This block turns it into a dataset
+    *directory* — one that ``util.load_vis_dataset`` opens with no special cases, because it is
+    written to the same contract the real Euclid cut-outs arrive in. What goes in it, and who
+    reads it:
+
+    - ``<output_dataset>.fits`` — the multi-extension image file. A primary HDU carrying the
+      ``EXT_n`` extension names and the ``WORST_BAND`` / ``WORST_PSF_HDR`` / ``WORST_PSF_MER``
+      cards, then ``(<BAND>_BGSUB, <BAND>_PSF, <BAND>_RMS)`` for each band, in that order. The
+      order is the contract, not a convention: the loader assigns band ``i`` an ordinal from the
+      ``_BGSUB`` extensions in file order and then indexes its image, PSF and noise map as
+      ``3i+1``, ``3i+2`` and ``3i+3``.
+    - ``info.json`` — ``pixel_scale``, ``mask_radius`` and ``mask_centre``. The first two are
+      required by the loader; ``mask_centre`` (here the lens mass centre, in arcsec) is only its
+      fallback, because the peak of ``segmentation/lens_flux.fits`` is preferred whenever that
+      map is present, as it is for a simulation.
+    - ``mask_extra_galaxies.fits`` — all-zero, because a simulation has no neighbouring
+      galaxies or artefacts whose noise needs scaling. It is the older of the two
+      noise-scaling masks the loader accepts; the preferred
+      ``segmentation/artefact_binary.fits`` is written (also all-zero) with the segmentation
+      maps. Writing both means the dataset exercises the
+      preferred branch while still being readable by the fallback one.
+    - ``rgb_0.png`` / ``rgb_1.png`` — the colour thumbnails the fit visualiser and the
+      segmentation diagnostic draw.
+    - ``segmentation/`` — the flux and binary maps of the optional-inputs chain, built from the
+      *noise-free* reference-band images (the lens light after PSF convolution, the lensed
+      source before it). Noise-free is the point: the peak-finding and local-maxima searches
+      these maps feed then give the same answer every time.
+
+    ``positions.json`` and ``truth.json`` complete the directory and are written just below.
+    ``dataset/README.md`` describes the same layout from the reading side.
     """
     write_dataset_fits(
         file_path=dataset_path / f"{args.output_dataset}.fits",
@@ -1056,6 +1251,24 @@ def simulate(args):
 
     """
     __Positions__
+
+    The multiple images: the points in the image plane whose light rays all trace back to the
+    same point in the source plane, the source centre. ``al.PointSolver`` finds them by
+    ray-tracing the simulation grid through the tracer, so for a mock they are the exact answer;
+    if the solver returns fewer than two, the source is not multiply imaged and the local-maxima
+    search on the lensed-source map is used instead, so a ``positions.json`` is always written.
+
+    They are written out because every fit of this dataset reads them back as a constraint on
+    the mass model: ``util.load_vis_dataset`` turns the file into an ``al.PositionsLH`` with a
+    0.2" threshold and hands it to the analysis, which penalises models that fail to trace those
+    images back to within that threshold of a common source-plane point. That is what stops a
+    search wandering into a mass model which is a good fit to the light but does not multiply
+    image the source at all. The same positions are reused a few lines below, where they are
+    recorded in ``truth.json`` along with the summed magnification at them.
+
+    One caveat worth knowing: ``preprocess/segmentation.py`` rewrites ``positions.json`` from
+    the local maxima of the source-flux map, discarding the exact solution. Re-running the
+    simulator restores it — it is deterministic for a given ``--seed``.
     """
     positions = positions_from_tracer(
         tracer=tracer,
@@ -1312,6 +1525,28 @@ def model_truth_from(tracer):
         }
 
     return galaxies
+
+
+"""
+__Arguments__
+
+The simulator carries its own parser rather than sharing ``util.parse_fit_args`` with the
+fitting scripts, because nothing it takes is a fitting argument — there is no search to
+configure and no cores to spread across. Four groups:
+
+- **mode** — ``--from-params`` / ``--from-result``, mutually exclusive, the former the default;
+- **which fit to resimulate** — ``--dataset``, ``--sample``, ``--unique_tag``, ``--search``,
+  ``--result_hash``: the same result locator ``scripts/tools/diagnose_latent.py`` takes, and
+  ignored entirely in ``--from-params`` mode;
+- **where the simulation is written** — ``--output-sample``, ``--output-dataset``,
+  ``--force-dataset-dir``;
+- **what is simulated** — ``--bands``, ``--shape``, ``--pixel-scale``, ``--mask-radius``,
+  ``--seed``, plus the two prior-edge knobs that govern the resimulation rule.
+
+``--seed`` is the one to remember: it seeds the Gaussian noise and nothing else, so a re-run
+with the same seed reproduces the dataset, and changing it is how you generate a second noise
+realisation of the *same* lens.
+"""
 
 
 def parse_args():

--- a/scripts/tools/build_inspect.py
+++ b/scripts/tools/build_inspect.py
@@ -36,9 +36,9 @@ Stage 1 of ``scripts/build_inspection_bundle.sh``.
 
 Usage
 -----
-    python scripts/build_inspect.py --sample=q1_walsmley
+    python scripts/tools/build_inspect.py --sample=q1_walsmley
 
-    python scripts/build_inspect.py \
+    python scripts/tools/build_inspect.py \
         --sample=dr1_prelim_grade_ab \
         --inspect_dir=inspect/dr1_prelim_grade_ab_run250 \
         --tar_to=/scratch/dr1_prelim_grade_ab.tar
@@ -55,7 +55,7 @@ from pathlib import Path
 from typing import Optional
 
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 DEFAULT_SAMPLE = "q1_walsmley"
 

--- a/scripts/tools/diagnose_latent.py
+++ b/scripts/tools/diagnose_latent.py
@@ -37,11 +37,11 @@ Usage
 -----
 Defaults target the shipped example dataset::
 
-    python scripts/diagnose_latent.py
+    python scripts/tools/diagnose_latent.py
 
 Point it at a real run::
 
-    python scripts/diagnose_latent.py \
+    python scripts/tools/diagnose_latent.py \
         --sample=dr1_prelim_grade_ab \
         --dataset=Tile102007899RA0631694872236DECNEG0650584220817 \
         --search=vis_lp
@@ -49,7 +49,7 @@ Point it at a real run::
 Test-mode results are written under ``<output>/test_mode/``, so inspect a smoke
 run with::
 
-    python scripts/diagnose_latent.py --output_path=output/test_mode
+    python scripts/tools/diagnose_latent.py --output_path=output/test_mode
 """
 
 import argparse
@@ -59,7 +59,7 @@ import sys
 import traceback
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import util
 
@@ -184,7 +184,7 @@ def main():
 
     from autolens import conf
 
-    project_root = Path(__file__).parent.parent
+    project_root = Path(__file__).parent.parent.parent
     output_path = (
         Path(args.output_path)
         if args.output_path is not None

--- a/scripts/tools/diagnose_latent_vis_pix.py
+++ b/scripts/tools/diagnose_latent_vis_pix.py
@@ -2,7 +2,7 @@
 Euclid Pipeline: Latent Variable Diagnostic (population sweep)
 ==============================================================
 
-The population version of ``scripts/diagnose_latent.py``. Where that script
+The population version of ``scripts/tools/diagnose_latent.py``. Where that script
 interrogates one result in depth, this one sweeps the first N converged results
 of a sample and prints the latent catalogue for each, so you can tell at a
 glance whether a latent failure is *universal* (every tile — a code or config
@@ -36,7 +36,7 @@ That is a real, reproducible property of the stage rather than a latent bug, and
 it is what a universal-failure sweep looks like. For a latent readout that
 evaluates end to end, sweep the light-profile stage instead::
 
-    python scripts/diagnose_latent_vis_pix.py --search=vis_lp
+    python scripts/tools/diagnose_latent_vis_pix.py --search=vis_lp
 
 The library latents that do not depend on the source reconstruction
 (``magnification``, ``effective_einstein_radius``, the lens fluxes) are
@@ -51,15 +51,15 @@ Usage
 -----
 Defaults target the shipped example dataset's sample::
 
-    python scripts/diagnose_latent_vis_pix.py
+    python scripts/tools/diagnose_latent_vis_pix.py
 
 Sweep a real sample::
 
-    python scripts/diagnose_latent_vis_pix.py --sample=dr1_prelim_grade_ab --limit=5
+    python scripts/tools/diagnose_latent_vis_pix.py --sample=dr1_prelim_grade_ab --limit=5
 
 Inspect a test-mode smoke run::
 
-    python scripts/diagnose_latent_vis_pix.py --output_path=output/test_mode
+    python scripts/tools/diagnose_latent_vis_pix.py --output_path=output/test_mode
 """
 
 import argparse
@@ -69,7 +69,7 @@ import sys
 import traceback
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import util
 
@@ -213,7 +213,7 @@ def main():
 
     from autolens import conf
 
-    project_root = Path(__file__).parent.parent
+    project_root = Path(__file__).parent.parent.parent
     output_path = (
         Path(args.output_path)
         if args.output_path is not None

--- a/smoke_tests.txt
+++ b/smoke_tests.txt
@@ -1,6 +1,6 @@
 # Scripts run by the PyAutoHeart smoke runner, in this order, in one output
 # directory that is wiped once before the first entry. Order is load-bearing:
-# scripts/diagnose_latent.py replays the latents of a finished result, so every
+# scripts/tools/diagnose_latent.py replays the latents of a finished result, so every
 # fit it reads must already have run above it.
 # `scripts/simulator.py` first: it is the dataset producer, and under
 # PYAUTO_TEST_MODE it writes to $PYAUTO_OUTPUT_DIR/simulator/ rather than
@@ -14,4 +14,4 @@ scripts/lens_model_waveband.py
 scripts/mge_lens_only.py
 scripts/sersic_lens_model.py
 scripts/sersic_lens_model_waveband.py
-scripts/diagnose_latent.py
+scripts/tools/diagnose_latent.py

--- a/start_here.py
+++ b/start_here.py
@@ -2,35 +2,280 @@
 Euclid Pipeline: Start Here
 ===========================
 
-This is a **thin shim**. The entry point for fitting a Euclid strong lens
-dataset is ``scripts/initial_lens_model.py`` — that is the file to run, read
-and edit; the README, ``AGENTS.md`` and the HPC submit scripts all name it.
+Welcome. This file is the front door to the Euclid strong lens modeling
+pipeline, and it is written to be read from top to bottom by someone who has
+never fitted a strong lens before.
 
-``start_here.py`` is kept only so that older commands, bookmarks and scripts
-that call ``python start_here.py`` keep working unchanged. It was previously a
-diverged copy of ``scripts/initial_lens_model.py`` that had fallen behind it
-(no pixelized-source stage); collapsing it into a shim removed that drift.
+It has two jobs. The first is functional: ``python start_here.py --dataset=...``
+runs a complete automated lens model, because the code at the bottom of this
+file forwards straight into ``scripts/initial_lens_model.py``. The second is
+educational: everything between here and that code explains what the pipeline
+does, what it needs from you, what it writes out, and which concepts you need in
+order to trust the numbers it produces.
 
-**Installation:** see https://github.com/PyAutoLabs/euclid_strong_lens_modeling_pipeline
+You can stop reading at any point. If you only want results, the two sections
+"__Installation__" and "__Running The Pipeline__" are enough — the pipeline is
+designed to run as a black box, and the output it writes to ``output/`` is
+meant to be inspected without knowing how any of it was computed. If you want to
+understand the model, keep going: the later sections build up the science one
+piece at a time.
 
-**Running as a black box:** pass it the dataset name and it fits automatically.
-Results and visualisations are written to ``output/``. For small samples,
-browsing ``output/`` directly is sufficient. For large samples use the
-``workflow/`` scripts to export .csv, .fits, and .png summaries via the
-database aggregator.
+__What This Repository Is__
 
-**Questions:** contact James Nightingale on the Euclid Consortium Slack.
+This repository is a packaged, runnable version of the Euclid strong lens
+modeling pipeline. It uses **PyAutoLens** to perform automated strong lens
+modeling of Euclid VIS cut-outs — the small postage-stamp images the Euclid MER
+pipeline produces around each lens candidate.
 
-Usage
------
+Given one cut-out, the pipeline fits a model of the foreground lens galaxy's
+light, a model of its mass, and a reconstruction of the lensed background
+source. From that fit it derives the quantities strong lensing science actually
+consumes: an Einstein radius, a magnification, deblended images of the lens and
+of the lensed source, and calibrated fluxes for both.
+
+It is deliberately a *pipeline* and not a library. Every decision that a lens
+modeller would normally make by hand — where to centre the mask, how many
+Gaussians to use, when to switch from a smooth source to a pixelized one, when
+to stop sampling — is already made, tuned on Euclid Q1 and DR1 data. That is
+what makes it possible to point it at a thousand cut-outs and walk away.
+
+__What This File Is__
+
+``start_here.py`` is a **thin shim**. The real implementation lives in
+``scripts/initial_lens_model.py``, and that is the file to read when you want to
+see the model being built line by line, or to edit when you want to change it.
+The README, ``AGENTS.md`` and the HPC submit scripts all name that script.
+
+This file exists for two reasons. It keeps older commands, bookmarks and job
+scripts that call ``python start_here.py`` working unchanged, and it is the
+place where the concepts are explained once, so that the scripts themselves can
+stay close to the code and point back here.
+
+There is no duplicated fitting logic below. ``fit`` is imported from
+``scripts/initial_lens_model.py`` and re-exported, so the two entry points can
+never drift apart. (They once did: this file used to be a diverged copy that had
+fallen a whole pixelized-source stage behind. Collapsing it into a shim removed
+that failure mode permanently.)
+
+__Installation__
+
+**PyAutoLens** supports Python 3.12 and later, with Python 3.13 recommended. You
+may want a virtual environment or conda environment to install into first.
+
+::
+
+    pip install --upgrade pip
+    pip install autolens
+
+Then clone this repository and change into it:
+
+::
+
+    git clone https://github.com/PyAutoLabs/euclid_strong_lens_modeling_pipeline
+    cd euclid_strong_lens_modeling_pipeline
+
+That is the whole installation for a CPU run. `README.md
+<https://github.com/PyAutoLabs/euclid_strong_lens_modeling_pipeline>`_ has the
+full instructions, including the GPU setup described next.
+
+__JAX And GPUs__
+
+**PyAutoLens** runs significantly faster on GPUs — often **50x or more**
+compared to CPUs. That acceleration comes from
+`JAX <https://docs.jax.dev/en/latest/notebooks/thinking_in_jax.html>`_, which
+provides GPU and TPU support.
+
+Installing **PyAutoLens** installs JAX as a dependency, but the default JAX
+install may not include GPU support. If you have a GPU, install JAX with GPU
+support **first**, following the
+`JAX installation guide <https://jax.readthedocs.io/en/latest/installation.html>`_,
+and install **PyAutoLens** afterwards. If **PyAutoLens** is installed without a
+working GPU setup a warning is printed; the pipeline still runs, just on CPU.
+
+For scale: ``scripts/initial_lens_model.py`` fits a lens in around 10 minutes on
+a GPU, and around 20 minutes on an 8-core CPU. Over a sample of a few thousand
+candidates that difference decides whether the run is a coffee break or a
+cluster allocation.
+
+__Running The Pipeline__
+
+Every script in this repository is run from the repository root, and they all
+share one argument parser (``util.parse_fit_args``). The minimal command is:
+
 ::
 
     python start_here.py --dataset=<name> --sample=<sample>
 
-Every command-line argument accepted by ``scripts/initial_lens_model.py``
-(``--dataset``, ``--sample``, ``--iterations_per_quick_update``,
-``--number_of_cores``, ``--use_cpu``, ``--skip_pix``) is accepted here and
-forwarded unchanged.
+The repository ships a real Euclid Q1 cut-out, so this command works
+immediately after cloning:
+
+::
+
+    python start_here.py --sample=q1_walsmley \\
+        --dataset=102018665_NEG570040238507752998 \\
+        --iterations_per_quick_update=10000
+
+That is the example command from ``README.md``, with ``start_here.py``
+substituted for ``scripts/initial_lens_model.py``; the two are interchangeable.
+
+The arguments, all of which this file forwards unchanged:
+
+- ``--dataset`` (**required**) — the dataset subdirectory inside
+  ``dataset/<sample>/``.
+- ``--sample`` (default: none) — the sample subdirectory inside ``dataset/``.
+  Omit it for a flat ``dataset/<name>/`` layout.
+- ``--iterations_per_quick_update`` (default: ``5000``) — sampler iterations
+  between on-the-fly visualisation updates.
+- ``--number_of_cores`` (default: ``1``) — CPU cores for the non-JAX Nautilus
+  searches.
+- ``--use_cpu`` (default: off) — CPU mode: disables JAX and applies the CPU
+  sparse operator to the pixelized stage.
+- ``--skip_pix`` (default: off) — return after the light-profile fit, skipping
+  the pixelized source stage.
+
+Note what is *not* on that list: ``mask_radius``. It is not a command-line
+argument. It is always read from the dataset's ``info.json``, so that the mask
+travels with the data rather than with the command, and a re-run of the same
+dataset is always masked identically.
+
+Two environment variables change where results go. ``PYAUTO_OUTPUT_DIR`` sets
+the results directory relative to the repository root (default ``output``), and
+``PYAUTO_TEST_MODE=1`` makes every search finish almost instantly with trivial
+samples so you can check that a script runs before committing to a real fit.
+
+__Watching It Fit__
+
+The fit is not silent and it is not a black hole. Nautilus, the sampler, writes
+a "quick update" every ``--iterations_per_quick_update`` iterations: the current
+maximum-likelihood model, its parameter estimates, and a set of figures showing
+the model image, the residuals, the deblended lens and source, and the source
+reconstruction.
+
+Those figures are written into the search's ``image/`` folder while the search
+is still running. Opening that folder part-way through a fit and refreshing it
+is the intended way to watch a lens model converge. Setting
+``--iterations_per_quick_update`` higher (the example above uses ``10000``)
+makes the fit spend less time plotting and more time sampling.
+
+__The Dataset Contract__
+
+A dataset is a directory. That directory is:
+
+::
+
+    dataset/<sample>/<name>/
+        <name>.fits    # the multi-HDU cut-out
+        info.json      # pixel_scale, mask_radius, optionally mask_centre
+        ...            # everything else is optional
+
+Two files are required.
+
+``<name>.fits`` is the multi-extension cut-out: a PRIMARY header followed by a
+repeating ``(<BAND>_BGSUB, <BAND>_PSF, <BAND>_RMS)`` triplet for each band, in
+that order. The pipeline locates the VIS band by scanning the HDU names for the
+``_BGSUB`` tag, falling back to ``_FLUX`` if a dataset was stamped with the
+other convention, and derives the image, PSF and noise-map HDU indices from the
+band's position in that list. You never supply an HDU index yourself.
+
+``info.json`` supplies ``pixel_scale`` (0.1 arcsec/pixel for Euclid VIS) and
+``mask_radius``, the radius in arcsec of the circular analysis mask. It may also
+supply ``mask_centre``, used when the lens is not at the centre of the frame.
+
+The mask radius is worth dwelling on, because it does more than crop the image.
+It sets the outer extent of the Gaussians used to model the galaxy light (see
+"__Multi Gaussian Expansion__" below), so it is a modeling choice, not just a
+display choice. It is also *clamped*: if an offset lens plus a generous radius
+would push the circular mask off the edge of the cut-out, the pipeline shrinks
+it to the largest radius that still fits.
+
+``dataset/README.md`` lists every dataset this repository ships, what each one
+is, what reads it, and how to regenerate it.
+
+__Optional Inputs, And What Happens Without Them__
+
+Everything beyond those two files is optional, and every optional input degrades
+gracefully — the pipeline falls back rather than failing.
+
+- ``segmentation/lens_flux.fits`` — a map of the deblended lens light. Its peak
+  is the most reliable estimate of the lens centre, so the mask is centred
+  there. Without it the pipeline uses ``mask_centre`` from ``info.json``, and
+  without that, the centre of the frame.
+- ``segmentation/artefact_binary.fits``, or ``mask_extra_galaxies.fits`` — a
+  binary map of neighbouring galaxies and artefacts. Where it is set, the noise
+  is scaled up so those pixels stop pulling on the fit. The first is what the
+  DR1 preprocessing writes; the second is the older convention. Whichever is
+  found first is used, and a mask cut out at a different size to the image is
+  ignored rather than misapplied.
+- ``positions.json`` — the sky positions of the source's multiple images. These
+  become a likelihood penalty that rejects mass models which cannot reproduce
+  the observed image configuration, which is the single most effective guard
+  against unphysical pixelized-source solutions. Without the file, the pipeline
+  derives positions from ``segmentation/source_flux.fits`` if that map is
+  present. Without either, it fits with no positional constraint. (A file
+  holding a single position is treated as absent: one image is not a
+  multiple-image constraint.)
+- ``rgb_0`` / ``rgb_1`` thumbnails (``.png``, ``.jpg`` or ``.jpeg``) — colour
+  composites, plotted alongside the fit for visual inspection.
+
+The shipped Q1 dataset deliberately ships *none* of the segmentation inputs, and
+the shipped simulated dataset ships all of them, so between them the two
+datasets exercise both the fallback and the preferred branch of every chain
+above.
+
+__The FITS Header Contract__
+
+Two things in the FITS **primary** header are read but never written by this
+pipeline, which makes them an input contract on the cut-out generator.
+
+``WORST_BAND`` names the worst-seeing band across all MER bands. Lower-cased, it
+indexes the HDU list to find that band's PSF. ``WORST_PSF_MER``,
+``WORST_PSF_HDR`` and ``WORST_PSF`` hold that PSF's FWHM in arcsec, read in that
+order, skipping Euclid's ``-99`` "not measured" sentinel.
+
+Together they enable matched-aperture photometry: the lens image is convolved to
+the resolution of the worst band, and fluxes are measured at 1, 2, 3 and 4 times
+that band's FWHM. If ``WORST_BAND`` is missing, or names a band absent from the
+cut-out, a warning is printed and those four aperture measurements are skipped —
+the lens model itself is unaffected. If ``WORST_BAND`` is present but all three
+FWHM keys are missing, the load **raises**, on purpose: the aperture radii are
+multiples of that FWHM, so a guessed value would silently corrupt the photometry
+instead of failing loudly.
+
+The image HDU's own header supplies ``MAGZERO``, the photometric zero-point that
+converts fitted fluxes into AB magnitudes and microJansky, and the WCS that
+converts the fitted lens centre into sky coordinates.
+
+__How A Dataset Is Loaded__
+
+All of the above is done in one call, ``util.load_vis_dataset``, which every
+fitting script in this repository uses so that they all see an identically
+prepared dataset. Read that function in ``util.py`` when you want the detail;
+in order, it:
+
+1. Resolves the dataset directory, ``dataset/<sample>/<name>/``, and the FITS
+   file inside it.
+2. Maps every waveband in the multi-extension FITS to its HDU index, by the
+   ``_BGSUB`` (or ``_FLUX``) image tag.
+3. Loads the VIS image, noise-map and PSF from the HDU triplet, at the pixel
+   scale given by ``info.json``.
+4. Chooses the mask centre — segmentation lens-flux peak, else ``mask_centre``,
+   else the frame centre — and finds the brightest sub-pixel coordinate within
+   0.3 arcsec of it. That coordinate anchors the model priors.
+5. Reads the image header for ``MAGZERO`` and the celestial WCS.
+6. Applies noise scaling from the artefact or extra-galaxies mask, if present.
+7. Applies the circular analysis mask, at the ``info.json`` radius, clamped to
+   fit inside the cut-out.
+8. Applies adaptive over-sampling: 4x sub-pixels within 0.1 arcsec of the lens
+   centre, 2x out to 0.3 arcsec, 1x beyond. Over-sampling matters most where the
+   light profile changes fastest, which is the very centre.
+9. Loads the worst-seeing band's PSF and FWHM for the aperture photometry.
+10. Builds the multiple-image positions constraint, from ``positions.json`` or
+    from the segmentation source-flux map.
+
+It returns a single ``EuclidDataset`` dataclass carrying the masked,
+over-sampled dataset plus every derived quantity — centre, zero-point, WCS,
+PSF, mask radius, positions — so that a pipeline reads attributes rather than
+re-deriving values and risking an inconsistency between scripts.
 """
 
 import sys
@@ -42,6 +287,362 @@ import util
 from scripts.initial_lens_model import fit
 
 __all__ = ["fit"]
+
+
+"""
+__Multi Gaussian Expansion__
+
+Here is the first idea the pipeline is built on.
+
+A galaxy's light has to be described by some mathematical function before it can
+be fitted. The traditional choice is a Sersic profile — a smooth, elegant, two-
+or three-parameter shape. It is also a straitjacket: real galaxies have
+isophotal twists, colour gradients, boxy or discy isophotes, and a Sersic
+profile forced onto them leaves structured residuals that the mass model then
+tries to absorb.
+
+A **Multi Gaussian Expansion (MGE)** takes the opposite approach. Instead of one
+flexible shape, it uses a sum of many rigid ones: the galaxy is decomposed into
+a basis of concentric elliptical Gaussians, typically 15 to 100 of them. Their
+widths are *fixed* to a set of logarithmically spaced values running from a
+fraction of a pixel out to the mask radius, so between them they can represent
+structure at every scale the image resolves. Only their shared centre and
+elliptical components are free.
+
+This pipeline uses 40 Gaussians for the lens light — two independent sets of 20,
+each set with its own ellipticity, so the model can capture a galaxy whose
+isophotes change shape with radius — and 20 for the source.
+
+__Why The MGE Makes This Pipeline Possible__
+
+The MGE would be an absurd model if all of those Gaussians had to be sampled.
+Sixty Gaussians with a free intensity each would be a sixty-dimensional
+non-linear problem, and no sampler would find its global maximum reliably.
+
+They are not sampled. The intensity of every Gaussian enters the model
+**linearly**, and a linear problem has an exact solution. At every likelihood
+evaluation, the pipeline solves for the intensities that best fit the data by
+linear algebra — an "inversion" — given the current non-linear parameters. The
+sampler never sees them.
+
+The consequences are what the whole pipeline rests on:
+
+- **The parameter space is tiny.** The initial fit has roughly 15 non-linear
+  parameters in total: the lens light's centre and ellipticities, the mass
+  model, and the source's centre and ellipticity. Everything that would have
+  made it large is solved rather than searched.
+- **The fit is robust.** A 15-dimensional space with a well-conditioned
+  likelihood is one a nested sampler explores exhaustively, so the reported
+  maximum is very likely the global one rather than a local trap.
+- **It suits a GPU.** The expensive inner operation becomes a dense linear
+  solve, which is exactly the kind of arithmetic JAX compiles and a GPU executes
+  in bulk.
+- **It is flexible where it needs to be.** The intensities are free to take
+  whatever profile the data prefers, including profiles no Sersic index can
+  produce.
+
+For a standalone tutorial on the MGE, outside the Euclid context, see
+``scripts/imaging/features/multi_gaussian_expansion/modeling.py`` in the
+`autolens_workspace <https://github.com/PyAutoLabs/autolens_workspace>`_.
+
+__The Mass Model__
+
+Light tells you where the stars are. The lens model needs to know where the
+*mass* is, and the two are related but not identical — most of a lens galaxy's
+mass inside its Einstein radius is dark matter.
+
+The pipeline models the total mass distribution as a **Singular Isothermal
+Ellipsoid (SIE)** plus an **external shear**.
+
+The SIE is the standard workhorse of galaxy-scale strong lensing. "Isothermal"
+means its density falls as the inverse square of radius, which is what both
+stellar dynamics and lensing measurements find for elliptical galaxies over the
+radii that strong lensing probes; "singular" means it is not softened at the
+centre; "ellipsoid" means it is allowed to be flattened rather than circular. It
+has an Einstein radius, an ellipticity and a centre.
+
+The external shear is a two-parameter correction for everything *outside* the
+model: a neighbouring galaxy, the group or cluster the lens sits in, structure
+along the line of sight. Fitting a lens without shear pushes that distortion
+into the lens's own ellipticity, which biases it.
+
+For the initial fit, the mass centre is **fixed to the brightest pixel** of the
+cut-out — the same coordinate the light model is anchored to. This is a strong
+assumption, and a deliberate one. The mass centre and the source position are
+close to degenerate early in a fit, and pinning the mass to the light removes
+that degeneracy at the moment when the sampler is least equipped to resolve it.
+The assumption is relaxed later: the pixelized stage frees the centre within a
+0.1 arcsec box around it, and ``scripts/full_model.py`` frees it fully.
+
+__The Two Searches__
+
+``scripts/initial_lens_model.py`` runs two searches, in order. Each has a name,
+and those names are the folders you will find under ``output/``.
+
+**``vis_lp``** — the light-profile fit. An MGE lens light, an SIE + shear mass,
+and an MGE source, all fitted together. This is the fast, robust stage: ~15
+non-linear parameters, a mass centre fixed to the light, no pixelization to go
+wrong. Its job is not to produce the final answer but to produce a *reliable*
+one — a mass model good enough that the next stage can be trusted to start from
+it.
+
+**``vis_pix``** — the pixelized-source fit. The lens light is now fixed to the
+``vis_lp`` result, the mass centre is freed within a small box around the
+brightest pixel, and the source is replaced with a pixelized reconstruction on a
+Delaunay mesh. Because this stage starts from a converged mass model, its
+positional constraint can be tightened using the ``vis_lp`` result, which is
+what keeps the reconstruction physical.
+
+``--skip_pix`` stops after ``vis_lp`` and returns its result. That is not just a
+speed switch: ``scripts/sersic_lens_model.py`` uses it because its Sersic source
+prior is seeded from ``galaxies.source.bulge``, and the pixelized fit replaces
+that bulge with a pixelization, leaving nothing to seed from.
+
+__Pixelized Sources__
+
+The second search is where the pipeline earns its accuracy, so it is worth
+understanding the concept even if you never read its implementation.
+
+An MGE source is a sum of concentric Gaussians. That is a good description of a
+smooth, single-component galaxy and a poor one of what high-redshift sources
+usually look like: clumpy, asymmetric, multi-component star-forming systems. If
+the source model cannot represent the real source, the fit compensates by
+distorting the *mass* model — and the mass model is the thing you wanted to
+measure.
+
+A **pixelization** removes that constraint. Instead of assuming a functional
+form, the source plane is divided into pixels and the brightness of each pixel
+is solved for directly. The source is then whatever the data says it is.
+
+Two refinements make this work in practice. First, the pixels are not a regular
+grid: they form an **irregular Delaunay mesh** whose points are distributed
+according to the source's own reconstructed light, so the mesh is dense where
+the source is bright and sparse where it is faint. A regular grid would waste
+most of its pixels on empty sky and under-resolve the one clump you care about.
+Second, the solution is **regularized** — neighbouring source pixels are
+penalised for differing wildly — because an unconstrained pixel-by-pixel fit
+would happily reproduce the noise.
+
+The pixelized source is also what makes complex mass models possible at all. A
+``PowerLaw`` or a decomposed stars-plus-dark-matter model has enough freedom to
+mimic source structure; only a source free enough to absorb its own structure
+lets the mass model be measured cleanly.
+
+For the mechanics — how the mesh points are placed, how the adapt images are
+built, how the mesh edge is handled — read the ``__Source Pix__`` section of
+``scripts/initial_lens_model.py``, which is the implementation. A standalone
+tutorial lives at ``scripts/imaging/features/pixelization/delaunay.py`` in the
+autolens_workspace.
+
+__Nautilus, JAX And The CPU Fallback__
+
+Both searches are run with **Nautilus**, a nested sampling algorithm.
+
+Nested sampling is not an optimizer. It maps the whole posterior rather than
+walking downhill to one point, which is what makes it suitable for automation: it
+returns uncertainties along with the maximum, it does not need a starting guess,
+and it is far harder to trap in a local maximum than a gradient method. The cost
+is many likelihood evaluations, which is precisely why the MGE's small parameter
+space matters so much.
+
+The two searches are tuned differently, because they are doing different jobs.
+``vis_lp`` samples 750 live points with a large batch size, exploring an easy
+space thoroughly and in parallel. ``vis_pix`` samples 300, with a smaller batch,
+because each of its evaluations costs far more. Both carry a maximum-likelihood
+cap so that a pathological lens cannot run forever.
+
+By default the likelihood is evaluated through **JAX**, which just-in-time
+compiles it and dispatches it to a GPU if one is available. That is where the
+50x comes from.
+
+``--use_cpu`` turns JAX off and takes the CPU path. This is not simply "the same
+thing, slower": the pixelized stage applies a **CPU sparse operator** in place of
+the dense GPU-friendly one, because the linear algebra that is fastest dense on
+a GPU is fastest sparse on a CPU. When you pass ``--use_cpu``, pass
+``--number_of_cores`` as well — that is the argument the ``vis_pix`` search uses
+to parallelise across CPU cores.
+
+__Reading The Output__
+
+Results are written under ``output/``, in a path built from the sample, the
+dataset, the pipeline and the search:
+
+::
+
+    output/<sample>/<dataset>/initial_lens_model/vis_lp/<hash>/
+    output/<sample>/<dataset>/initial_lens_model/vis_pix/<hash>/
+
+The ``<sample>/<dataset>`` part is the path prefix, ``initial_lens_model`` is
+the pipeline's unique tag, and ``vis_lp`` / ``vis_pix`` are the search names.
+Every other pipeline in ``scripts/`` follows the same scheme with its own tag,
+so results from different pipelines on the same lens sit side by side. The
+``<hash>`` folder identifies a particular model and configuration; re-running an
+identical fit reuses it, while changing the model creates a new one. Setting
+``PYAUTO_OUTPUT_DIR`` moves the whole tree.
+
+Inside a result folder:
+
+- ``image/`` holds the on-the-fly visualisation, refreshed throughout the fit —
+  the fit subplot, the deblended lens and source, the source reconstruction, the
+  image with the multiple-image positions overlaid, and an RGB subplot built
+  from the dataset's colour thumbnails by this pipeline's custom visualiser.
+- ``files/`` holds the machine-readable results: ``model.json``,
+  ``samples_summary.json``, and ``wcs.json`` — the last written by this
+  pipeline's ``util.AnalysisImaging``, recording the fitted lens centre in sky
+  coordinates so a result can be matched back to a catalogue position.
+
+For a handful of lenses, browsing that tree directly is enough. For more than a
+handful, see "__Workflow__" below.
+
+__Latent Variables__
+
+The parameters the sampler varies are not the quantities you want to publish.
+Nobody reports an MGE ellipticity component; they report an Einstein radius, a
+magnification, a flux.
+
+Those derived quantities are **latent variables**: computed from each sample of
+the model rather than sampled directly, which means they arrive with full
+posteriors rather than a single number propagated from a best fit. This
+pipeline's ``util.AnalysisImaging`` declares the catalogue that gets computed —
+the library latents enabled in ``config/latent.yaml`` (total lens, lensed-source
+and source fluxes, both raw and in microJansky, plus the magnification and the
+effective Einstein radius) together with four Euclid-specific aperture fluxes.
+
+The aperture fluxes are the matched-aperture photometry described under "__The
+FITS Header Contract__": the model lens image, convolved to the worst-seeing
+band's resolution and summed within 1, 2, 3 and 4 times that band's PSF FWHM,
+converted through ``MAGZERO`` into microJansky. They exist so that Euclid VIS
+fluxes can be compared like-for-like against the other bands in an SED fit.
+
+``scripts/tools/diagnose_latent.py`` replays this whole catalogue on a finished result
+and prints every value, flagging NaNs and zero sentinels, without running a
+search. It is the fastest way to check that a fit produced usable science.
+
+__SLaM: Source, Light And Mass__
+
+Everything above describes the *initial* lens model, which is two searches. The
+full pipeline is five, and the idea that organises them is called **SLaM** —
+Source, (lens) Light and Mass.
+
+The reasoning is that one giant fit of the final, complex model is the worst
+possible way to get to it. A model with a ``PowerLaw`` mass, a detailed lens
+light and a pixelized source has too many parameters and too many degeneracies
+for a sampler handed nothing but priors. It will find a local maximum, and it
+will find a different one on the next lens.
+
+So the model is built in stages, each seeded from the last:
+
+- **Source first.** Complex mass models need a pixelized source, and a pixelized
+  source needs a decent mass model to be initialised safely. So the chain starts
+  by establishing a robust source using a *simple* mass model — an Isothermal
+  with shear, exactly the ``vis_lp`` fit described above — and then upgrades that
+  source to a pixelization.
+- **Light second.** Modeling the lens light accurately means deblending it from
+  the lensed source, which is only possible once the source is well described.
+  With source and mass held fixed, the light model can be refined on its own.
+- **Mass last.** The most complex mass model is fitted at the end, when the
+  source and lens light are already known and the sampler's whole budget can go
+  into the parameters that were the point of the exercise.
+
+Each stage is a small, well-conditioned search whose result narrows the priors of
+the next. That is *search chaining*, and it is why a five-search chain converges
+where a one-search fit does not.
+
+``scripts/full_model.py`` implements this chain — SOURCE LP, two pixelized SOURCE
+PIX stages, LIGHT LP, and a MASS TOTAL stage fitting a ``PowerLaw`` plus shear —
+with a prose block introducing each stage in turn. Read it for the design
+reasoning in depth. For chaining as a general technique, outside this pipeline,
+see ``scripts/guides/modeling/chaining.py`` and
+``scripts/guides/modeling/slam_start_here.py`` in the autolens_workspace.
+"""
+
+"""
+__Where To Go Next: The Fitting Pipelines__
+
+``scripts/`` holds the pipelines. All of them are run from the repository root
+and take the arguments listed above. ``scripts/README.md`` describes each in
+full; one line each:
+
+- ``scripts/initial_lens_model.py`` — **the entry point**, and what this file
+  runs. MGE lens light + SIE + shear mass + MGE source (``vis_lp``), then a
+  pixelized Delaunay source (``vis_pix``).
+- ``scripts/sersic_lens_model.py`` — Sersic lens and source fits with the mass
+  model fixed to the initial fit, giving the cleaner photometry that SED fitting
+  needs. Chains off ``initial_lens_model`` run with ``--skip_pix``.
+- ``scripts/lens_model_waveband.py`` — fits the lower-resolution NIR and EXT
+  bands with the VIS lens model held fixed.
+- ``scripts/sersic_lens_model_waveband.py`` — the **SED chain** driver, running
+  the previous three in order over every band. Give it its own
+  ``PYAUTO_OUTPUT_DIR`` so its many per-band results stay out of the main tree.
+- ``scripts/mge_lens_only.py`` — MGE subtraction of the lens light only, which
+  reveals the lensed source quickly for inspection without fitting a mass model.
+- ``scripts/full_model.py`` — the full SLaM chain described above, ending in a
+  ``PowerLaw`` + shear mass model.
+
+``scripts/simulator.py`` is the only producer of simulated data here. No fitting
+script auto-simulates a missing dataset, deliberately: most users fit real
+Euclid imaging, and a silent auto-simulate would hide a broken data path.
+
+__Where To Go Next: Workflow__
+
+Once you have fitted more than a few dozen lenses, opening ``output/`` folder by
+folder stops being a workflow. ``workflow/`` is the answer to that.
+
+Its scripts use the PyAutoFit **database aggregator** to load every result under
+``output/`` at once — querying by pipeline tag and search name, exactly the
+``initial_lens_model`` / ``vis_lp`` strings described above — and distil them
+into a few files:
+
+- ``workflow/csv_make.py`` — ``.csv`` catalogues of lens model parameters across
+  the whole sample, for scientific interpretation and for sharing.
+- ``workflow/png_make.py`` — custom ``.png`` summaries, for example every fit
+  laid out one lens per row for fast visual triage.
+- ``workflow/fits_make.py`` — ``.fits`` images of the results, such as the
+  deblended lens and lensed-source light.
+
+The aggregator can also read from a ``.sqlite`` database rather than the
+directory tree, which is worth doing once you are past a few hundred fits.
+``workflow/example/`` holds the real versions used on Euclid runs.
+
+__Where To Go Next: Catalogue__
+
+``catalogue/`` is the stage after that: it turns a directory of finished fits
+into the **inspection bundle** — one folder per lens holding the thirteen files a
+scientist needs to judge that lens — plus the master CSVs spanning the sample.
+It is the direct ancestor of the exported DR1 catalogue.
+
+Its producers live in ``catalogue/scripts/``: they generate the mass, lens-Sersic,
+source-Sersic and magnitude CSVs and the deblending FITS from the fits, and
+collect the PNGs the searches already wrote. ``scripts/build_inspection_bundle.sh``
+runs all seven stages in order for a sample. ``catalogue/README.md`` has the
+file-to-producer table, the run order, and the upstream fit each stage needs.
+
+__Further Reading__
+
+- `The PyAutoLens readthedocs <https://pyautolens.readthedocs.io/en/latest>`_ —
+  an overview of the core features, a new-user starting guide and an
+  installation guide.
+- `The autolens_workspace <https://github.com/PyAutoLabs/autolens_workspace>`_ —
+  example scripts and the HowToLens lecture notebooks. The examples cited above
+  live under ``scripts/imaging/features/`` and ``scripts/guides/modeling/``.
+- `This repository's README <https://github.com/PyAutoLabs/euclid_strong_lens_modeling_pipeline>`_
+  — installation, the argument table, the dataset requirements, the CI layout and
+  the visualization settings.
+
+__Questions__
+
+If the output your science needs is not being produced, that is treated as a gap
+in the pipeline rather than something for you to work around: contact **James
+Nightingale on the Euclid Consortium Slack** so it can be added and become a
+standard output of the Euclid strong lens modeling pipeline, and therefore of the
+data release.
+
+**PyAutoLens** also has automated pipelines for group-scale lenses, lensed point
+sources such as quasars, and double source plane lenses. They were once in this
+repository and were removed when it was narrowed to the Euclid VIS chain above;
+they still live in **PyAutoLens** itself and can be restored here on request —
+ask on Slack.
+"""
 
 
 if __name__ == "__main__":

--- a/tools/psf_size.py
+++ b/tools/psf_size.py
@@ -53,6 +53,10 @@ psf.output_to_fits(file_path=Path(dataset_path) / "psf.fits", overwrite=True)
 
 """
 __Png output__
+
+Plot the full and trimmed PSFs side by side as log10 .png images in the dataset
+folder, so the trim can be checked by eye: the trimmed kernel should retain the
+PSF core and its first ring while the clipped wings are visibly negligible.
 """
 aplt.plot_array(
     array=psf_full,

--- a/util.py
+++ b/util.py
@@ -493,6 +493,20 @@ class LatentEuclid(al.LatentLens):
         with ``psf_lowest_resolution`` and centred at its brightest pixel. The
         ``FitImaging`` is built once and shared. Returns a tuple positionally
         aligned with :meth:`keys`.
+
+        The four aperture values are **matched-aperture** photometry: the lens
+        image is convolved to the resolution of the worst-seeing band across
+        all MER bands (``psf_lowest_resolution``, selected by the dataset's
+        ``WORST_BAND`` header key) and the flux is measured inside circular
+        apertures of 1, 2, 3 and 4 times that band's PSF FWHM — hence the
+        ``total_lens_flux_{1,2,3,4}_fwhm_mujy`` keys. Matching the aperture to
+        the worst band is what makes the per-band fluxes comparable, and so
+        usable for SED fitting.
+
+        If the analysis carries no worst-band PSF (``WORST_BAND`` absent from
+        the dataset, or naming a band not in the cut-out) the four values are
+        NaN and are dropped from the written latent summary; the fit itself is
+        unaffected.
         """
         from autolens.analysis.latent import LATENT_FUNCTIONS, latent_keys_enabled
 
@@ -828,9 +842,24 @@ def load_vis_dataset(
         hdu=0,
     )
 
-    # `WORST_BAND` / `WORST_PSF_*` are stamped by the upstream Euclid cut-out
-    # generator; neither this pipeline nor PyAutoReduce writes them. When they
-    # are absent the aperture-flux latents degrade to NaN rather than crashing.
+    # `WORST_BAND` / `WORST_PSF_*` are an *input contract* on the dataset: they
+    # are stamped by the upstream Euclid cut-out generator, and neither this
+    # pipeline nor PyAutoReduce writes them.
+    #
+    # `WORST_BAND` names the worst-seeing band across all MER bands (e.g.
+    # `DES_G`); lower-cased it indexes the HDU list to find that band's PSF,
+    # which the aperture-flux latents are convolved to. The FWHM itself comes
+    # from `WORST_PSF_MER` / `WORST_PSF_HDR` / `WORST_PSF` (see
+    # `psf_fwhm_arcsec_from_primary_header`).
+    #
+    # Two degradation paths, deliberately different:
+    #
+    #  - `WORST_BAND` missing, or naming a band absent from the cut-out: warn
+    #    and skip the four aperture latents (they come out NaN). The fit itself
+    #    is unaffected.
+    #  - `WORST_BAND` present but every FWHM key missing or `-99`: raise. The
+    #    aperture radii are multiples of that FWHM, so a guessed value would
+    #    silently corrupt the photometry rather than fail.
     worst_band = header_primary.get("WORST_BAND", None)
     if worst_band is not None:
         lowest_resolution_waveband = worst_band.lower()

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -9,3 +9,8 @@ of results. For example, .png files showing the maximum likelihood model on a si
 - `png_make`: Make custom .png files showing lens modeling results or other quantities for quick result inspection.
 - `csv_make`: Make .csv catalogues of lens modeling results for scientific interpretation.
 - `fits_make`: Make .fits files of lens modeling results for scientific interpretation, for example .fits file images debelending the lens and lensed source light.
+
+The `example` folder holds these APIs applied to real Euclid runs — `example/csv/lens_mass.py` scrapes the mass model
+parameters of every "vis" fit, `example/csv/magnitudes.py` the multi-waveband magnitudes, and `example/png/mge_inspect.py`
+builds MGE inspection images. For the production versions of the same scrapes, which write the inspection bundle and its
+master CSVs, see [`catalogue/README.md`](../catalogue/README.md).

--- a/workflow/csv_make.py
+++ b/workflow/csv_make.py
@@ -21,7 +21,7 @@ __Real Examples__
 
 This example illustrates the API for outputting results to a .csv file.
 
-In the folder `workflow/examples`, we provide actual examples of how this APi is used to create .csv files
+In the folder `workflow/example`, we provide actual examples of how this APi is used to create .csv files
 that output the results of real lens modeling using the Euclid pipeline, for example a .csv with all mass
 model parameters for every lens model-fit to a "vis" dataset.
 


### PR DESCRIPTION
Closes #47.

## Summary

Phase 3a of the euclid-dr1-prep epic: restores the in-script narrative lost at 355b309 and turns `start_here.py` from a 63-line shim into the fully documented new-user end-to-end guide (24 sections, ~630 prose lines) while keeping the phase-1 code-drift fix — execution still delegates to `scripts.initial_lens_model.fit`, byte-identical code. Every recovered claim drift-verified against current code and `autolens_workspace`. Also lands the batch-review addendum: README structural edits, `scripts/tools/` move (diagnose/build-inspect scripts) with all registrations updated, AGENTS.md 471 → 251 lines.

Highlights: `initial_lens_model.py`'s empty `__Source Pix__` now documents the whole pixelized stage; `full_model.py` 10 → 26 sections (SLaM `__Design Choices__` restored); `lens_model_waveband.py` 0 → 22; `mge_lens_only.py` 0 → 27; six catalogue producers lifted from zero sections.

## Test Plan (member-reported, from the ship checkpoint on #47)

- `python -m pytest -q` → 61 passed (fast + slow); `.github/scripts/run_smoke.py` → 9/9 PASS including the moved tools path
- Prose-only proof: string-stripped ASTs identical to main except the path fixes forced by the tools move
- Drift greps zero (`Jammy2211`, `slam_pipeline`, `workflow/examples`, `Preloads`, mask_radius-as-argument); no empty `__Section__` header repo-wide

## Review context (batch 2026-08-31-pm, member euclid-3a-prose)

Opened from the parked branch at the human's request so the batch review judges a real PR with CI — merge remains the review's ruling. Note for the reviewer: the independent adversary leg was **not** run for this member (self-review only), and three judgment calls are listed in the ship-checkpoint comment on #47 (AGENTS.md scope; the `batch_size` kwarg bug filed separately; two small doc follow-ups surfaced).

- [ ] Human: plan sound in hindsight?
- [ ] Human: diff matches plan (no scope creep)?
- [ ] Human: merge, amend, or reject — then log the outcome

Generated by the PyAutoLabs agent workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qj5UN31m3FSCxzgp5jTrPj)_