### PR TITLE
CPU route: two-stage vis_lp (JAX) → vis_pix (Numba + pool) submission, GPU route documented (#49)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ environment variables and the per-script tables are in
 [`scripts/README.md`](scripts/README.md), not duplicated here. What is not there:
 
 - `util.parse_fit_args()` returns a **6-tuple**: `(sample_name, dataset_name,
-  iterations_per_quick_update, number_of_cores, use_cpu, skip_pix)`.
+  iterations_per_quick_update, number_of_cores, use_cpu, stage)`.
 - The diagnostics take their own arguments. `scripts/tools/diagnose_latent.py`
   accepts `--dataset` / `--sample` / `--output_path` / `--unique_tag` /
   `--search` / `--result_hash`; `scripts/tools/diagnose_latent_vis_pix.py` is a
@@ -186,14 +186,12 @@ overwrite the committed dataset (`--force-dataset-dir` overrides that).
 ## HPC
 
 `hpc/` holds the `batch_gpu/` / `batch_cpu/` SLURM submit scripts (with their
-`output/` and `error/` logs) and the `sync` script. Setup:
-`cp hpc/sync.conf.example hpc/sync.conf` and edit in your host and paths
-(`sync.conf` is gitignored). `hpc/sync push | pull | sync | status`: `push` sends
-the source trees plus `dataset/` with `--ignore-existing`, `pull` retrieves
-`output/`, `output_sed/` (the SED chain's tree) and `inspect/`, skipping any
-absent on the cluster. Submit from the cluster itself, e.g.
-`sbatch hpc/batch_gpu/submit_initial_lens_model`, with `PROJECT_PATH` exported to
-the remote project root.
+`output/` and `error/` logs) and the `sync` script (`push | pull | sync | status`
+plus `submit`, `push-submit`, `jobs`, `tail`, `logs`, `wait-and-pull` and more
+(`hpc/sync help`)). Route choice, the `--stage` argument, the per-stage
+environment blocks, the measured process-boundary test and the full `hpc/sync`
+verb list are in `hpc/README.md`; the three cluster `config/general.yaml` keys
+below are also repeated there.
 
 The shipped `config/` is deliberately **laptop-friendly**. Three
 `config/general.yaml` keys were different in the DR1 science runs — cluster

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ the lens model improve over time!
 ## Overview
 
 The starting point for Euclid strong lens modeling is `scripts/initial_lens_model.py`. It performs
-automated lens modeling in around 10 minutes per lens on a GPU, around 20 minutes on an 8 core CPU.
+automated lens modeling in around 10 minutes per lens on a GPU, around 20 minutes on an 8 core CPU
+(times from the DR1 science runs under their own `config/`; `hpc/README.md` has the times measured with the committed one).
 Which to use for a whole sample is a question of scale — see `hpc/README.md`.
 
 This script can be run as a black-box, with key output being generated, including:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ To ensure GPU acceleration, it is recommended that you install JAX with GPU supp
 
 If you install **PyAutoLens** without a proper GPU setup, a warning will be displayed.
 
+## Running On A Cluster
+
+`hpc/README.md` covers SLURM submission: a one-job GPU route recommended for a small
+subset of lenses, and a two-stage CPU route (`vis_lp` under JAX on CPU, then `vis_pix`
+with Numba and a process pool) for large samples on many cores, with example scripts
+under `hpc/batch_gpu/` and `hpc/batch_cpu/` and the `hpc/sync` transfer/submit tool.
+
 ## Getting Started
 
 **PyAutoLens** supports Python 3.12 and later, with **Python 3.13 recommended**.
@@ -59,6 +66,7 @@ the lens model improve over time!
 
 The starting point for Euclid strong lens modeling is `scripts/initial_lens_model.py`. It performs
 automated lens modeling in around 10 minutes per lens on a GPU, around 20 minutes on an 8 core CPU.
+Which to use for a whole sample is a question of scale — see `hpc/README.md`.
 
 This script can be run as a black-box, with key output being generated, including:
 
@@ -113,10 +121,10 @@ python scripts/full_model.py --sample=q1_walsmley --dataset=EUCLJ174517.55+65561
 | Script | What it fits | Chains off |
 |---|---|---|
 | `start_here.py` | Thin shim over `scripts/initial_lens_model.py` — kept so older commands keep working. | — |
-| `scripts/initial_lens_model.py` | **The entry point.** SIE + shear mass, MGE lens light, MGE source (`vis_lp`), then a pixelized Delaunay source (`vis_pix`). `--skip_pix` stops after `vis_lp`. | — |
+| `scripts/initial_lens_model.py` | **The entry point.** SIE + shear mass, MGE lens light, MGE source (`vis_lp`), then a pixelized Delaunay source (`vis_pix`). `--stage=vis_lp` stops after `vis_lp`. | — |
 | `scripts/sersic_lens_model.py` | Sersic lens and source with the mass model fixed, for accurate SED photometry. | `initial_lens_model` `vis_lp` |
 | `scripts/lens_model_waveband.py` | Every non-VIS band (NIR / EXT) with the VIS lens model held fixed. | `initial_lens_model` or `sersic_lens_model` |
-| `scripts/sersic_lens_model_waveband.py` | The **SED chain** driver: runs `initial_lens_model --skip_pix`, then `sersic_lens_model`, then `lens_model_waveband` over every band. Run it under its own `PYAUTO_OUTPUT_DIR`. | — (drives the three above) |
+| `scripts/sersic_lens_model_waveband.py` | The **SED chain** driver: runs `initial_lens_model --stage=vis_lp`, then `sersic_lens_model`, then `lens_model_waveband` over every band. Run it under its own `PYAUTO_OUTPUT_DIR`. | — (drives the three above) |
 | `scripts/mge_lens_only.py` | MGE subtraction of the lens light only, revealing the lensed source quickly. | — |
 | `scripts/full_model.py` | The full SLaM chain: MGE source, two Delaunay pixelized-source stages, refined lens light, then a PowerLaw + shear mass model. Uses `al.mesh.Delaunay` with `al.reg.AdaptSplit` (`reg.Adapt` cannot JIT on the Delaunay family) and `pixels=500` in its second stage — the `autolens_workspace` `delaunay.py` example uses 1000, but Euclid VIS cut-outs are small. | — |
 
@@ -147,7 +155,7 @@ All fitting pipelines share one argument parser (`util.parse_fit_args`):
 | `--iterations_per_quick_update` | `5000` | Sampler iterations between on-the-fly visualisation updates. |
 | `--number_of_cores` | `1` | CPU cores for the non-JAX Nautilus searches. |
 | `--use_cpu` | off | CPU mode: disables JAX and applies the CPU sparse operator to the pixelized stage. |
-| `--skip_pix` | off | Return after the MGE light-profile fit, skipping the pixelized source stage. Used by the Sersic chain, whose source prior cannot be seeded from a pixelization. |
+| `--stage` | all | Which stage(s) to run: all, vis_lp (MGE fit only) or vis_pix (pixelized source only; requires a completed vis_lp result and stops with an error otherwise). --skip_pix is a deprecated alias of --stage vis_lp. |
 
 `mask_radius` is **not** an argument — it is always read from the dataset's `info.json`.
 

--- a/activate.sh
+++ b/activate.sh
@@ -1,10 +1,40 @@
-BASE=/mnt/ral/jnightin/PyAuto
+# Activate the Python environment that has PyAutoLens installed.
+#
+# Most users just `pip install autolens` (see "Getting Started" in README.md) into a
+# virtual environment. By default this looks for a `.venv` created inside the project
+# edit VENV to point elsewhere, e.g. ~/venv/PyAuto.
+#
+# Resolving relative to this file (not the current directory) means it works both for a
+# local `source activate.sh` and for the HPC scripts' `source $PROJECT_PATH/activate.sh`.
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV=$HERE/.venv
 
-source $BASE/PyAuto/bin/activate
-
-export PYTHONPATH=$BASE:\
+if [ -f "$VENV/bin/activate" ]; then
+    source "$VENV/bin/activate"
+elif [ -n "${PYAUTO_HPC_BASE:-}" ] && [ -f "$PYAUTO_HPC_BASE/PyAuto/bin/activate" ]; then
+    # Shared / HPC checkout: point PYAUTO_HPC_BASE at the directory that holds a
+    # `PyAuto/` virtualenv alongside editable PyAuto* source checkouts, e.g.
+    #   export PYAUTO_HPC_BASE=/path/to/your/PyAuto
+    BASE="$PYAUTO_HPC_BASE"
+    source "$BASE/PyAuto/bin/activate"
+    export PYTHONPATH=$BASE:\
 $BASE/PyAutoNerves:\
 $BASE/PyAutoFit:\
 $BASE/PyAutoArray:\
 $BASE/PyAutoGalaxy:\
 $BASE/PyAutoLens
+else
+    echo "No local .venv found (set PYAUTO_HPC_BASE for a shared/HPC PyAuto checkout)." >&2
+fi
+
+# Developer setup only: if you run against editable source checkouts of the PyAuto*
+# libraries instead of a pip install, drop the line above and add their parent directory
+# to PYTHONPATH, e.g.:
+#
+#   SRC=~/Code/PyAutoLabs
+#   export PYTHONPATH=$SRC:\
+#   $SRC/PyAutoNerves:\
+#   $SRC/PyAutoFit:\
+#   $SRC/PyAutoArray:\
+#   $SRC/PyAutoGalaxy:\
+#   $SRC/PyAutoLens

--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -56,6 +56,10 @@
 - workflow/example/csv/magnitudes.py  # Aggregator workflow example: scrapes latent magnitudes from converged multi-band fits in `output/`; skip_latents() is True in every test mode, so no latents are written.
 - workflow/example/png/mge_inspect.py  # Aggregator workflow example: builds MGE inspection PNGs from converged fits; PYAUTO_FAST_PLOTS=1 in the smoke profile suppresses all PNG output.
 
+# --- HPC diagnostics ------------------------------------------------------
+
+- hpc/diagnostics/jax_fork_control.py  # Cluster diagnostic, not a pipeline example: it runs real Nautilus fits (a JAX leg, then a forked-pool leg, then a subprocess leg) to measure whether the CPU route's process boundary is still needed. Minutes to tens of minutes per leg, takes its own --leg/--cores/--output arguments, and is meant to be run by hand on the cluster you are about to use. hpc/README.md documents it.
+
 # --- CI runners -----------------------------------------------------------
 # The PR gate reaches these through PyAutoHeart's reusable workflow. A
 # DISCOVERY run points run_python.py at "." and rglobs, dotted directories

--- a/docs/drift_report.md
+++ b/docs/drift_report.md
@@ -44,7 +44,7 @@ fewer than two positions are found on disk. `VisualizerImaging` also picked up
 tile dumps are actually stored on disk.
 
 `parse_fit_args` now returns a 6-tuple, adding `--number_of_cores`,
-`--use_cpu` and `--skip_pix`. This is a breaking change, and every call
+`--use_cpu` and `--stage`. This is a breaking change, and every call
 site — all six scripts that unpack it — was updated in the same commit.
 
 ### The script chain
@@ -65,7 +65,7 @@ latents, the RGB visualizer and `wcs.json` from every pixelized-source fit;
 all three are now restored.
 
 The new `scripts/sersic_lens_model_waveband.py` (~56 lines, no new model
-code) chains `initial_lens_model.fit(skip_pix=True)` →
+code) chains `initial_lens_model.fit(stage="vis_lp")` →
 `sersic_lens_model.fit_sersic` → `lens_model_waveband.fit_waveband`. It is
 meant to run under a dedicated `PYAUTO_OUTPUT_DIR` so the per-band SED
 outputs don't bloat the main results tree; each upstream stage
@@ -359,3 +359,10 @@ and are worth carrying forward:
   truth with one free parameter. `latent_draw_via_pdf_size` is inert for
   `af.Drawer` — it falls back to all samples — so it is not a knob for making
   that fit cheaper; `total_draws` is.
+
+## 2026-09-02 — hpc/ two-stage route (#49)
+
+The `hpc/batch_cpu/` two-stage CPU submit scripts, the extended `hpc/sync`
+verb set and the `--stage` argument were ported from `Science/euclid/hpc/`;
+personal values (host, user, paths) were scrubbed to placeholders. `sync_jump`
+and the DR1 chunking helper were not ported.

--- a/hpc/README.md
+++ b/hpc/README.md
@@ -86,6 +86,10 @@ It is a diagnostic, never part of CI, and it writes `results.json` with one entr
 leg (start method, whether an XLA backend was initialised at the fork point, wall
 time, outcome).
 
+`hpc/batch_cpu/submit_jax_fork_control` is that command as a SLURM job -- 16 cores,
+all three legs, results under `output_diag/jax_fork_control` -- so the pooled legs are
+measured at the size a production `vis_pix` fit actually forks.
+
 ## Setting up the cluster
 
 1. **The environment.** Every submit script runs `source $PROJECT_PATH/activate.sh`.

--- a/hpc/README.md
+++ b/hpc/README.md
@@ -30,8 +30,10 @@ see out of the box. The discrepancy is open, and tracked as
 The GPU route is the simplest and, per lens, by far the fastest. The two-stage CPU route
 exists because a cluster with hundreds of CPU cores and few GPUs can fit a large sample
 faster in aggregate: the `vis_lp` MGE fit is a good fit for JAX on the CPU backend, while
-the pixelized `vis_pix` fit is fastest with the Numba sparse operator and a forked
-process pool, which JAX's sparse linear algebra does not yet match. Under JAX the
+the pixelized `vis_pix` fit, with JAX switched off, is fastest with the Numba sparse
+operator and a forked process pool across many cores. That operator is the CPU route's
+tool and is applied only under `--use_cpu`; the GPU route applies no sparse operator at
+all and fits the plain dataset with JAX's own linear algebra. Under JAX the
 `--number_of_cores` argument is ignored, because PyAutoFit routes a JAX likelihood
 to its serial path and lets JAX vectorise instead.
 

--- a/hpc/README.md
+++ b/hpc/README.md
@@ -1,0 +1,130 @@
+# Running the pipeline on a cluster
+
+This directory holds everything needed to run `scripts/initial_lens_model.py` (and the
+other fitting pipelines) under SLURM: example submission scripts for a GPU route and a
+CPU route in `batch_gpu/` and `batch_cpu/`, and the `sync` script that moves code,
+datasets, logs and results between your machine and the cluster.
+
+Read this page once to pick a route. Everything else about the fits themselves is in
+`start_here.py`; the submission scripts only decide *where* and *how* that script runs.
+
+## Which route?
+
+| Your situation | Route | Script | What one job does |
+|---|---|---|---|
+| A small subset of lenses (up to a few hundred) and a GPU node is available | **GPU** (recommended) | `batch_gpu/submit_initial_lens_model` | Both stages, `vis_lp` then `vis_pix`, in one process under JAX. About 10 minutes per lens. |
+| A large sample and many CPU cores, or no GPU | **Two-stage CPU** | `batch_cpu/submit_initial_lens_model_two_stage` | One submission; `vis_lp` under JAX on the CPU backend, then `vis_pix` with the Numba sparse operator and a process pool, as two consecutive Python processes. |
+| As above, but you want different walltime, memory or core counts per stage, or to re-run one stage alone | **Two-stage CPU, two jobs** | `batch_cpu/submit_initial_lens_model_vis_lp` then `batch_cpu/submit_initial_lens_model_vis_pix` | The same two stages as two array jobs. Submit the second once the first has finished. |
+| A cluster where JAX is unavailable or broken | **Numba only** | `batch_cpu/submit_initial_lens_model` | Both stages in one process with JAX disabled. The `vis_lp` stage is markedly slower this way. |
+
+The GPU route is the simplest and, per lens, by far the fastest. The two-stage CPU route
+exists because a cluster with hundreds of CPU cores and few GPUs can fit a large sample
+faster in aggregate: the `vis_lp` MGE fit is a good fit for JAX on the CPU backend, while
+the pixelized `vis_pix` fit is fastest with the Numba sparse operator and a forked
+process pool, which JAX's sparse linear algebra does not yet match. Under JAX the
+`--number_of_cores` argument is ignored, because PyAutoFit routes a JAX likelihood
+to its serial path and lets JAX vectorise instead.
+
+Every script fits the committed example dataset by default (`sample=q1_walsmley`,
+one entry in its `datasets` list, `--array=0-0`). To fit your own lenses, add their
+dataset directory names to the list and widen `--array` to match.
+
+## The `--stage` argument
+
+`scripts/initial_lens_model.py` takes `--stage {all,vis_lp,vis_pix}` (default `all`):
+
+- `--stage vis_lp` runs the MGE lens-light and source fit and stops.
+- `--stage vis_pix` loads the completed `vis_lp` result and runs the pixelized source
+  fit. If that result is not complete it stops immediately with an error naming the
+  missing output directory and the `--stage vis_lp` command to run first, instead of
+  silently starting `vis_lp` from scratch (which could also collide with a `vis_lp`
+  job still running on the same lens).
+- `--stage all` runs both, which is what the GPU route and the Numba-only route use.
+
+`--skip_pix` still works as a deprecated alias of `--stage vis_lp`.
+
+## Why the CPU route uses two processes
+
+The two CPU stages want different environments. `vis_lp` under JAX wants the CPU
+backend pinned (`JAX_PLATFORMS=cpu`, so it never grabs a GPU that was not allocated)
+and every linear-algebra library given the full core count, because its parallelism
+is threads. `vis_pix` wants every thread count pinned to `1`, because its parallelism
+is `--number_of_cores` pool processes and giving each worker a full set of BLAS
+threads oversubscribes the node. The scripts set these per stage; the two-job scripts
+carry one block each, and the single-submission script applies each block with `env`
+on its own command line so nothing leaks between the stages.
+
+The stages also run in separate Python processes. This is a conservative default rather
+than a measured necessity. PyAutoFit documents that a forked worker whose *likelihood*
+touches JAX deadlocks in XLA compilation (`autofit/non_linear/search/nest/nautilus/search.py`),
+and the DR1 science runs were submitted as two jobs on that basis. The `vis_pix`
+likelihood under `--use_cpu` is Numba, not JAX, so the documented case does not apply
+directly, and a control test on a laptop did not reproduce a hang:
+
+| Leg (`hpc/diagnostics/jax_fork_control.py`) | Machine | Pool | Wall | Outcome |
+|---|---|---|---|---|
+| `control`: JAX likelihood evaluated in-process, then a `use_jax=False` pooled Nautilus | WSL2, 8 logical CPUs, CPU JAX | 4 | 265 s | PASS |
+| `control_real`: the script's own `fit(stage="vis_lp")` under JAX, then `fit(stage="vis_pix", use_cpu=True)` in the same process | same | 4 | 494 s | PASS |
+| `subprocess`: JAX stage in a child of a JAX-free parent, then the pooled fit | same | 4 | 233 s | PASS |
+
+Untested there: production sampler sizes (`n_live` 750 and 300 against 50 in the
+test), multi-hour wall times, pools of 16 or more workers, and cluster cgroup limits.
+Until the same run passes on a cluster node at production scale, keep the process
+boundary. It costs nothing with the single-submission script, which already gives
+you one submission and one place in the queue. `forkserver` and `spawn` are not an
+option: PyAutoFit pins the `fork` start method because `forkserver` corrupts model
+instances (PyAutoFit#1437).
+
+To repeat the measurement on your cluster:
+
+```bash
+python hpc/diagnostics/jax_fork_control.py --leg all --cores $SLURM_CPUS_PER_TASK \
+    --output /path/to/scratch/jax_fork_control
+```
+
+It is a diagnostic, never part of CI, and it writes `results.json` with one entry per
+leg (start method, whether an XLA backend was initialised at the fork point, wall
+time, outcome).
+
+## Setting up the cluster
+
+1. **The environment.** Every submit script runs `source $PROJECT_PATH/activate.sh`.
+   That file activates a local `.venv` if one exists, otherwise a shared PyAuto
+   install named by `PYAUTO_HPC_BASE` (a directory holding a `PyAuto/` virtualenv
+   beside editable checkouts of the PyAuto libraries). Export it in your cluster
+   shell profile, or edit the default in `activate.sh`.
+2. **The project path.** Export `PROJECT_PATH` to the project's root on the cluster
+   before submitting; the scripts read it and it is the same location as
+   `$HPC_BASE/$PROJECT_NAME` in `sync.conf`.
+3. **The partition names.** The scripts use `--partition=cpu` and `--partition=gpu`.
+   Rename them to your cluster's partitions, or override on the command line:
+   `sbatch --partition=<name> hpc/batch_cpu/submit_initial_lens_model_two_stage`.
+4. **Submit from the script's directory**, or via `hpc/sync submit`. The `-o` / `-e`
+   directives are relative paths into `output/` and `error/` beside the script, and
+   SLURM will not create them for you.
+5. **Config for large runs.** The committed `config/` is laptop-friendly. Three
+   `config/general.yaml` keys were set differently for the DR1 science runs and are
+   worth changing in your cluster checkout (there is no override mechanism):
+   `output.samples_to_csv: false` (one `samples.csv` per search adds up over
+   thousands of lenses), `hpc.hpc_mode: true` (no GUI visualisation or screen
+   logging; pair it with a larger `hpc.iterations_per_quick_update`), and
+   `numba.cache: false` (Numba's on-disk cache is unreliable on NFS).
+
+## Moving things with `sync`
+
+`cp hpc/sync.conf.example hpc/sync.conf` and fill in your SSH alias, the storage
+path and the project name (`sync.conf` is gitignored). Then, from the project root:
+
+| Command | What it does |
+|---|---|
+| `hpc/sync push` / `push --no-data` | Upload code and config, with or without `dataset/`. |
+| `hpc/sync submit cpu <script>` / `submit gpu <script>` | `sbatch` one of the scripts in `batch_cpu/` or `batch_gpu/`, from its own directory. |
+| `hpc/sync push-submit cpu <script>` | Push, then submit. |
+| `hpc/sync jobs` / `sacct` / `cancel <id>` | Queue, history, cancel. |
+| `hpc/sync tail cpu` / `tail gpu` | Stream the live SLURM logs. |
+| `hpc/sync logs` | Download only the SLURM logs (fast, use mid-run). |
+| `hpc/sync pull` | Download the logs, then `output/` and the other result trees. |
+| `hpc/sync wait-and-pull [secs]` | Poll until no jobs remain, then pull. |
+| `hpc/sync status` / `check` / `du` | Dry-run transfer, connection test, remote disk usage. |
+
+`hpc/sync help` lists everything.

--- a/hpc/README.md
+++ b/hpc/README.md
@@ -12,10 +12,20 @@ Read this page once to pick a route. Everything else about the fits themselves i
 
 | Your situation | Route | Script | What one job does |
 |---|---|---|---|
-| A small subset of lenses (up to a few hundred) and a GPU node is available | **GPU** (recommended) | `batch_gpu/submit_initial_lens_model` | Both stages, `vis_lp` then `vis_pix`, in one process under JAX. About 10 minutes per lens. |
-| A large sample and many CPU cores, or no GPU | **Two-stage CPU** | `batch_cpu/submit_initial_lens_model_two_stage` | One submission; `vis_lp` under JAX on the CPU backend, then `vis_pix` with the Numba sparse operator and a process pool, as two consecutive Python processes. |
+| A small subset of lenses (up to a few hundred) and a GPU node is available | **GPU** (recommended) | `batch_gpu/submit_initial_lens_model` | Both stages, `vis_lp` then `vis_pix`, in one process under JAX. Measured on one A100 with the committed config: 74 min per lens (31 min `vis_lp`, 42 min `vis_pix`). |
+| A large sample and many CPU cores, or no GPU | **Two-stage CPU** | `batch_cpu/submit_initial_lens_model_two_stage` | One submission; `vis_lp` under JAX on the CPU backend, then `vis_pix` with the Numba sparse operator and a process pool, as two consecutive Python processes. Measured on 8 cores with the committed config: 3 h 17 min per lens (26 min `vis_lp`, 2 h 51 min `vis_pix`). |
 | As above, but you want different walltime, memory or core counts per stage, or to re-run one stage alone | **Two-stage CPU, two jobs** | `batch_cpu/submit_initial_lens_model_vis_lp` then `batch_cpu/submit_initial_lens_model_vis_pix` | The same two stages as two array jobs. Submit the second once the first has finished. |
 | A cluster where JAX is unavailable or broken | **Numba only** | `batch_cpu/submit_initial_lens_model` | Both stages in one process with JAX disabled. The `vis_lp` stage is markedly slower this way. |
+
+Both figures come from the acceptance runs recorded below, with the committed,
+laptop-friendly `config/`. The "around 10 minutes per lens" quoted in the
+repository's `README.md` and `start_here.py` is the DR1 science-run figure,
+measured under that run's own configuration (`hpc.hpc_mode: true`, a much larger
+`hpc.iterations_per_quick_update`, and its own sampler settings); it has not been
+reproduced with the committed config, and the quick-update overhead alone does
+not account for the gap. Treat the measured numbers above as the ones you will
+see out of the box. The discrepancy is open, and tracked as
+`PyAutoMind/draft/bug/euclid/gpu_per_lens_time_vs_documented_10_min.md`.
 
 The GPU route is the simplest and, per lens, by far the fastest. The two-stage CPU route
 exists because a cluster with hundreds of CPU cores and few GPUs can fit a large sample
@@ -59,21 +69,28 @@ than a measured necessity. PyAutoFit documents that a forked worker whose *likel
 touches JAX deadlocks in XLA compilation (`autofit/non_linear/search/nest/nautilus/search.py`),
 and the DR1 science runs were submitted as two jobs on that basis. The `vis_pix`
 likelihood under `--use_cpu` is Numba, not JAX, so the documented case does not apply
-directly, and a control test on a laptop did not reproduce a hang:
+directly, and a control test did not reproduce a hang on either a laptop or a
+cluster node:
 
 | Leg (`hpc/diagnostics/jax_fork_control.py`) | Machine | Pool | Wall | Outcome |
 |---|---|---|---|---|
 | `control`: JAX likelihood evaluated in-process, then a `use_jax=False` pooled Nautilus | WSL2, 8 logical CPUs, CPU JAX | 4 | 265 s | PASS |
 | `control_real`: the script's own `fit(stage="vis_lp")` under JAX, then `fit(stage="vis_pix", use_cpu=True)` in the same process | same | 4 | 494 s | PASS |
 | `subprocess`: JAX stage in a child of a JAX-free parent, then the pooled fit | same | 4 | 233 s | PASS |
+| `control` | RAL `euclid-ral-compute-1`, 16 cores | 16 | 216 s | PASS |
+| `control_real` | same | 16 | 378 s | PASS |
+| `subprocess` | same | 16 | 220 s | PASS |
 
-Untested there: production sampler sizes (`n_live` 750 and 300 against 50 in the
-test), multi-hour wall times, pools of 16 or more workers, and cluster cgroup limits.
-Until the same run passes on a cluster node at production scale, keep the process
-boundary. It costs nothing with the single-submission script, which already gives
-you one submission and one place in the queue. `forkserver` and `spawn` are not an
-option: PyAutoFit pins the `fork` start method because `forkserver` corrupts model
-instances (PyAutoFit#1437).
+The cluster rows add a 16-worker pool under real cgroup limits, which the laptop
+run could not exercise. What remains untested is production sampler size (`n_live`
+750 and 300, against 50 in the control) and multi-hour wall times: every leg above
+ran a small fit. Until a production-size run passes, keep the process boundary. It
+costs nothing with the single-submission script, which already gives you one
+submission and one place in the queue. The single-process route is filed as a
+follow-up rather than abandoned
+(`PyAutoMind/draft/feature/euclid/single_process_cpu_route_jax_vis_lp_numba_vis_pix.md`).
+`forkserver` and `spawn` are not an option: PyAutoFit pins the `fork` start method
+because `forkserver` corrupts model instances (PyAutoFit#1437).
 
 To repeat the measurement on your cluster:
 
@@ -88,7 +105,34 @@ time, outcome).
 
 `hpc/batch_cpu/submit_jax_fork_control` is that command as a SLURM job -- 16 cores,
 all three legs, results under `output_diag/jax_fork_control` -- so the pooled legs are
-measured at the size a production `vis_pix` fit actually forks.
+measured at the size a production `vis_pix` fit actually forks. The RAL rows in
+the table above came from that job (16 cores, all three legs, 13.6 min total).
+
+## Acceptance on RAL
+
+Both routes were run end to end from the scripts in this directory, on the
+committed example lens (`q1_walsmley/102018665_NEG570040238507752998`), on the
+RAL cluster on 2026-09-03:
+
+| Route | Script | Allocation | `vis_lp` | `vis_pix` | Total | Outcome |
+|---|---|---|---|---|---|---|
+| GPU | `batch_gpu/submit_initial_lens_model` | one A100 80GB PCIe, 1 core | 31.5 min | 42.5 min | 1 h 14 min | COMPLETED |
+| Two-stage CPU | `batch_cpu/submit_initial_lens_model_two_stage` | 8 cores, 8 pool workers | 25.5 min | 2 h 51 min | 3 h 17 min | COMPLETED |
+
+The CPU chain's second process logged `Fit Already Completed: skipping
+non-linear search` for `vis_lp` and went straight to `vis_pix`. That is the
+`--stage vis_pix` guard doing its job: it found the cached `vis_lp` result and
+did not re-fit it.
+
+A first GPU attempt did not get that far. The allocated A100 was in MIG mode
+with no instances configured, so `cuInit(0)` failed with
+`CUDA_ERROR_NO_DEVICE`, JAX fell back to its CPU backend, and the job ran the
+whole fit on its single allocated core -- `vis_lp` took 45 minutes and `vis_pix`
+was about 5% done when the two-hour wall killed it. `nvidia-smi` reported a
+healthy A100 throughout, and nothing in the job's own output said the GPU had
+gone. Every script in `batch_gpu/` now checks `jax.default_backend()` before it
+starts, so a GPU job whose JAX backend is CPU exits within seconds, naming the
+node, instead of burning its entire walltime.
 
 ## Setting up the cluster
 

--- a/hpc/README.md
+++ b/hpc/README.md
@@ -12,7 +12,7 @@ Read this page once to pick a route. Everything else about the fits themselves i
 
 | Your situation | Route | Script | What one job does |
 |---|---|---|---|
-| A small subset of lenses (up to a few hundred) and a GPU node is available | **GPU** (recommended) | `batch_gpu/submit_initial_lens_model` | Both stages, `vis_lp` then `vis_pix`, in one process under JAX. Measured on one A100 with the committed config: 74 min per lens (31 min `vis_lp`, 42 min `vis_pix`). |
+| A small subset of lenses (up to a few hundred) and a GPU node is available | **GPU** (recommended) | `batch_gpu/submit_initial_lens_model` | Both stages, `vis_lp` then `vis_pix`, in one process under JAX. Measured on one A100 80GB PCIe with the committed config: 1 h 14 min to 1 h 44 min per lens across two runs on two different nodes (`vis_lp` 30-38 min, `vis_pix` 42-64 min). |
 | A large sample and many CPU cores, or no GPU | **Two-stage CPU** | `batch_cpu/submit_initial_lens_model_two_stage` | One submission; `vis_lp` under JAX on the CPU backend, then `vis_pix` with the Numba sparse operator and a process pool, as two consecutive Python processes. Measured on 8 cores with the committed config: 3 h 17 min per lens (26 min `vis_lp`, 2 h 51 min `vis_pix`). |
 | As above, but you want different walltime, memory or core counts per stage, or to re-run one stage alone | **Two-stage CPU, two jobs** | `batch_cpu/submit_initial_lens_model_vis_lp` then `batch_cpu/submit_initial_lens_model_vis_pix` | The same two stages as two array jobs. Submit the second once the first has finished. |
 | A cluster where JAX is unavailable or broken | **Numba only** | `batch_cpu/submit_initial_lens_model` | Both stages in one process with JAX disabled. The `vis_lp` stage is markedly slower this way. |
@@ -24,7 +24,13 @@ measured under that run's own configuration (`hpc.hpc_mode: true`, a much larger
 `hpc.iterations_per_quick_update`, and its own sampler settings); it has not been
 reproduced with the committed config, and the quick-update overhead alone does
 not account for the gap. Treat the measured numbers above as the ones you will
-see out of the box. The discrepancy is open, and tracked as
+see out of the box.
+
+The GPU range above is node-to-node spread, not a setting you can choose. The two
+runs used different A100 nodes, and the `vis_lp` stage — whose code and iteration
+count were identical in both — was 25% slower on the second, which accounts for
+most of the difference. The discrepancy against the science figure is still open
+and tracked as
 `PyAutoMind/draft/bug/euclid/gpu_per_lens_time_vs_documented_10_min.md`.
 
 The GPU route is the simplest and, per lens, by far the fastest. The two-stage CPU route
@@ -118,8 +124,28 @@ RAL cluster on 2026-09-03:
 
 | Route | Script | Allocation | `vis_lp` | `vis_pix` | Total | Outcome |
 |---|---|---|---|---|---|---|
-| GPU | `batch_gpu/submit_initial_lens_model` | one A100 80GB PCIe, 1 core | 31.5 min | 42.5 min | 1 h 14 min | COMPLETED |
+| GPU | `batch_gpu/submit_initial_lens_model` | A100 80GB PCIe (`euclid-ral-gpu-2`), 1 core | 30.2 min | 42.4 min | 1 h 14 min | COMPLETED |
+| GPU, re-run after the sparse-operator fix | `batch_gpu/submit_initial_lens_model` | A100 80GB PCIe (`euclid-ral-gpu-1`), 1 core | 37.7 min | 63.8 min | 1 h 44 min | COMPLETED |
 | Two-stage CPU | `batch_cpu/submit_initial_lens_model_two_stage` | 8 cores, 8 pool workers | 25.5 min | 2 h 51 min | 3 h 17 min | COMPLETED |
+
+The second GPU row is the same lens re-run after `scripts/initial_lens_model.py`
+stopped applying the Numba sparse operator on the JAX path (it is the CPU route's
+tool; the science tree never applied it under JAX). It is recorded here because
+the obvious expectation — that the GPU route would get faster — is wrong, and the
+next reader should not have to re-run it to find that out:
+
+- `vis_lp` does not touch the operator in either run, and both runs took exactly
+  15 quick-update blocks, so it is a clean node-speed probe: 2.01 min per block
+  against 2.51, a **25% slower node** on the re-run.
+- `vis_pix` went from 3.26 min per block to 4.55, a factor of 1.40. Divide out the
+  1.25 node factor and about 1.12 is left — one run against one run on a shared
+  cluster, which is inside the noise.
+- The quick updates themselves are unchanged (13.8 s against 13.2 s mean).
+
+So the operator was neither the reason the GPU route is slow nor a meaningful
+speed-up on it. The fix stands as a correctness fix — the JAX path now matches the
+science tree and fits the plain dataset — and the gap to the documented ~10 min
+per lens has to come from somewhere else.
 
 The CPU chain's second process logged `Fit Already Completed: skipping
 non-linear search` for `vis_lp` and went straight to `vis_pix`. That is the
@@ -135,6 +161,15 @@ healthy A100 throughout, and nothing in the job's own output said the GPU had
 gone. Every script in `batch_gpu/` now checks `jax.default_backend()` before it
 starts, so a GPU job whose JAX backend is CPU exits within seconds, naming the
 node, instead of burning its entire walltime.
+
+That guard also trips when the Python environment was never activated, because
+then JAX is not importable at all and the check fails the same way. If it fires,
+read the `.err` file before blaming the node: `No local .venv found (set
+PYAUTO_HPC_BASE ...)` followed by `ModuleNotFoundError: No module named 'jax'`
+means `activate.sh` found nothing, not that the GPU is missing. `sbatch` does not
+carry your login shell's exports into the job unless you pass them, so submit with
+`--export=ALL,PROJECT_PATH=...,PYAUTO_HPC_BASE=...` or set both in your cluster
+shell profile.
 
 ## Setting up the cluster
 

--- a/hpc/batch_cpu/submit_initial_lens_model_two_stage
+++ b/hpc/batch_cpu/submit_initial_lens_model_two_stage
@@ -8,9 +8,15 @@
 #   consecutive `python3` invocations inside a single SLURM allocation.
 #
 # WHY TWO PROCESSES RATHER THAN ONE
-#   The `vis_pix` search is parallelised by a forked multiprocessing pool, and a
-#   forked pool cannot be used safely in a process in which JAX has already
-#   initialised. Running the two stages as separate `python3` calls preserves
+#   The `vis_pix` search is parallelised by a forked multiprocessing pool. The
+#   two stages run as separate Python processes. This is a conservative
+#   default: PyAutoFit documents an XLA deadlock for a forked worker whose
+#   likelihood touches JAX, and the DR1 science runs were submitted this way.
+#   A local control test (hpc/diagnostics/jax_fork_control.py) did not
+#   reproduce a hang for the CPU route, whose vis_pix likelihood is Numba;
+#   production sampler sizes and large pools are untested, so the boundary is
+#   kept until a cluster run passes. hpc/README.md has the measured table.
+#   Running the two stages as separate `python3` calls preserves
 #   that process boundary -- the second call starts from a clean interpreter
 #   that has never imported a JAX backend -- while still costing you only one
 #   submission and one place in the queue.

--- a/hpc/batch_cpu/submit_initial_lens_model_two_stage
+++ b/hpc/batch_cpu/submit_initial_lens_model_two_stage
@@ -1,0 +1,156 @@
+#!/bin/bash -l
+#
+# Initial lens model on CPU: both stages, one submission, two Python processes.
+#
+# WHAT THIS DOES
+#   Runs `vis_lp` (JAX pinned to the CPU backend) and then `vis_pix` (JAX
+#   disabled, Numba CPU sparse operator, Nautilus process pool) as two
+#   consecutive `python3` invocations inside a single SLURM allocation.
+#
+# WHY TWO PROCESSES RATHER THAN ONE
+#   The `vis_pix` search is parallelised by a forked multiprocessing pool, and a
+#   forked pool cannot be used safely in a process in which JAX has already
+#   initialised. Running the two stages as separate `python3` calls preserves
+#   that process boundary -- the second call starts from a clean interpreter
+#   that has never imported a JAX backend -- while still costing you only one
+#   submission and one place in the queue.
+#
+#   Each stage's environment is therefore applied with `env` on its own command
+#   line rather than `export`ed, so the JAX variables set for stage 1 cannot
+#   leak into stage 2's interpreter.
+#
+#   `set -e` below means stage 2 never starts if stage 1 failed: `--stage=vis_pix`
+#   needs the `vis_lp` result and would only fail again, more slowly.
+#
+# WHEN TO USE THE SEPARATE SCRIPTS INSTEAD
+#   `submit_initial_lens_model_vis_lp` + `submit_initial_lens_model_vis_pix` run
+#   the same two stages as two jobs. Prefer those when the stages want different
+#   walltimes, memory or CPU counts, when the queue is short enough that two
+#   smaller jobs start sooner than one long one, or when you want to re-run one
+#   stage without re-running the other.
+#
+# CPU COUNT
+#   The two stages use the allocation differently: stage 1 spends it on JAX/BLAS
+#   *threads*, stage 2 on pool *processes*. Neither scales indefinitely, and a
+#   count that is reasonable for one is reasonable for the other, so a single
+#   `--cpus-per-task` serves both -- 8 is a sensible starting point. Raising it
+#   helps stage 2 (more pool workers) more than stage 1, whose threaded speed-up
+#   flattens off first.
+
+#SBATCH -J euclid_initial_lens_model_two_stage
+#SBATCH -n 1
+#SBATCH --cpus-per-task=8
+#SBATCH -o output/output.%A_%a.out
+#SBATCH -e error/error.%A_%a.err
+#SBATCH --partition=cpu
+#SBATCH -t 36:00:00
+#SBATCH --mem=64gb
+#SBATCH --array=0-0
+#SBATCH --mail-type=END,FAIL
+#SBATCH --mail-user=your.email@institution.ac.uk
+
+# -----------------------------------------------------------------------------
+# Environment
+#
+# Set PROJECT_PATH to this project on the HPC before submitting:
+#
+#   export PROJECT_PATH=/PATH/TO/LARGE_STORAGE/YOUR_USERNAME/euclid_strong_lens_modeling_pipeline
+#   sbatch hpc/batch_cpu/submit_initial_lens_model_two_stage
+#
+# This is the same location as $HPC_BASE/$PROJECT_NAME in hpc/sync.conf.
+#
+# Nothing JAX-related and no thread counts are exported here: each stage below
+# carries its own, so the two cannot interfere.
+# -----------------------------------------------------------------------------
+source $PROJECT_PATH/activate.sh
+
+# Stop the job the moment a stage fails, rather than running the next one.
+set -e
+
+THREADS=$SLURM_CPUS_PER_TASK
+
+# -----------------------------------------------------------------------------
+# Sample
+#
+# The sample is the subdirectory inside dataset/ that contains the datasets.
+# -----------------------------------------------------------------------------
+sample=q1_walsmley
+
+# -----------------------------------------------------------------------------
+# Dataset list
+#
+# Each entry is the name of a subdirectory inside dataset/$sample/.
+# One array task is launched per entry, and each fits a different lens.
+#
+# To fit many lenses, add entries here and widen the --array directive above to
+# match: three datasets means --array=0-2.
+# -----------------------------------------------------------------------------
+datasets=(
+102018665_NEG570040238507752998
+)
+
+INDEX=$SLURM_ARRAY_TASK_ID
+dataset="${datasets[$INDEX]}"
+
+echo "=========================================="
+echo "Array task : $INDEX / ${#datasets[@]}"
+echo "Sample     : $sample"
+echo "Dataset    : $dataset"
+echo "CPUs       : $THREADS"
+date
+
+# -----------------------------------------------------------------------------
+# Stage 1 — vis_lp, JAX on the CPU backend.
+#
+# JAX_PLATFORM_NAME / JAX_PLATFORMS keep JAX off any GPU that was not allocated.
+# Every linear algebra library gets the full allocation, because this stage's
+# parallelism is threads: the search evaluates a batch of models on the device
+# rather than through a pool.
+# -----------------------------------------------------------------------------
+echo ""
+echo "---- Stage 1/2: vis_lp (JAX on CPU) ----"
+date
+
+env JAX_PLATFORM_NAME=cpu \
+    JAX_PLATFORMS=cpu \
+    OPENBLAS_NUM_THREADS=$THREADS \
+    MKL_NUM_THREADS=$THREADS \
+    OMP_NUM_THREADS=$THREADS \
+    VECLIB_MAXIMUM_THREADS=$THREADS \
+    NUMEXPR_NUM_THREADS=$THREADS \
+    NPROC=$THREADS \
+    python3 $PROJECT_PATH/scripts/initial_lens_model.py --sample=$sample --dataset=$dataset \
+        --stage=vis_lp --number_of_cores=$THREADS
+
+echo "Finished vis_lp: $dataset"
+date
+
+# -----------------------------------------------------------------------------
+# Stage 2 — vis_pix, no JAX, Numba CPU sparse operator.
+#
+# A fresh interpreter, with no JAX variables inherited from stage 1, so the
+# Nautilus pool forks from a process that never initialised a JAX backend.
+#
+# Thread counts are pinned to 1: the parallelism here is `--number_of_cores`
+# pool processes, and giving each of them a full complement of BLAS threads
+# would oversubscribe the node by a factor of $THREADS.
+# -----------------------------------------------------------------------------
+echo ""
+echo "---- Stage 2/2: vis_pix (Numba CPU sparse, no JAX) ----"
+date
+
+env OPENBLAS_NUM_THREADS=1 \
+    MKL_NUM_THREADS=1 \
+    OMP_NUM_THREADS=1 \
+    VECLIB_MAXIMUM_THREADS=1 \
+    NUMEXPR_NUM_THREADS=1 \
+    NPROC=$THREADS \
+    python3 $PROJECT_PATH/scripts/initial_lens_model.py --sample=$sample --dataset=$dataset \
+        --stage=vis_pix --use_cpu --number_of_cores=$THREADS --iterations_per_quick_update=1000
+
+echo "Finished vis_pix: $dataset"
+date
+
+echo ""
+echo "Finished both stages: $dataset"
+date

--- a/hpc/batch_cpu/submit_initial_lens_model_vis_lp
+++ b/hpc/batch_cpu/submit_initial_lens_model_vis_lp
@@ -1,33 +1,28 @@
 #!/bin/bash -l
 #
-# Initial lens model on CPU: both stages, one submission, ONE Python process,
-# no JAX anywhere.
+# Initial lens model, stage 1 of 2 on CPU: the `vis_lp` search only.
 #
 # WHAT THIS DOES
-#   Runs `vis_lp` and `vis_pix` back to back in a single `python3` call with
-#   `--use_cpu`, which disables JAX for the whole run and swaps in the Numba CPU
-#   sparse operator for the pixelized stage.
+#   Fits the light-profile source model (`vis_lp`) with JAX pinned to the CPU
+#   backend, then exits. It does NOT fit the pixelized source.
 #
-# WHEN TO USE IT
-#   When JAX is unavailable or unwanted on the cluster -- this is the one route
-#   that never imports a JAX backend -- or for a single quick fit where the
-#   simplicity of one job is worth more than the runtime.
+# WHY IT EXITS AFTER vis_lp
+#   The pixelized stage (`vis_pix`) on CPU is parallelised by a forked
+#   multiprocessing pool, and a forked pool cannot be used safely in a process
+#   in which JAX has already initialised. Ending the job here guarantees the
+#   next stage starts in a fresh Python process that has never imported a JAX
+#   backend.
 #
-# THE COST, AND WHY THE TWO-STAGE SCRIPTS EXIST
-#   One process means one environment, and the two stages want opposite ones.
-#   `vis_lp` is fastest with the allocation spent on BLAS/Numba *threads*;
-#   `vis_pix` is parallelised by a Nautilus process pool and wants those threads
-#   pinned to 1, or each of `--number_of_cores` workers spawns a full complement
-#   of threads and oversubscribes the node. The thread counts below serve
-#   `vis_lp`, so the `vis_pix` half of this job is oversubscribed by design.
+# WHAT TO SUBMIT NEXT
+#   sbatch submit_initial_lens_model_vis_pix
+#   (keep the `sample`, `datasets` and `--array` values below in step with it,
+#   so array task N fits the same lens in both jobs)
 #
-#   `submit_initial_lens_model_two_stage` (one submission) and
-#   `submit_initial_lens_model_vis_lp` + `submit_initial_lens_model_vis_pix`
-#   (two submissions) split the run into two processes, which lets each stage
-#   have the environment it wants and lets `vis_lp` use JAX on the CPU. Prefer
-#   one of those for anything beyond a handful of lenses.
+#   If you would rather send one job to the queue instead of two, use
+#   `submit_initial_lens_model_two_stage`, which runs both stages back to back
+#   in separate Python processes inside a single allocation.
 
-#SBATCH -J euclid_initial_lens_model_cpu
+#SBATCH -J euclid_initial_lens_model_vis_lp
 #SBATCH -n 1
 #SBATCH --cpus-per-task=8
 #SBATCH -o output/output.%A_%a.out
@@ -45,15 +40,14 @@
 # Set PROJECT_PATH to this project on the HPC before submitting:
 #
 #   export PROJECT_PATH=/PATH/TO/LARGE_STORAGE/YOUR_USERNAME/euclid_strong_lens_modeling_pipeline
-#   sbatch hpc/batch_cpu/submit_initial_lens_model
+#   sbatch hpc/batch_cpu/submit_initial_lens_model_vis_lp
 #
 # This is the same location as $HPC_BASE/$PROJECT_NAME in hpc/sync.conf.
 # -----------------------------------------------------------------------------
 source $PROJECT_PATH/activate.sh
 
-# `--use_cpu` already keeps JAX out of the run; these are belt and braces, so
-# that an incidental JAX import somewhere in the stack cannot reach for a GPU
-# that was not allocated to this job.
+# Force JAX onto the CPU backend, so it does not try to use a GPU that was not
+# allocated to this job.
 export JAX_PLATFORM_NAME=cpu
 export JAX_PLATFORMS=cpu
 
@@ -61,8 +55,9 @@ export JAX_PLATFORMS=cpu
 # this each library spawns one thread per physical core, and array jobs sharing
 # a node oversubscribe it badly.
 #
-# This setting favours `vis_lp`; see "THE COST" in the header for what it means
-# for the `vis_pix` half of the run.
+# Threads are the right unit of parallelism for this stage: the `vis_lp` search
+# evaluates a batch of models on the device, so its speed comes from JAX and
+# BLAS threading rather than from a process pool.
 THREADS=$SLURM_CPUS_PER_TASK
 export OPENBLAS_NUM_THREADS=$THREADS
 export MKL_NUM_THREADS=$THREADS
@@ -91,9 +86,6 @@ datasets=(
 102018665_NEG570040238507752998
 )
 
-# -----------------------------------------------------------------------------
-# Select dataset for this array task
-# -----------------------------------------------------------------------------
 INDEX=$SLURM_ARRAY_TASK_ID
 dataset="${datasets[$INDEX]}"
 
@@ -101,15 +93,15 @@ echo "=========================================="
 echo "Array task : $INDEX / ${#datasets[@]}"
 echo "Sample     : $sample"
 echo "Dataset    : $dataset"
-echo "Stage      : vis_lp + vis_pix (Numba CPU, no JAX)"
+echo "Stage      : vis_lp (JAX on CPU)"
 echo "CPUs       : $THREADS"
 date
 
-# `--use_cpu` disables JAX and swaps in the Numba CPU sparse operator for the
-# pixelized stage; `--number_of_cores` parallelises the Nautilus sampler across
-# the CPUs allocated above.
+# `--number_of_cores` is inert for this stage — the `vis_lp` search takes its
+# parallelism from the device batch, not from a pool — but it is passed anyway
+# so the two stage scripts read identically and a single edit changes both.
 python3 $PROJECT_PATH/scripts/initial_lens_model.py --sample=$sample --dataset=$dataset \
-    --use_cpu --number_of_cores=$THREADS
+    --stage=vis_lp --number_of_cores=$THREADS
 
-echo "Finished: $dataset"
+echo "Finished vis_lp: $dataset"
 date

--- a/hpc/batch_cpu/submit_initial_lens_model_vis_lp
+++ b/hpc/batch_cpu/submit_initial_lens_model_vis_lp
@@ -8,8 +8,14 @@
 #
 # WHY IT EXITS AFTER vis_lp
 #   The pixelized stage (`vis_pix`) on CPU is parallelised by a forked
-#   multiprocessing pool, and a forked pool cannot be used safely in a process
-#   in which JAX has already initialised. Ending the job here guarantees the
+#   multiprocessing pool. The two stages run as separate Python processes.
+#   This is a conservative default: PyAutoFit documents an XLA deadlock for a
+#   forked worker whose likelihood touches JAX, and the DR1 science runs were
+#   submitted this way. A local control test (hpc/diagnostics/jax_fork_control.py)
+#   did not reproduce a hang for the CPU route, whose vis_pix likelihood is
+#   Numba; production sampler sizes and large pools are untested, so the
+#   boundary is kept until a cluster run passes. hpc/README.md has the
+#   measured table. Ending the job here guarantees the
 #   next stage starts in a fresh Python process that has never imported a JAX
 #   backend.
 #

--- a/hpc/batch_cpu/submit_initial_lens_model_vis_pix
+++ b/hpc/batch_cpu/submit_initial_lens_model_vis_pix
@@ -14,9 +14,14 @@
 #   `submit_initial_lens_model_vis_lp` first and let it finish.
 #
 #   No JAX environment is exported below. That is deliberate, and is the reason
-#   this is a separate job: a forked pool cannot be used safely in a process in
-#   which JAX has already initialised, so the process boundary between the two
-#   stages is what makes the CPU route work at all.
+#   this is a separate job. The two stages run as separate Python processes.
+#   This is a conservative default: PyAutoFit documents an XLA deadlock for a
+#   forked worker whose likelihood touches JAX, and the DR1 science runs were
+#   submitted this way. A local control test (hpc/diagnostics/jax_fork_control.py)
+#   did not reproduce a hang for the CPU route, whose vis_pix likelihood is
+#   Numba; production sampler sizes and large pools are untested, so the
+#   boundary is kept until a cluster run passes. hpc/README.md has the
+#   measured table.
 
 #SBATCH -J euclid_initial_lens_model_vis_pix
 #SBATCH -n 1

--- a/hpc/batch_cpu/submit_initial_lens_model_vis_pix
+++ b/hpc/batch_cpu/submit_initial_lens_model_vis_pix
@@ -1,0 +1,99 @@
+#!/bin/bash -l
+#
+# Initial lens model, stage 2 of 2 on CPU: the `vis_pix` search only.
+#
+# WHAT THIS DOES
+#   Fits the pixelized source model (`vis_pix`) with JAX disabled entirely, so
+#   the inversion runs through the Numba CPU sparse operator and the Nautilus
+#   sampler is parallelised by a forked multiprocessing pool.
+#
+# WHAT IT REQUIRES
+#   A completed `vis_lp` result for the same sample and dataset. `--stage=vis_pix`
+#   loads that result to build its model and fails fast — before the allocation
+#   is spent — if it is not there. Submit
+#   `submit_initial_lens_model_vis_lp` first and let it finish.
+#
+#   No JAX environment is exported below. That is deliberate, and is the reason
+#   this is a separate job: a forked pool cannot be used safely in a process in
+#   which JAX has already initialised, so the process boundary between the two
+#   stages is what makes the CPU route work at all.
+
+#SBATCH -J euclid_initial_lens_model_vis_pix
+#SBATCH -n 1
+#SBATCH --cpus-per-task=8
+#SBATCH -o output/output.%A_%a.out
+#SBATCH -e error/error.%A_%a.err
+#SBATCH --partition=cpu
+#SBATCH -t 18:00:00
+#SBATCH --mem=64gb
+#SBATCH --array=0-0
+#SBATCH --mail-type=END,FAIL
+#SBATCH --mail-user=your.email@institution.ac.uk
+
+# -----------------------------------------------------------------------------
+# Environment
+#
+# Set PROJECT_PATH to this project on the HPC before submitting:
+#
+#   export PROJECT_PATH=/PATH/TO/LARGE_STORAGE/YOUR_USERNAME/euclid_strong_lens_modeling_pipeline
+#   sbatch hpc/batch_cpu/submit_initial_lens_model_vis_pix
+#
+# This is the same location as $HPC_BASE/$PROJECT_NAME in hpc/sync.conf.
+# -----------------------------------------------------------------------------
+source $PROJECT_PATH/activate.sh
+
+# Pin every linear algebra library to a SINGLE thread.
+#
+# This stage's parallelism is the Nautilus process pool: `--number_of_cores`
+# below forks one worker per allocated CPU. If each of those workers also
+# spawned one BLAS thread per core the node would be oversubscribed by a factor
+# of $THREADS, and the run gets slower as it is given more CPUs. One thread per
+# worker process is the correct pairing.
+THREADS=$SLURM_CPUS_PER_TASK
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export OMP_NUM_THREADS=1
+export VECLIB_MAXIMUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+export NPROC=$THREADS
+
+# -----------------------------------------------------------------------------
+# Sample
+#
+# The sample is the subdirectory inside dataset/ that contains the datasets.
+# Must match the vis_lp job that produced the results this stage reads.
+# -----------------------------------------------------------------------------
+sample=q1_walsmley
+
+# -----------------------------------------------------------------------------
+# Dataset list
+#
+# Each entry is the name of a subdirectory inside dataset/$sample/.
+# Keep this list, and the --array directive above, identical to the vis_lp job,
+# so array task N fits the same lens in both stages.
+# -----------------------------------------------------------------------------
+datasets=(
+102018665_NEG570040238507752998
+)
+
+INDEX=$SLURM_ARRAY_TASK_ID
+dataset="${datasets[$INDEX]}"
+
+echo "=========================================="
+echo "Array task : $INDEX / ${#datasets[@]}"
+echo "Sample     : $sample"
+echo "Dataset    : $dataset"
+echo "Stage      : vis_pix (Numba CPU sparse, no JAX)"
+echo "Pool procs : $THREADS"
+date
+
+# `--use_cpu` disables JAX and swaps in the Numba CPU sparse operator;
+# `--number_of_cores` sizes the Nautilus pool; `--iterations_per_quick_update`
+# is lowered from its default of 5000 because CPU inversions are slow enough
+# that 5000 iterations is a long wait for the first sign of progress -- 1000
+# gets an on-disk update out of a long-running job far sooner.
+python3 $PROJECT_PATH/scripts/initial_lens_model.py --sample=$sample --dataset=$dataset \
+    --stage=vis_pix --use_cpu --number_of_cores=$THREADS --iterations_per_quick_update=1000
+
+echo "Finished vis_pix: $dataset"
+date

--- a/hpc/batch_cpu/submit_jax_fork_control
+++ b/hpc/batch_cpu/submit_jax_fork_control
@@ -1,0 +1,93 @@
+#!/bin/bash -l
+#
+# Diagnostic: run the JAX-vs-forked-pool control test as a SLURM job.
+#
+# WHAT THIS DOES
+#   Runs `hpc/diagnostics/jax_fork_control.py --leg all` on a compute node, so the
+#   question hpc/README.md's "Why the CPU route uses two processes" leaves open --
+#   does a process that has initialised JAX poison a later forked Nautilus pool
+#   whose likelihood is Numba? -- is answered at cluster scale rather than on a
+#   laptop. The measured table in that section was taken on WSL2 with a pool of 4;
+#   what it does not cover is a real node: a large pool, cgroup limits, and the
+#   allocation a production `vis_pix` fit actually gets.
+#
+#   Three legs run, each in its own child process so a leg that deadlocks is killed
+#   at `--timeout` and recorded as HANG rather than hanging the driver:
+#     control       a JAX likelihood evaluated in-process, then a `use_jax=False`
+#                   pooled Nautilus fit.
+#     control_real  the pipeline's own `fit(stage="vis_lp")` under JAX, then
+#                   `fit(stage="vis_pix", use_cpu=True)` in the same process.
+#     subprocess    the two-process shape the CPU submit scripts use: the JAX stage
+#                   in a child of a JAX-free parent, then the pooled fit.
+#
+#   `results.json` and the per-leg `leg.log` under `$PROJECT_PATH/output_diag/` are
+#   the evidence. If every leg PASSes here, the process boundary in
+#   `submit_initial_lens_model_two_stage` is bookkeeping rather than necessity; if
+#   `control` or `control_real` HANGs, the boundary is load-bearing and the two-stage
+#   scripts are right to keep it.
+#
+# THIS IS A DIAGNOSTIC, NOT A FIT
+#   It runs a real but tiny Nautilus fit and answers a design question. It is never
+#   part of CI and produces no science output. Submit it once per cluster.
+#
+# ENVIRONMENT
+#   `--cores $SLURM_CPUS_PER_TASK` is the point of running this here: the pooled legs
+#   are what matter, and 16 workers is the size a production CPU `vis_pix` job would
+#   fork. Thread counts are pinned to 1 for the same reason the `vis_pix` stage pins
+#   them -- the parallelism is pool processes, and a full complement of BLAS threads
+#   in each worker would oversubscribe the node by a factor of 16. `JAX_PLATFORMS=cpu`
+#   keeps the JAX legs off any GPU, which this partition has not allocated.
+#
+#   Memory scales with `--cpus-per-task`: each forked worker holds its own copy of the
+#   dataset, roughly 2 GB per worker on the example lens (measured MaxRSS 36 GB at 16
+#   cores on RAL), so raise `--mem` with the core count.
+
+#SBATCH -J euclid_jax_fork_control
+#SBATCH -n 1
+#SBATCH --cpus-per-task=16
+#SBATCH -o output/output.%A.out
+#SBATCH -e error/error.%A.err
+#SBATCH --partition=cpu
+#SBATCH -t 04:00:00
+#SBATCH --mem=64gb
+#SBATCH --mail-type=END,FAIL
+#SBATCH --mail-user=your.email@institution.ac.uk
+
+# -----------------------------------------------------------------------------
+# Environment
+#
+# Set PROJECT_PATH to this project on the HPC before submitting:
+#
+#   export PROJECT_PATH=/PATH/TO/LARGE_STORAGE/YOUR_USERNAME/euclid_strong_lens_modeling_pipeline
+#   sbatch hpc/batch_cpu/submit_jax_fork_control
+#
+# This is the same location as $HPC_BASE/$PROJECT_NAME in hpc/sync.conf.
+# -----------------------------------------------------------------------------
+source $PROJECT_PATH/activate.sh
+
+# Keep JAX on the CPU backend: the legs that initialise JAX must not reach for a
+# GPU this job was not allocated.
+export JAX_PLATFORM_NAME=cpu
+export JAX_PLATFORMS=cpu
+
+# The pooled legs are what this test measures, so every worker gets one thread.
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export OMP_NUM_THREADS=1
+export VECLIB_MAXIMUM_THREADS=1
+export NUMEXPR_NUM_THREADS=1
+
+CORES=$SLURM_CPUS_PER_TASK
+
+echo "=========================================="
+echo "Diagnostic : jax_fork_control (--leg all)"
+echo "Cores      : $CORES"
+echo "Output     : $PROJECT_PATH/output_diag/jax_fork_control"
+date
+
+python3 $PROJECT_PATH/hpc/diagnostics/jax_fork_control.py --leg all \
+    --cores $CORES --n_like_max 2000 --timeout 3600 \
+    --output $PROJECT_PATH/output_diag/jax_fork_control
+
+echo "Finished: jax_fork_control"
+date

--- a/hpc/batch_cpu/template
+++ b/hpc/batch_cpu/template
@@ -1,4 +1,19 @@
 #!/bin/bash -l
+#
+# Starting point for a one-off CPU job: a single lens, no array, both stages in
+# one Numba-only Python process (`--use_cpu`, no JAX).
+#
+# Copy it, rename it, and change the `sample`, `dataset` and the `python3` line
+# to whichever script you want to run. For fitting more than one lens, start
+# from `submit_initial_lens_model` (array job, same single-process shape) or,
+# better, from the two-stage scripts:
+#
+#   submit_initial_lens_model_two_stage  one submission, two processes
+#   submit_initial_lens_model_vis_lp     stage 1, JAX on CPU
+#   submit_initial_lens_model_vis_pix    stage 2, Numba CPU sparse, no JAX
+#
+# which give each stage the thread/process environment it actually wants. See
+# the header of `submit_initial_lens_model` for why one process cannot.
 
 #SBATCH -J euclid_cpu
 #SBATCH -n 1
@@ -9,21 +24,29 @@
 #SBATCH -t 18:00:00
 #SBATCH --mem=64gb
 #SBATCH --mail-type=END,FAIL
-#SBATCH --mail-user=james.w.nightingale@durham.ac.uk
+#SBATCH --mail-user=your.email@institution.ac.uk
 
-# -------------------------------
+# -----------------------------------------------------------------------------
 # Environment
 #
-# Set PROJECT_PATH before submitting:
-#   export PROJECT_PATH=/path/to/your/project
-# -------------------------------
+# Set PROJECT_PATH to this project on the HPC before submitting:
+#
+#   export PROJECT_PATH=/PATH/TO/LARGE_STORAGE/YOUR_USERNAME/euclid_strong_lens_modeling_pipeline
+#   sbatch hpc/batch_cpu/template
+#
+# This is the same location as $HPC_BASE/$PROJECT_NAME in hpc/sync.conf.
+# -----------------------------------------------------------------------------
 source $PROJECT_PATH/activate.sh
 
-# Force JAX to use CPU only (no GPU)
+# `--use_cpu` already keeps JAX out of the run; these are belt and braces, so
+# that an incidental JAX import somewhere in the stack cannot reach for a GPU
+# that was not allocated to this job.
 export JAX_PLATFORM_NAME=cpu
 export JAX_PLATFORMS=cpu
 
-# Pin thread counts to the allocated CPUs
+# Pin every linear algebra library to the CPUs SLURM actually allocated. Without
+# this each library spawns one thread per physical core, and jobs sharing a node
+# oversubscribe it badly.
 THREADS=$SLURM_CPUS_PER_TASK
 export OPENBLAS_NUM_THREADS=$THREADS
 export MKL_NUM_THREADS=$THREADS
@@ -32,18 +55,18 @@ export VECLIB_MAXIMUM_THREADS=$THREADS
 export NUMEXPR_NUM_THREADS=$THREADS
 export NPROC=$THREADS
 
-# -------------------------------
+# -----------------------------------------------------------------------------
 # Sample and Dataset
 #
 # Set sample to the subdirectory inside dataset/ and dataset to the specific lens.
-# For one-off single runs; use submit_initial_lens_model for array jobs.
-# -------------------------------
+# -----------------------------------------------------------------------------
 sample=q1_walsmley
 dataset=102018665_NEG570040238507752998
 
 echo "=========================================="
-echo "Sample: $sample"
-echo "Dataset: $dataset"
+echo "Sample  : $sample"
+echo "Dataset : $dataset"
+echo "CPUs    : $THREADS"
 date
 
 python3 $PROJECT_PATH/scripts/initial_lens_model.py --sample=$sample --dataset=$dataset \

--- a/hpc/batch_gpu/submit_full_model
+++ b/hpc/batch_gpu/submit_full_model
@@ -37,6 +37,16 @@ echo "Dataset: $dataset"
 date
 nvidia-smi
 
+# Fail fast if JAX cannot actually see the allocated GPU. A GPU job that falls back to
+# the CPU backend is worse than one that dies: it looks alive, runs the fit on
+# `--cpus-per-task` cores, and burns the whole walltime. Measured on a MIG-mode A100
+# with no instances, where `cuInit(0)` fails with CUDA_ERROR_NO_DEVICE and JAX logs
+# "Falling back to cpu" -- a two-hour job that never touched the device.
+python3 -c 'import jax; b = jax.default_backend(); print(f"JAX backend: {b}"); raise SystemExit(0 if b == "gpu" else 1)' || {
+    echo "ERROR: JAX cannot see a GPU on $(hostname) (MIG-mode or missing CUDA); refusing to run a GPU job on the CPU. Resubmit with --exclude=<node> or check the nvidia-smi output above." >&2
+    exit 1
+}
+
 python3 $PROJECT_PATH/scripts/full_model.py --sample=$sample --dataset=$dataset
 
 echo "Finished: $dataset"

--- a/hpc/batch_gpu/submit_initial_lens_model
+++ b/hpc/batch_gpu/submit_initial_lens_model
@@ -10,6 +10,12 @@
 #   run on the device, so no process pool is involved and no process boundary
 #   between the stages is needed. One job per lens, and that is the whole story.
 #
+# MEASURED WALLTIME
+#   One lens of the committed example sample took 1 h 14 min end to end on an
+#   A100 80GB PCIe with the committed `config/` -- 31 min for `vis_lp`, 42 min
+#   for `vis_pix`. The 4 hour default below leaves headroom for a slower lens
+#   or a busier node; hpc/README.md has the full acceptance table.
+#
 # WHEN TO USE THE CPU SCRIPTS INSTEAD
 #   When no GPU partition is available to you, or when the GPU queue is long
 #   enough that CPU nodes get you results sooner. `hpc/batch_cpu/` holds those
@@ -23,7 +29,7 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=32gb
-#SBATCH --time=02:00:00
+#SBATCH --time=04:00:00
 #SBATCH --array=0-0
 #SBATCH -o output/output.%A_%a.out
 #SBATCH -e error/error.%A_%a.err

--- a/hpc/batch_gpu/submit_initial_lens_model
+++ b/hpc/batch_gpu/submit_initial_lens_model
@@ -1,4 +1,21 @@
 #!/bin/bash -l
+#
+# Initial lens model on GPU: both stages, one submission, one Python process.
+#
+# THIS IS THE RECOMMENDED ROUTE for fitting a small subset of lenses.
+#
+# WHAT THIS DOES
+#   Runs `vis_lp` and `vis_pix` end to end in a single `python3` call with JAX
+#   on the allocated GPU. Both stages -- including the pixelized inversion --
+#   run on the device, so no process pool is involved and no process boundary
+#   between the stages is needed. One job per lens, and that is the whole story.
+#
+# WHEN TO USE THE CPU SCRIPTS INSTEAD
+#   When no GPU partition is available to you, or when the GPU queue is long
+#   enough that CPU nodes get you results sooner. `hpc/batch_cpu/` holds those
+#   routes; start from `submit_initial_lens_model_two_stage`, and read its
+#   header for why the CPU path has to split the two stages across two
+#   processes and this one does not.
 
 #SBATCH -J euclid_initial_lens_model
 #SBATCH --partition=gpu

--- a/hpc/batch_gpu/submit_initial_lens_model
+++ b/hpc/batch_gpu/submit_initial_lens_model
@@ -12,9 +12,11 @@
 #
 # MEASURED WALLTIME
 #   One lens of the committed example sample took 1 h 14 min end to end on an
-#   A100 80GB PCIe with the committed `config/` -- 31 min for `vis_lp`, 42 min
-#   for `vis_pix`. The 4 hour default below leaves headroom for a slower lens
-#   or a busier node; hpc/README.md has the full acceptance table.
+#   A100 80GB PCIe with the committed `config/`, and 1 h 44 min for the same lens
+#   on a different A100 node -- most of that spread is the node, measured on the
+#   `vis_lp` stage, which was identical in both runs. The 4 hour default below
+#   leaves headroom for a slower lens or a busier node; hpc/README.md has the full
+#   acceptance table.
 #
 # WHEN TO USE THE CPU SCRIPTS INSTEAD
 #   When no GPU partition is available to you, or when the GPU queue is long

--- a/hpc/batch_gpu/submit_initial_lens_model
+++ b/hpc/batch_gpu/submit_initial_lens_model
@@ -59,6 +59,16 @@ echo "Dataset: $dataset"
 date
 nvidia-smi
 
+# Fail fast if JAX cannot actually see the allocated GPU. A GPU job that falls back to
+# the CPU backend is worse than one that dies: it looks alive, runs the fit on
+# `--cpus-per-task` cores, and burns the whole walltime. Measured on a MIG-mode A100
+# with no instances, where `cuInit(0)` fails with CUDA_ERROR_NO_DEVICE and JAX logs
+# "Falling back to cpu" -- a two-hour job that never touched the device.
+python3 -c 'import jax; b = jax.default_backend(); print(f"JAX backend: {b}"); raise SystemExit(0 if b == "gpu" else 1)' || {
+    echo "ERROR: JAX cannot see a GPU on $(hostname) (MIG-mode or missing CUDA); refusing to run a GPU job on the CPU. Resubmit with --exclude=<node> or check the nvidia-smi output above." >&2
+    exit 1
+}
+
 # -------------------------------
 # Run the initial lens model.
 #

--- a/hpc/batch_gpu/submit_sersic_waveband
+++ b/hpc/batch_gpu/submit_sersic_waveband
@@ -55,7 +55,7 @@ date
 nvidia-smi
 
 # -------------------------------
-# Run the SED chain: vis_lp (skip_pix) -> Sersic VIS -> every other waveband.
+# Run the SED chain: vis_lp (--stage=vis_lp) -> Sersic VIS -> every other waveband.
 # -------------------------------
 python3 $PROJECT_PATH/scripts/sersic_lens_model_waveband.py --sample=$sample --dataset=$dataset
 

--- a/hpc/batch_gpu/submit_sersic_waveband
+++ b/hpc/batch_gpu/submit_sersic_waveband
@@ -54,6 +54,16 @@ echo "Output dir: $PYAUTO_OUTPUT_DIR"
 date
 nvidia-smi
 
+# Fail fast if JAX cannot actually see the allocated GPU. A GPU job that falls back to
+# the CPU backend is worse than one that dies: it looks alive, runs the fit on
+# `--cpus-per-task` cores, and burns the whole walltime. Measured on a MIG-mode A100
+# with no instances, where `cuInit(0)` fails with CUDA_ERROR_NO_DEVICE and JAX logs
+# "Falling back to cpu" -- a two-hour job that never touched the device.
+python3 -c 'import jax; b = jax.default_backend(); print(f"JAX backend: {b}"); raise SystemExit(0 if b == "gpu" else 1)' || {
+    echo "ERROR: JAX cannot see a GPU on $(hostname) (MIG-mode or missing CUDA); refusing to run a GPU job on the CPU. Resubmit with --exclude=<node> or check the nvidia-smi output above." >&2
+    exit 1
+}
+
 # -------------------------------
 # Run the SED chain: vis_lp (--stage=vis_lp) -> Sersic VIS -> every other waveband.
 # -------------------------------

--- a/hpc/diagnostics/jax_fork_control.py
+++ b/hpc/diagnostics/jax_fork_control.py
@@ -1,0 +1,904 @@
+"""
+Diagnostic: does a JAX-initialised process poison PyAutoFit's forked pool?
+=========================================================================
+
+The CPU route of ``scripts/initial_lens_model.py`` runs its two searches in two
+separate processes rather than one, and this script is the control test that
+measures why. Both stages live in one script — ``vis_lp`` builds its analysis
+with ``use_jax=True`` and ``vis_pix`` builds a second analysis with
+``use_jax=False`` and hands it to a multiprocessing ``Nautilus`` pool — so if
+one process could do both, the two-process split would be unnecessary
+bookkeeping. PyAutoFit builds every pool with the ``fork`` start method
+(``autofit/non_linear/parallel/context.py::fork_context``, pinned because
+``forkserver`` corrupts model instances, PyAutoFit#1437) and documents at
+``autofit/non_linear/search/nest/nautilus/search.py`` L370-380 that a forked
+child of a JAX-initialised parent "deadlocks in XLA compilation when the
+likelihood touches JAX"; the same file at L240 routes any analysis with
+``analysis._use_jax`` to the serial ``fit_x1_cpu`` path, so a JAX analysis never
+reaches a pool at all. What is *not* documented is the case the pipeline
+actually hits: a parent that initialised JAX for an earlier, finished stage,
+then forks a pool whose likelihood is pure numpy/numba. This script measures
+exactly that, by running two legs and reporting PASS / HANG / ERROR for each:
+
+  control       one process: evaluate a ``vis_lp``-style ``use_jax=True``
+                likelihood (which initialises XLA in-process), then run a
+                ``vis_pix``-style ``use_jax=False`` pooled Nautilus fit.
+  control_real  the same in one process, but driving the pipeline's own
+                ``scripts/initial_lens_model.py::fit`` — ``stage="vis_lp"``
+                with ``use_cpu=False``, then ``stage="vis_pix"`` with
+                ``use_cpu=True`` — so the measured path is the caller's real
+                invocation and the pixelized stage consumes the actual
+                JAX-produced ``vis_lp`` result.
+  subprocess    the pipeline's proposed fix: the JAX stage runs in a child
+                process launched by ``subprocess.run``, so the parent never
+                imports JAX, and the parent then runs the same pooled fit.
+
+``forkserver`` / ``spawn`` are deliberately NOT measured as a fix: PyAutoFit
+pins ``fork`` for correctness (PyAutoFit#1437, cited above), so switching the
+start method is not an option this pipeline may take, and a leg that measured
+it would answer a question nobody can act on.
+
+Run it (from the project root, on any machine with the example dataset)::
+
+    python hpc/diagnostics/jax_fork_control.py --leg all \
+        --output /tmp/jax_fork_control
+
+    python hpc/diagnostics/jax_fork_control.py --leg control --cores 4 \
+        --n_like_max 300 --timeout 600
+
+Each leg runs in its own child process launched by this script's driver, so a
+leg that deadlocks is killed at ``--timeout`` and recorded as HANG instead of
+hanging the driver. Per-leg wall time, outcome and environment (start method,
+cores, whether ``jax`` is in ``sys.modules``, the JAX backend platform, Python
+and library versions) are printed to stdout and written to
+``<output>/results.json``.
+
+This is a diagnostic, never part of CI. It runs a real (if tiny) Nautilus fit,
+takes minutes, and one of its two legs is *expected* to hang — none of which
+belongs in an automated test suite. Its output is evidence for a design
+decision, not a pass/fail gate.
+
+**Questions:** contact James Nightingale on the Euclid Consortium Slack.
+"""
+
+import argparse
+import json
+import multiprocessing
+import os
+import signal
+import subprocess
+import sys
+import time
+import traceback
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_SAMPLE = "q1_walsmley"
+DEFAULT_DATASET = "102018665_NEG570040238507752998"
+
+# Sampler settings deliberately far below the pipeline's own. The question is
+# whether the pool starts and keeps running, not what the posterior looks like,
+# so every leg is sized to finish in minutes when it does not deadlock.
+N_LIVE = 50
+N_BATCH = 8
+HILBERT_PIXELS = 200
+EDGE_PIXELS_TOTAL = 30
+
+
+# ---------------------------------------------------------------------------
+# Environment metadata
+# ---------------------------------------------------------------------------
+
+
+def jax_state() -> dict:
+    """
+    Whether JAX is imported, and whether it has actually *initialised* a
+    backend — measured without initialising one.
+
+    These are two different things, and the difference is the whole
+    measurement. ``import jax`` is cheap and inert; it is
+    ``jax._src.xla_bridge`` handing out a backend (the first compiled call)
+    that spins up XLA and its threads, and that is the state a fork is said to
+    be unsafe from. ``jax.default_backend()`` cannot be used to ask, because
+    asking initialises the default backend — so the private ``_backends``
+    registry is read directly instead, and an empty registry means nothing has
+    been initialised. If a future JAX moves that registry the value comes back
+    as ``"unknown"`` rather than a wrong answer.
+    """
+    state = {
+        "jax_in_sys_modules": "jax" in sys.modules,
+        "jax_backends_initialised": None,
+    }
+
+    if "jax" in sys.modules:
+        try:
+            from jax._src import xla_bridge
+
+            state["jax_backends_initialised"] = sorted(xla_bridge._backends.keys())
+        except Exception:  # pragma: no cover - diagnostic only
+            state["jax_backends_initialised"] = "unknown"
+
+    return state
+
+
+def env_dict(cores: int, output_path: Path = None, extra: dict = None) -> dict:
+    """
+    The facts each leg records about the process it ran in.
+
+    ``jax_backends_initialised`` is the load-bearing one: it says whether the
+    process that is about to fork has XLA running inside it (see
+    :func:`jax_state`).
+    """
+    info = {
+        "python": sys.version.split()[0],
+        "start_method": multiprocessing.get_start_method(),
+        "cores": cores,
+        "autofit_version": None,
+        "autolens_version": None,
+        "PYAUTO_DISABLE_JAX": os.environ.get("PYAUTO_DISABLE_JAX"),
+        "PYAUTO_TEST_MODE": os.environ.get("PYAUTO_TEST_MODE"),
+        "JAX_PLATFORMS": os.environ.get("JAX_PLATFORMS"),
+    }
+    info.update(jax_state())
+
+    for name in ("autofit", "autolens"):
+        module = sys.modules.get(name)
+        if module is not None:
+            info[f"{name}_version"] = getattr(module, "__version__", None)
+        else:
+            # Read the metadata rather than importing: the `subprocess` leg
+            # records its environment before it has imported anything, and an
+            # import here would change the very process being measured.
+            try:
+                from importlib.metadata import version
+
+                info[f"{name}_version"] = version(name)
+            except Exception:
+                info[f"{name}_version"] = None
+
+    if extra is not None:
+        info.update(extra)
+
+    # Written at the fork point rather than at the end of the leg, so that a
+    # leg which never returns still leaves its environment on disk for the
+    # driver to fold into results.json.
+    if output_path is not None:
+        (output_path / "leg.json").write_text(json.dumps(info, indent=2))
+
+    return info
+
+
+def import_autolens_pulls_jax() -> bool:
+    """
+    Import ``autolens`` and report whether that alone put ``jax`` into
+    ``sys.modules``.
+
+    This is the fact the two-process split stands or falls on. If merely
+    importing the library initialised JAX, then *every* pipeline process would
+    be a JAX process and no arrangement of stages could give the pool a clean
+    parent — the fix would have to be a different start method, which
+    PyAutoFit#1437 rules out. Both legs record it.
+    """
+    import autolens  # noqa: F401
+
+    return "jax" in sys.modules
+
+
+# ---------------------------------------------------------------------------
+# The two stages, built to mirror scripts/initial_lens_model.py
+# ---------------------------------------------------------------------------
+
+
+def _push_config(output_path: Path):
+    """
+    Point the config at the project's own ``config/`` and the results at
+    ``output_path``, exactly as ``scripts/initial_lens_model.py`` does — except
+    that the output path is always given explicitly, so a diagnostic run can
+    never write into the project's real ``output/`` tree.
+    """
+    from autolens import conf
+
+    conf.instance.push(new_path=PROJECT_ROOT / "config", output_path=output_path)
+
+
+def _load(dataset: str, sample: str):
+    sys.path.insert(0, str(PROJECT_ROOT))
+    import util
+
+    return util, util.load_vis_dataset(dataset, sample_name=sample)
+
+
+def jax_stage(dataset: str, sample: str, output_path: Path) -> float:
+    """
+    The ``vis_lp`` stage, reduced to the one thing that matters here: build the
+    MGE-lens-light + SIE-mass + MGE-source analysis with ``use_jax=True`` and
+    evaluate its likelihood once. That single call traces and compiles the
+    likelihood, so XLA is initialised in this process when it returns.
+
+    The model mirrors ``scripts/initial_lens_model.py`` ``fit`` (L128-L228): 2
+    bases of 20 Gaussians for the lens light, an ``Isothermal`` with its centre
+    fixed to the brightest pixel plus ``ExternalShear``, and 20 Gaussians for
+    the source. No search is run — the sampler is not what is being measured.
+    """
+    _push_config(output_path)
+
+    import autofit as af
+    import autolens as al
+
+    util, d = _load(dataset, sample)
+
+    lens_bulge = al.model_util.mge_model_from(
+        mask_radius=d.mask_radius,
+        total_gaussians=20,
+        gaussian_per_basis=2,
+        centre_prior_is_uniform=True,
+        centre=d.dataset_centre,
+    )
+
+    mass = af.Model(al.mp.Isothermal)
+    mass.centre.centre_0 = d.dataset_centre[0]
+    mass.centre.centre_1 = d.dataset_centre[1]
+
+    source_bulge = al.model_util.mge_model_from(
+        mask_radius=d.mask_radius,
+        total_gaussians=20,
+        centre_prior_is_uniform=False,
+        centre=d.dataset_centre,
+    )
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=0.5,
+                bulge=lens_bulge,
+                mass=mass,
+                shear=af.Model(al.mp.ExternalShear),
+            ),
+            source=af.Model(al.Galaxy, redshift=1.0, bulge=source_bulge),
+        )
+    )
+
+    analysis = util.AnalysisImaging(
+        dataset=d.dataset,
+        positions_likelihood_list=d.positions_likelihood_list,
+        use_jax=True,
+        dataset_main_path=d.dataset_main_path,
+        title_prefix="VIS",
+        plot_rgb=True,
+        psf_lowest_resolution=d.psf_lowest_resolution,
+        psf_lowest_resolution_fwhm=d.psf_lowest_resolution_fwhm,
+        pixel_wcs=d.pixel_wcs,
+        magzero=d.magzero,
+    )
+
+    if not analysis._use_jax:
+        raise RuntimeError(
+            "the JAX stage built an analysis with _use_jax=False — JAX is "
+            "missing or PYAUTO_DISABLE_JAX=1 is set, so this leg would not "
+            "measure the fork conflict at all."
+        )
+
+    log_likelihood = float(
+        analysis.log_likelihood_function(model.instance_from_prior_medians())
+    )
+
+    if "jax" not in sys.modules:
+        raise RuntimeError(
+            "the JAX likelihood was evaluated but `jax` is not in sys.modules — "
+            "the analysis did not route through JAX, so this leg is void."
+        )
+
+    import jax
+
+    print(
+        f"[jax stage] log_likelihood={log_likelihood:.4f} "
+        f"backend={jax.default_backend()} devices={jax.devices()}",
+        flush=True,
+    )
+
+    return log_likelihood
+
+
+def pooled_pix_fit(dataset: str, sample: str, output_path: Path, cores: int, n_like_max: int):
+    """
+    The ``vis_pix`` stage: a Delaunay pixelized source on the Numba CPU sparse
+    operator, ``use_jax=False``, handed to a multiprocessing ``Nautilus``.
+
+    This mirrors ``scripts/initial_lens_model.py`` L410-L572 — the CPU sparse
+    operator, the Hilbert image mesh with a ring of zeroed edge points, the
+    signal-to-noise over-sampling map, ``reg.AdaptSplit``, and a free mass
+    centre — with two deliberate departures, neither of which touches the
+    fork question:
+
+    * the adapt image is the dataset's own signal-to-noise map rather than the
+      lens-subtracted source image from a converged ``vis_lp`` result, so the
+      diagnostic does not have to run a full first search to build its second
+      one, and
+    * the fixed lens-light MGE instance is drawn from the prior medians rather
+      than from a converged ``vis_lp`` fit, and the sampler settings are tiny
+      (see ``N_LIVE`` above).
+
+    What is preserved is everything the pool sees: a numpy/numba likelihood, a
+    pixelized inversion, and ``number_of_cores > 1``, which is the condition
+    under which ``Nautilus.fit_multiprocessing`` builds a forked pool.
+    """
+    _push_config(output_path)
+
+    import numpy as np
+
+    import autofit as af
+    import autolens as al
+
+    util, d = _load(dataset, sample)
+
+    imaging = d.dataset
+    mask = imaging.mask
+
+    # scripts/initial_lens_model.py L436-440: --use_cpu selects the Numba CPU
+    # sparse operator rather than the JAX one.
+    imaging = imaging.apply_sparse_operator_cpu()
+
+    adapt_data = np.asarray(imaging.signal_to_noise_map)
+    adapt_data = np.clip(adapt_data, 0.01 * float(np.max(adapt_data)), None)
+    adapt_image = al.Array2D(values=adapt_data, mask=mask)
+
+    image_mesh = al.image_mesh.Hilbert(
+        pixels=HILBERT_PIXELS, weight_power=3.5, weight_floor=0.01
+    )
+    image_plane_mesh_grid = image_mesh.image_plane_mesh_grid_from(
+        mask=mask, adapt_data=adapt_image
+    )
+    image_plane_mesh_grid = al.image_mesh.append_with_circle_edge_points(
+        image_plane_mesh_grid=image_plane_mesh_grid,
+        centre=mask.mask_centre,
+        radius=d.mask_radius + mask.pixel_scale / 2.0,
+        n_points=EDGE_PIXELS_TOTAL,
+    )
+
+    adapt_images = al.AdaptImages(
+        galaxy_name_image_dict={"('galaxies', 'source')": adapt_image},
+        galaxy_name_image_plane_mesh_grid_dict={
+            "('galaxies', 'source')": image_plane_mesh_grid
+        },
+    )
+
+    over_sample_size_pixelization = al.Array2D(
+        values=np.where(adapt_data > 3.0, 4, 2), mask=mask
+    )
+    imaging = imaging.apply_over_sampling(
+        over_sample_size_lp=imaging.grids.lp.over_sample_size,
+        over_sample_size_pixelization=over_sample_size_pixelization,
+    )
+
+    analysis = util.AnalysisImaging(
+        dataset=imaging,
+        adapt_images=adapt_images,
+        positions_likelihood_list=d.positions_likelihood_list,
+        use_jax=False,
+        dataset_main_path=d.dataset_main_path,
+        title_prefix="VIS",
+        plot_rgb=True,
+        psf_lowest_resolution=d.psf_lowest_resolution,
+        psf_lowest_resolution_fwhm=d.psf_lowest_resolution_fwhm,
+        pixel_wcs=d.pixel_wcs,
+        magzero=d.magzero,
+    )
+
+    if analysis._use_jax:
+        raise RuntimeError(
+            "the pixelized analysis has _use_jax=True — it would be routed to "
+            "the serial fit_x1_cpu path (nautilus/search.py L240) and no pool "
+            "would ever be forked, so this leg is void."
+        )
+
+    mass = af.Model(al.mp.Isothermal)
+    mass.centre.centre_0 = af.UniformPrior(
+        lower_limit=d.dataset_centre[0] - 0.1, upper_limit=d.dataset_centre[0] + 0.1
+    )
+    mass.centre.centre_1 = af.UniformPrior(
+        lower_limit=d.dataset_centre[1] - 0.1, upper_limit=d.dataset_centre[1] + 0.1
+    )
+
+    # The lens light is a fixed 2x20 Gaussian MGE *instance*, as in
+    # scripts/initial_lens_model.py L540-546 where it is the vis_lp maximum
+    # likelihood instance. Here it is drawn from the prior medians instead —
+    # the light is not fitted either way, so it costs the likelihood the same
+    # 40 Gaussian evaluations per call that the pipeline pays.
+    lens_bulge = al.model_util.mge_model_from(
+        mask_radius=d.mask_radius,
+        total_gaussians=20,
+        gaussian_per_basis=2,
+        centre_prior_is_uniform=True,
+        centre=d.dataset_centre,
+    ).instance_from_prior_medians()
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=0.5,
+                bulge=lens_bulge,
+                mass=mass,
+                shear=af.Model(al.mp.ExternalShear),
+            ),
+            source=af.Model(
+                al.Galaxy,
+                redshift=1.0,
+                pixelization=af.Model(
+                    al.Pixelization,
+                    mesh=al.mesh.Delaunay(
+                        pixels=image_plane_mesh_grid.shape[0],
+                        zeroed_pixels=EDGE_PIXELS_TOTAL,
+                    ),
+                    regularization=al.reg.AdaptSplit,
+                ),
+            ),
+        ),
+    )
+
+    search = af.Nautilus(
+        path_prefix=Path(sample) / dataset if sample is not None else Path(dataset),
+        unique_tag="jax_fork_control",
+        name="vis_pix",
+        n_live=N_LIVE,
+        n_batch=N_BATCH,
+        n_like_max=n_like_max,
+        iterations_per_quick_update=1000000,
+        number_of_cores=cores,
+        session=None,
+    )
+
+    # The real fork point. Everything above — loading the dataset in
+    # particular — has already run, so this is the state the pool workers
+    # inherit, and it is not the same as the state recorded when the leg
+    # started.
+    fork_state = jax_state()
+    (output_path / "fork_state.json").write_text(json.dumps(fork_state, indent=2))
+    print(
+        f"[pooled fit] forking pool: cores={cores} "
+        f"start_method={multiprocessing.get_start_method()} "
+        f"at_fork={json.dumps(fork_state)}",
+        flush=True,
+    )
+
+    result = search.fit(model=model, analysis=analysis)
+
+    print(
+        f"[pooled fit] finished: "
+        f"max_log_likelihood={result.samples.max_log_likelihood_sample.log_likelihood:.4f}",
+        flush=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The legs
+# ---------------------------------------------------------------------------
+
+
+def leg_control(args, output_path: Path) -> dict:
+    """
+    One process does both stages. The JAX stage runs first and leaves XLA
+    initialised; the pooled numpy/numba fit then forks out of that process.
+    """
+    pulls_jax = import_autolens_pulls_jax()
+    print(f"[control] import autolens -> jax in sys.modules: {pulls_jax}", flush=True)
+
+    print("[control] stage 1: JAX likelihood (initialises XLA in this process)", flush=True)
+    jax_stage(args.dataset, args.sample, output_path)
+
+    info = env_dict(
+        args.cores, output_path, {"import_autolens_pulls_jax": pulls_jax}
+    )
+    print(f"[control] environment at fork: {json.dumps(info)}", flush=True)
+
+    print("[control] stage 2: pooled numpy/numba pixelized fit", flush=True)
+    pooled_pix_fit(args.dataset, args.sample, output_path, args.cores, args.n_like_max)
+
+    return info
+
+
+def leg_subprocess(args, output_path: Path) -> dict:
+    """
+    The proposed fix: the JAX stage runs in a child process, so this process
+    never imports JAX and its fork is clean.
+
+    The assertion before and after the ``subprocess.run`` is the whole point of
+    the leg — a parent that had quietly pulled JAX in (via ``import autolens``,
+    say) would be forking from a JAX-initialised process after all, and the leg
+    would be measuring nothing.
+    """
+    if "jax" in sys.modules:
+        raise RuntimeError(
+            "`jax` is already in sys.modules before the JAX stage was launched — "
+            "this leg cannot demonstrate a clean parent."
+        )
+
+    # Import autolens in the parent, exactly as the real pipeline process does,
+    # then re-check. If this pulled JAX in, the leg is void and says so.
+    pulls_jax = import_autolens_pulls_jax()
+    print(
+        f"[subprocess] import autolens -> jax in sys.modules: {pulls_jax}", flush=True
+    )
+    if pulls_jax:
+        raise RuntimeError(
+            "`import autolens` alone put jax in sys.modules — no pipeline "
+            "process can be a clean fork source, so the two-process split "
+            "cannot be the fix and this leg proves nothing."
+        )
+
+    print(
+        f"[subprocess] before launching the JAX stage: "
+        f"jax_in_sys_modules={'jax' in sys.modules} "
+        f"(autolens imported: {'autolens' in sys.modules})",
+        flush=True,
+    )
+
+    print("[subprocess] stage 1: JAX likelihood in a child process", flush=True)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--_jax_stage_worker",
+            "--dataset",
+            args.dataset,
+            "--sample",
+            args.sample,
+            "--output",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    for line in completed.stdout.splitlines():
+        print(f"    [child] {line}", flush=True)
+    if completed.returncode != 0:
+        print(completed.stderr[-4000:], flush=True)
+        raise RuntimeError(
+            f"the JAX stage child exited {completed.returncode}; see stderr above."
+        )
+
+    if "jax" in sys.modules:
+        raise RuntimeError(
+            "`jax` entered sys.modules in the parent while the child ran — the "
+            "parent is no longer a clean fork source."
+        )
+
+    info = env_dict(
+        args.cores, output_path, {"import_autolens_pulls_jax": pulls_jax}
+    )
+    print(f"[subprocess] environment at fork: {json.dumps(info)}", flush=True)
+
+    print("[subprocess] stage 2: pooled numpy/numba pixelized fit", flush=True)
+    pooled_pix_fit(args.dataset, args.sample, output_path, args.cores, args.n_like_max)
+
+    return info
+
+
+def _load_pipeline_script():
+    """
+    Import ``scripts/initial_lens_model.py`` as a module, so the leg calls the
+    pipeline's own ``fit`` rather than a re-implementation of it.
+    """
+    import importlib.util
+
+    path = PROJECT_ROOT / "scripts" / "initial_lens_model.py"
+    spec = importlib.util.spec_from_file_location("initial_lens_model_diag", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _clamp_nautilus(n_live: int, n_like_max: int):
+    """
+    Make the pipeline's two real searches cheap enough to run as a diagnostic,
+    without editing the pipeline.
+
+    ``scripts/initial_lens_model.py`` resolves ``af.Nautilus`` from the
+    ``autofit`` module at call time, so replacing that attribute with a
+    factory that overrides ``n_live`` and ``n_like_max`` reaches both searches
+    and leaves every other argument — ``batch_size``, ``n_batch``,
+    ``number_of_cores``, the paths — exactly as the pipeline sets them. A
+    factory rather than a subclass, so the search is still an ``af.Nautilus``
+    and its config lookups and identifier are unaffected.
+    """
+    import autofit as af
+
+    original = af.Nautilus
+
+    def clamped(*args, **kwargs):
+        kwargs["n_live"] = n_live
+        kwargs["n_like_max"] = n_like_max
+        return original(*args, **kwargs)
+
+    af.Nautilus = clamped
+    return original
+
+
+def leg_control_real(args, output_path: Path) -> dict:
+    """
+    The control test run through the pipeline's own entry point.
+
+    ``leg_control`` builds a faithful *imitation* of the two stages; this leg
+    calls the real ``scripts/initial_lens_model.py::fit`` twice in one process,
+    exactly as a single-process CPU run would:
+
+      1. ``fit(..., use_cpu=False, stage="vis_lp")`` — the real light-profile
+         search, under JAX, in this process. The sharpened probe is asserted
+         afterwards: if no XLA backend was initialised, this leg would be
+         forking from a clean process and would prove nothing.
+      2. ``fit(..., use_cpu=True, number_of_cores=cores, stage="vis_pix")`` —
+         the real pixelized search, which loads the JAX-produced ``vis_lp``
+         result from disk via ``search.fit``'s completed-fit short circuit and
+         forks its Numba likelihood pool out of this same, JAX-initialised
+         process.
+
+    Output is redirected with ``PYAUTO_OUTPUT_DIR``, which is what the script
+    itself reads (L70-73), so the diagnostic never writes into the project's
+    ``output/``. The only thing altered is the sampler cost, via
+    ``_clamp_nautilus``.
+    """
+    os.environ["PYAUTO_OUTPUT_DIR"] = str(output_path)
+
+    pulls_jax = import_autolens_pulls_jax()
+    print(f"[control_real] import autolens -> jax in sys.modules: {pulls_jax}", flush=True)
+
+    _clamp_nautilus(N_LIVE, args.n_like_max)
+    pipeline = _load_pipeline_script()
+
+    print(
+        f"[control_real] stage 1: real fit(stage='vis_lp', use_cpu=False) under JAX",
+        flush=True,
+    )
+    pipeline.fit(
+        dataset_name=args.dataset,
+        sample_name=args.sample,
+        iterations_per_quick_update=1000000,
+        number_of_cores=1,
+        use_cpu=False,
+        stage="vis_lp",
+    )
+
+    after_vis_lp = jax_state()
+    print(f"[control_real] after vis_lp: {json.dumps(after_vis_lp)}", flush=True)
+    if not after_vis_lp["jax_backends_initialised"]:
+        raise RuntimeError(
+            "the real vis_lp stage returned without initialising an XLA "
+            "backend — this process is not a JAX-initialised parent, so the "
+            "leg cannot test the fork conflict."
+        )
+
+    info = env_dict(
+        args.cores, output_path, {"import_autolens_pulls_jax": pulls_jax}
+    )
+    print(f"[control_real] environment at fork: {json.dumps(info)}", flush=True)
+
+    fork_state = jax_state()
+    (output_path / "fork_state.json").write_text(json.dumps(fork_state, indent=2))
+
+    print(
+        f"[control_real] stage 2: real fit(stage='vis_pix', use_cpu=True, "
+        f"number_of_cores={args.cores}) forking from this process",
+        flush=True,
+    )
+    result = pipeline.fit(
+        dataset_name=args.dataset,
+        sample_name=args.sample,
+        iterations_per_quick_update=1000000,
+        number_of_cores=args.cores,
+        use_cpu=True,
+        stage="vis_pix",
+    )
+
+    print(
+        f"[control_real] finished: max_log_likelihood="
+        f"{result.samples.max_log_likelihood_sample.log_likelihood:.4f}",
+        flush=True,
+    )
+
+    return info
+
+
+LEGS = {
+    "control": leg_control,
+    "control_real": leg_control_real,
+    "subprocess": leg_subprocess,
+}
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def run_leg_in_child(leg: str, args) -> dict:
+    """
+    Run one leg in its own process group and wait up to ``--timeout`` seconds.
+
+    A deadlocked leg is unkillable from inside itself, so the driver owns the
+    clock: on timeout the whole process group is killed (the pool's forked
+    workers included) and the leg is recorded as HANG. Each leg writes its
+    environment to ``<output>/<leg>/leg.json`` before it forks, so that record
+    survives even when the leg never returns.
+    """
+    output_path = Path(args.output) / leg
+    output_path.mkdir(parents=True, exist_ok=True)
+    log_path = output_path / "leg.log"
+
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--_run_leg",
+        leg,
+        "--dataset",
+        args.dataset,
+        "--sample",
+        args.sample,
+        "--cores",
+        str(args.cores),
+        "--n_like_max",
+        str(args.n_like_max),
+        "--output",
+        str(args.output),
+    ]
+
+    print(f"\n{'=' * 78}\n=== leg: {leg}\n{'=' * 78}", flush=True)
+    print(f"    {' '.join(command)}", flush=True)
+
+    start = time.time()
+    with open(log_path, "w") as log_file:
+        process = subprocess.Popen(
+            command,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        try:
+            returncode = process.wait(timeout=args.timeout)
+            timed_out = False
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            returncode = None
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            process.wait()
+    wall = time.time() - start
+
+    print(log_path.read_text(), flush=True)
+
+    record = {"leg": leg, "wall_seconds": round(wall, 1), "log": str(log_path)}
+
+    leg_json = output_path / "leg.json"
+    if leg_json.exists():
+        record.update(json.loads(leg_json.read_text()))
+
+    fork_json = output_path / "fork_state.json"
+    if fork_json.exists():
+        record.update(
+            {f"at_fork_{k}": v for k, v in json.loads(fork_json.read_text()).items()}
+        )
+
+    if timed_out:
+        record["outcome"] = "HANG"
+        record["detail"] = f"killed after --timeout={args.timeout}s"
+    elif returncode == 0:
+        record["outcome"] = "PASS"
+    else:
+        tail = log_path.read_text().strip().splitlines()
+        record["outcome"] = "ERROR"
+        record["detail"] = "\n".join(tail[-12:])
+
+    print(
+        f"=== leg {leg}: {record['outcome']} in {record['wall_seconds']}s", flush=True
+    )
+    return record
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--leg",
+        choices=["control", "control_real", "subprocess", "all"],
+        default="all",
+        help="which leg to run (default: all).",
+    )
+    parser.add_argument("--dataset", default=DEFAULT_DATASET)
+    parser.add_argument("--sample", default=DEFAULT_SAMPLE)
+    parser.add_argument(
+        "--cores",
+        type=int,
+        default=4,
+        help="cores for the pooled vis_pix fit; must exceed 1 or no pool is "
+        "forked (default: 4).",
+    )
+    parser.add_argument("--n_like_max", type=int, default=300)
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="seconds before a leg is killed and recorded as HANG (default: 600).",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(PROJECT_ROOT / "output" / "jax_fork_control"),
+        help="directory for per-leg fit output, logs and results.json.",
+    )
+
+    # Internal entry points: one leg, or the JAX stage of the subprocess leg.
+    parser.add_argument("--_run_leg", choices=list(LEGS), default=None)
+    parser.add_argument("--_jax_stage_worker", action="store_true")
+
+    args = parser.parse_args(argv)
+
+    output_root = Path(args.output).resolve()
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    if args._jax_stage_worker:
+        jax_stage(args.dataset, args.sample, output_root)
+        return 0
+
+    if args._run_leg is not None:
+        leg = args._run_leg
+        output_path = output_root / leg
+        output_path.mkdir(parents=True, exist_ok=True)
+        try:
+            LEGS[leg](args, output_path)
+        except Exception:
+            traceback.print_exc()
+            return 1
+        return 0
+
+    if args.cores <= 1:
+        parser.error(
+            "--cores must be > 1: Nautilus builds no pool at all for a single "
+            "core (nautilus/search.py, `if self.number_of_cores <= 1`), so the "
+            "legs would fork nothing and measure nothing."
+        )
+    if os.environ.get("PYAUTO_TEST_MODE"):
+        parser.error(
+            "PYAUTO_TEST_MODE is set: test mode skips the sampler entirely, so "
+            "no pool is created and neither leg measures anything. Unset it."
+        )
+    if os.environ.get("PYAUTO_DISABLE_JAX") == "1":
+        parser.error(
+            "PYAUTO_DISABLE_JAX=1 is set: the JAX stage would silently fall "
+            "back to numpy and never initialise XLA. Unset it."
+        )
+
+    legs = list(LEGS) if args.leg == "all" else [args.leg]
+    records = [run_leg_in_child(leg, args) for leg in legs]
+
+    results = {
+        "dataset": args.dataset,
+        "sample": args.sample,
+        "cores": args.cores,
+        "n_like_max": args.n_like_max,
+        "timeout": args.timeout,
+        "driver_python": sys.version.split()[0],
+        "legs": records,
+    }
+    results_path = output_root / "results.json"
+    results_path.write_text(json.dumps(results, indent=2))
+
+    print(f"\n{'=' * 78}\n=== summary\n{'=' * 78}", flush=True)
+    for record in records:
+        print(
+            f"{record['leg']:<12} {record['outcome']:<6} "
+            f"{record['wall_seconds']:>8.1f}s  "
+            f"at_fork: jax_imported={record.get('at_fork_jax_in_sys_modules')} "
+            f"xla_backends={record.get('at_fork_jax_backends_initialised')}  "
+            f"import_autolens_pulls_jax="
+            f"{record.get('import_autolens_pulls_jax')}",
+            flush=True,
+        )
+    print(f"\nwritten to {results_path}", flush=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hpc/sync
+++ b/hpc/sync
@@ -141,6 +141,15 @@ EXCLUDES=(
 push() {
     local dryrun="${1:-}"
 
+    # Create the project directory on the HPC before the first rsync. rsync only
+    # ever creates the last component of a destination path, so on a cluster that
+    # has never seen this project `${REMOTE}/catalogue/` needs two levels made and
+    # the transfer dies with "mkdir ... failed: No such file or directory". A dry
+    # run must leave the remote untouched, so it is skipped there.
+    if [[ -z "$dryrun" ]]; then
+        ssh "${HPC_HOST}" "mkdir -p '${REMOTE_PATH}'"
+    fi
+
     echo "==> [push] code/config  →  ${REMOTE}"
     for dir in "${CODE_DIRS[@]}"; do
         local src="${PROJECT_ROOT}/${dir}/"

--- a/hpc/sync
+++ b/hpc/sync
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# hpc/sync — bidirectional project sync between local machine and HPC
+# hpc/sync — drive this project on an HPC cluster without typing ssh
 #
 # SETUP
 #   cp hpc/sync.conf.example hpc/sync.conf
@@ -7,10 +7,33 @@
 #   # sync.conf is gitignored — it stays on your machine only.
 #
 # USAGE (run from the project root or hpc/ directory)
-#   hpc/sync push     Push code and data to the HPC
-#   hpc/sync pull     Download results from the HPC
-#   hpc/sync sync     Push, then pull  (default)
-#   hpc/sync status   Dry run — show what would transfer without moving anything
+#
+# Transfer:
+#   hpc/sync push                            Push code, config and data to the HPC
+#   hpc/sync push --no-data                  Push code and config only (skip dataset/)
+#   hpc/sync pull                            Download SLURM logs, then results
+#   hpc/sync logs                            Download SLURM logs only (fast, use mid-run)
+#   hpc/sync sync                            Push, then pull  (default)
+#   hpc/sync sync --no-data                  Push code only, then pull
+#   hpc/sync push-data-init                  First-time dataset upload via a tar pipe
+#   hpc/sync pull-full                       Whole results download via a tar pipe
+#   hpc/sync status                          Dry run — show what would transfer
+#
+# Jobs:
+#   hpc/sync submit [cpu|gpu] <script>       Submit a SLURM job from hpc/batch_<type>/
+#   hpc/sync push-submit [cpu|gpu] <script>  Push code, then submit
+#   hpc/sync jobs                            Show queued/running jobs (squeue)
+#   hpc/sync sacct                           Show job history and exit codes (sacct)
+#   hpc/sync cancel <job_id>                 Cancel a job by ID (scancel)
+#   hpc/sync wait-and-pull [secs]            Poll until no jobs remain, then pull
+#
+# Inspect:
+#   hpc/sync tail [cpu|gpu]                  Stream live SLURM log output (Ctrl+C to stop)
+#   hpc/sync du                              Show remote disk usage
+#   hpc/sync check                           Verify SSH connection and remote paths
+#   hpc/sync clear-logs [cpu|gpu]            Delete SLURM output/error log files
+#
+#   hpc/sync help                            Print the command list
 
 set -euo pipefail
 
@@ -18,16 +41,29 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 CONF="${SCRIPT_DIR}/sync.conf"
 
+# `help` is answered before the configuration below, which hard-fails when
+# HPC_HOST/HPC_BASE are unset — the command list has to be readable by someone
+# who has not written hpc/sync.conf yet.
+case "${1:-}" in
+    help|--help|-h) HELP_REQUESTED=1 ;;
+    *)              HELP_REQUESTED=0 ;;
+esac
+
 # ---------------------------------------------------------------------------
 # Configuration — loaded from hpc/sync.conf, with environment variable overrides
 # ---------------------------------------------------------------------------
 [[ -f "$CONF" ]] && source "$CONF"
 
-HPC_HOST="${HPC_HOST:?HPC_HOST not set. Copy hpc/sync.conf.example → hpc/sync.conf and edit it.}"
-HPC_BASE="${HPC_BASE:?HPC_BASE not set. Copy hpc/sync.conf.example → hpc/sync.conf and edit it.}"
+if [[ "$HELP_REQUESTED" -eq 0 ]]; then
+    HPC_HOST="${HPC_HOST:?HPC_HOST not set. Copy hpc/sync.conf.example → hpc/sync.conf and edit it.}"
+    HPC_BASE="${HPC_BASE:?HPC_BASE not set. Copy hpc/sync.conf.example → hpc/sync.conf and edit it.}"
+fi
+HPC_HOST="${HPC_HOST:-}"
+HPC_BASE="${HPC_BASE:-}"
 PROJECT_NAME="${PROJECT_NAME:-$(basename "$PROJECT_ROOT")}"
 
 REMOTE="${HPC_HOST}:${HPC_BASE}/${PROJECT_NAME}"
+REMOTE_PATH="${HPC_BASE}/${PROJECT_NAME}"
 
 # ---------------------------------------------------------------------------
 # Transfer lists
@@ -54,6 +90,16 @@ ROOT_FILES=(activate.sh start_here.py util.py __init__.py README.md LICENSE)
 # the entire archive on every sync (critical for large datasets).
 DATA_DIRS=(dataset)
 
+# SLURM stdout/stderr logs, pulled ahead of the results by `pull` and on their
+# own by `logs`. They are small and are the fastest way to see what a job is
+# doing, so they are worth fetching while a run is still going.
+LOG_DIRS=(
+    hpc/batch_cpu/output
+    hpc/batch_cpu/error
+    hpc/batch_gpu/output
+    hpc/batch_gpu/error
+)
+
 # Pulled from the HPC after jobs finish.
 #
 # `output/`      the main VIS results tree.
@@ -74,6 +120,12 @@ PULL_DIRS=(output output_sed inspect)
 # ---------------------------------------------------------------------------
 RSYNC=(rsync -az --partial --info=progress2)
 
+# Bulk-transfer SSH options, used by the tar pipes (`push-data-init`,
+# `pull-full`). AES-GCM is markedly faster than the default cipher on any CPU
+# with AES-NI, which matters when a single stream carries the whole archive.
+# The control commands (sbatch, squeue, tail) move no data and use plain `ssh`.
+SSH_BULK=(ssh -c aes128-gcm@openssh.com)
+
 EXCLUDES=(
     --exclude='__pycache__/'
     --exclude='*.pyc'
@@ -83,6 +135,9 @@ EXCLUDES=(
 )
 
 # ---------------------------------------------------------------------------
+# Transfer commands
+# ---------------------------------------------------------------------------
+
 push() {
     local dryrun="${1:-}"
 
@@ -108,6 +163,12 @@ push() {
             "${existing_root_files[@]}" "${REMOTE}/"
     fi
 
+    if [[ -n "${SKIP_DATA:-}" ]]; then
+        echo ""
+        echo "    [data skipped — --no-data]"
+        return
+    fi
+
     echo ""
     echo "==> [push] data  →  ${REMOTE}  (--ignore-existing: skips files already on HPC)"
     for dir in "${DATA_DIRS[@]}"; do
@@ -122,9 +183,55 @@ push() {
     done
 }
 
+push_data_init() {
+    echo "==> [push-data-init] first-time dataset upload via tar pipe  →  ${REMOTE}"
+    echo "    Use this once, for a fresh remote that has no dataset/ at all."
+    echo "    For every sync after that, 'push' (rsync --ignore-existing) is faster."
+    echo ""
+
+    for dir in "${DATA_DIRS[@]}"; do
+        local src="${PROJECT_ROOT}/${dir}/"
+        if [[ ! -d "$src" ]]; then
+            echo "    skip: ${dir}/ not found locally"
+            continue
+        fi
+        local file_count size
+        file_count=$(find "$src" -type f | wc -l)
+        size=$(du -sh "$src" | cut -f1)
+        echo "    ${dir}/  (${file_count} files, ${size})"
+        # No compression: FITS files are binary and do not compress meaningfully.
+        # tar streams straight into ssh, so no temporary archive is written locally.
+        tar cf - -C "${PROJECT_ROOT}" "${dir}" | \
+            "${SSH_BULK[@]}" "${HPC_HOST}" \
+                "mkdir -p '${REMOTE_PATH}' && tar xf - -C '${REMOTE_PATH}/'"
+    done
+}
+
+pull_logs() {
+    local dryrun="${1:-}"
+
+    echo "<== [logs] SLURM output/error logs  ←  ${REMOTE}"
+    for dir in "${LOG_DIRS[@]}"; do
+        echo "    ${dir}/"
+        mkdir -p "${PROJECT_ROOT}/${dir}"
+        # The remote log directories do not exist until a job has written to
+        # them; create them so rsync has something to read rather than aborting.
+        if [[ -z "$dryrun" ]]; then
+            ssh "${HPC_HOST}" "mkdir -p '${REMOTE_PATH}/${dir}'" 2>/dev/null || true
+        fi
+        "${RSYNC[@]}" "${EXCLUDES[@]}" --update ${dryrun} \
+            "${REMOTE}/${dir}/" \
+            "${PROJECT_ROOT}/${dir}/" \
+            || echo "    skip: ${dir}/ not present on the HPC"
+    done
+}
+
 pull() {
     local dryrun="${1:-}"
 
+    pull_logs "${dryrun}"
+
+    echo ""
     echo "<== [pull] results  ←  ${REMOTE}"
     for dir in "${PULL_DIRS[@]}"; do
         echo "    ${dir}/"
@@ -141,6 +248,33 @@ pull() {
     done
 }
 
+pull_full() {
+    echo "<== [pull-full] whole results download via tar pipe  ←  ${REMOTE}"
+    echo "    One stream for the entire tree — avoids rsync's per-file overhead,"
+    echo "    which dominates when the results are many small files."
+    echo "    For incremental pulls as jobs finish, use 'pull' instead."
+    echo ""
+
+    for dir in "${PULL_DIRS[@]}"; do
+        echo "    ${dir}/"
+        mkdir -p "${PROJECT_ROOT}/${dir}"
+        # search_internal excluded — large sampler state, not needed locally.
+        # A directory that is not on the HPC yet makes tar exit non-zero; that
+        # is not a failure of the pull, so it is tolerated.
+        if command -v pv &>/dev/null; then
+            "${SSH_BULK[@]}" "${HPC_HOST}" \
+                "tar cf - --exclude='search_internal' -C '${REMOTE_PATH}' '${dir}'" | \
+                pv -r -t -b | \
+                tar xf - -C "${PROJECT_ROOT}/" || echo "    skip: ${dir}/ not present on the HPC"
+        else
+            echo "    (no live rate — install pv for progress, e.g. apt install pv)"
+            "${SSH_BULK[@]}" "${HPC_HOST}" \
+                "tar cf - --exclude='search_internal' -C '${REMOTE_PATH}' '${dir}'" | \
+                tar xf - -C "${PROJECT_ROOT}/" || echo "    skip: ${dir}/ not present on the HPC"
+        fi
+    done
+}
+
 status() {
     echo "========================================"
     echo " DRY RUN — nothing will be transferred "
@@ -152,7 +286,295 @@ status() {
 }
 
 # ---------------------------------------------------------------------------
+# Job commands
+# ---------------------------------------------------------------------------
+
+# `cpu` and `gpu` name the hpc/batch_cpu and hpc/batch_gpu directories, not the
+# cluster's partitions — which partition a job lands on is the `--partition`
+# line inside the submit script itself.
+require_batch_type() {
+    local batch_type="${1:-}"
+    if [[ "$batch_type" != "gpu" && "$batch_type" != "cpu" ]]; then
+        echo "ERROR: batch type must be 'cpu' or 'gpu', got: '${batch_type}'"
+        exit 1
+    fi
+}
+
+submit_usage() {
+    local verb="${1}"
+    echo "Usage: $(basename "$0") ${verb} [cpu|gpu] <script_name>"
+    echo ""
+    echo "  <script_name> is a file in hpc/batch_cpu/ or hpc/batch_gpu/, e.g."
+    echo "    $(basename "$0") ${verb} gpu submit_initial_lens_model"
+    echo "    $(basename "$0") ${verb} cpu submit_initial_lens_model_two_stage"
+    echo "    $(basename "$0") ${verb} cpu submit_initial_lens_model_vis_lp"
+    echo "    $(basename "$0") ${verb} cpu submit_initial_lens_model_vis_pix"
+}
+
+submit() {
+    local batch_type="${1:-}"
+    local script_name="${2:-}"
+
+    if [[ -z "$batch_type" || -z "$script_name" ]]; then
+        submit_usage submit
+        exit 1
+    fi
+    require_batch_type "$batch_type"
+
+    local remote_dir="${REMOTE_PATH}/hpc/batch_${batch_type}"
+    echo "==> [submit] sbatch ${script_name}  (batch_${batch_type})  @  ${HPC_HOST}"
+    echo ""
+    # sbatch is run from the batch directory because the submit scripts write
+    # their logs to the relative paths output/ and error/.
+    ssh "${HPC_HOST}" "cd '${remote_dir}' && sbatch '${script_name}'"
+}
+
+push_submit() {
+    local batch_type="${1:-}"
+    local script_name="${2:-}"
+
+    if [[ -z "$batch_type" || -z "$script_name" ]]; then
+        submit_usage push-submit
+        exit 1
+    fi
+    require_batch_type "$batch_type"
+
+    push
+    echo ""
+    submit "$batch_type" "$script_name"
+}
+
+jobs_cmd() {
+    echo "==> [jobs] SLURM queue  @  ${HPC_HOST}"
+    echo ""
+    ssh "${HPC_HOST}" "squeue --me 2>/dev/null || squeue -u \"\$(id -un)\""
+}
+
+sacct_cmd() {
+    echo "==> [sacct] SLURM accounting — finished jobs and their exit codes  @  ${HPC_HOST}"
+    echo ""
+    ssh "${HPC_HOST}" "sacct -u \"\$(id -un)\""
+}
+
+cancel() {
+    local job_id="${1:-}"
+    if [[ -z "$job_id" ]]; then
+        echo "Usage: $(basename "$0") cancel <job_id>"
+        echo "       (job IDs come from '$(basename "$0") jobs')"
+        exit 1
+    fi
+    echo "==> [cancel] scancel ${job_id}  @  ${HPC_HOST}"
+    ssh "${HPC_HOST}" "scancel '${job_id}'"
+    echo "    Job ${job_id} cancelled."
+}
+
+wait_and_pull() {
+    local interval="${1:-60}"
+    echo "==> [wait-and-pull] polling every ${interval}s until no jobs remain  @  ${HPC_HOST}"
+    echo "    Ctrl+C to abort — the jobs keep running."
+    echo ""
+    while true; do
+        local n_running
+        n_running=$(ssh "${HPC_HOST}" "squeue --me --noheader 2>/dev/null | wc -l" 2>/dev/null || echo "0")
+        n_running="${n_running//[[:space:]]/}"
+        if [[ "${n_running}" -eq 0 ]]; then
+            echo "    $(date '+%H:%M:%S')  No jobs running — pulling results..."
+            echo ""
+            pull
+            break
+        fi
+        echo "    $(date '+%H:%M:%S')  ${n_running} job(s) still running — next check in ${interval}s"
+        sleep "${interval}"
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Inspect commands
+# ---------------------------------------------------------------------------
+
+tail_logs() {
+    local batch_type="${1:-gpu}"
+    require_batch_type "$batch_type"
+
+    local log_dir="${REMOTE_PATH}/hpc/batch_${batch_type}/output"
+    echo "<== [tail] streaming batch_${batch_type} logs  ←  ${HPC_HOST}"
+    echo "    Ctrl+C to stop."
+    echo ""
+    # -t allocates a TTY so Ctrl+C reaches tail rather than being swallowed by SSH
+    ssh -t "${HPC_HOST}" "
+        shopt -s nullglob
+        files=(\"${log_dir}\"/*.out)
+        if [[ \${#files[@]} -eq 0 ]]; then
+            echo 'No .out files yet in ${log_dir}/'
+        else
+            tail -f \"\${files[@]}\"
+        fi
+    "
+}
+
+du_cmd() {
+    echo "==> [du] remote disk usage  @  ${HPC_HOST}:${REMOTE_PATH}"
+    echo ""
+    local dirs="${DATA_DIRS[*]} ${PULL_DIRS[*]}"
+    ssh "${HPC_HOST}" "
+        for d in ${dirs}; do
+            path='${REMOTE_PATH}'/\"\$d\"
+            if [[ -d \"\$path\" ]]; then
+                size=\$(du -sh \"\$path\" 2>/dev/null | cut -f1)
+                printf '    %-10s  %s/\n' \"\$size\" \"\$d\"
+            else
+                printf '    %-10s  %s\n' '-' \"\$d/ (not found)\"
+            fi
+        done
+        total=\$(du -sh '${REMOTE_PATH}' 2>/dev/null | cut -f1)
+        printf '    %-10s  %s\n' \"\$total\" 'total'
+        echo ''
+        df -h '${REMOTE_PATH}' 2>/dev/null | tail -1 | \
+            awk '{printf \"    filesystem: %s used of %s (%s free)\n\", \$3, \$2, \$4}'
+    "
+}
+
+check_cmd() {
+    echo "==> [check] verifying connection and remote setup  @  ${HPC_HOST}"
+    echo ""
+
+    local all_ok=1
+
+    printf "    SSH connection ............ "
+    if ssh "${HPC_HOST}" "exit 0" 2>/dev/null; then
+        echo "OK"
+    else
+        echo "FAILED  (check HPC_HOST and your ~/.ssh/config)"; all_ok=0
+    fi
+
+    printf "    Remote project dir ........ "
+    if ssh "${HPC_HOST}" "[[ -d '${REMOTE_PATH}' ]]" 2>/dev/null; then
+        echo "OK  (${REMOTE_PATH})"
+    else
+        echo "NOT FOUND  (${REMOTE_PATH}) — run '$(basename "$0") push' to create it"; all_ok=0
+    fi
+
+    printf "    sbatch available .......... "
+    if ssh "${HPC_HOST}" "command -v sbatch &>/dev/null" 2>/dev/null; then
+        echo "OK"
+    else
+        echo "NOT FOUND  (is this a SLURM cluster login node?)"; all_ok=0
+    fi
+
+    echo ""
+    echo "    Filesystem:"
+    ssh "${HPC_HOST}" "df -h '${HPC_BASE}' 2>/dev/null | tail -1 | \
+        awk '{printf \"    %s used of %s (%s free) on %s\n\", \$3, \$2, \$4, \$1}'" || true
+
+    echo ""
+    if [[ "$all_ok" -eq 1 ]]; then
+        echo "    All checks passed."
+    else
+        echo "    One or more checks FAILED — review above."
+        return 1
+    fi
+}
+
+clear_logs() {
+    local batch_type="${1:-}"
+
+    local types=("cpu" "gpu")
+    if [[ -n "$batch_type" ]]; then
+        require_batch_type "$batch_type"
+        types=("$batch_type")
+    fi
+
+    echo "==> [clear-logs] will delete .out and .err files, locally and on the HPC"
+    echo ""
+    for type in "${types[@]}"; do
+        for subdir in output error; do
+            echo "    local   hpc/batch_${type}/${subdir}/"
+            echo "    remote  hpc/batch_${type}/${subdir}/"
+        done
+    done
+    echo ""
+    read -r -p "    Delete all the above? [y/N] " confirm
+    [[ "$confirm" =~ ^[Yy]$ ]] || { echo "    Aborted."; return 0; }
+    echo ""
+
+    for type in "${types[@]}"; do
+        for subdir in output error; do
+            local local_dir="${PROJECT_ROOT}/hpc/batch_${type}/${subdir}"
+            local remote_dir="${REMOTE_PATH}/hpc/batch_${type}/${subdir}"
+
+            # Local — only if files exist, so rm never sees an unmatched glob.
+            if compgen -G "${local_dir}/*.out" > /dev/null 2>&1 || \
+               compgen -G "${local_dir}/*.err" > /dev/null 2>&1; then
+                rm -f "${local_dir}"/*.out "${local_dir}"/*.err
+                echo "    cleared local   hpc/batch_${type}/${subdir}/"
+            fi
+
+            # Remote
+            ssh "${HPC_HOST}" "
+                shopt -s nullglob
+                files=('${remote_dir}'/*.out '${remote_dir}'/*.err)
+                if [[ \${#files[@]} -gt 0 ]]; then
+                    rm -f \"\${files[@]}\"
+                    echo '    cleared remote  hpc/batch_${type}/${subdir}/'
+                fi
+            " || true
+        done
+    done
+    echo ""
+    echo "    Done."
+}
+
+print_help() {
+    echo "Usage: $(basename "$0") <command> [options]"
+    echo ""
+    echo "Transfer:"
+    echo "  push                            Upload code, config and data to the HPC"
+    echo "  push --no-data                  Upload code and config only (skip dataset/)"
+    echo "  pull                            Download SLURM logs, then results"
+    echo "  logs                            Download SLURM logs only (fast, use mid-run)"
+    echo "  sync                            push then pull (default)"
+    echo "  sync --no-data                  push --no-data then pull"
+    echo "  push-data-init                  First-time dataset upload via a tar pipe"
+    echo "  pull-full                       Whole results download via a tar pipe"
+    echo "  status                          Dry run — show what would transfer"
+    echo ""
+    echo "Jobs:"
+    echo "  submit [cpu|gpu] <script>       Submit a SLURM job from hpc/batch_<type>/"
+    echo "                                  CPU scripts:"
+    echo "                                    submit_initial_lens_model"
+    echo "                                    submit_initial_lens_model_two_stage"
+    echo "                                    submit_initial_lens_model_vis_lp"
+    echo "                                    submit_initial_lens_model_vis_pix"
+    echo "                                  GPU scripts:"
+    echo "                                    submit_initial_lens_model"
+    echo "                                    submit_full_model"
+    echo "                                    submit_sersic_waveband"
+    echo "  push-submit [cpu|gpu] <script>  Push code, then submit"
+    echo "  jobs                            Show queued/running jobs (squeue)"
+    echo "  sacct                           Show job history and exit codes (sacct)"
+    echo "  cancel <job_id>                 Cancel a job by ID (scancel)"
+    echo "  wait-and-pull [secs]            Poll until no jobs remain, then pull (default: 60s)"
+    echo ""
+    echo "Inspect:"
+    echo "  tail [cpu|gpu]                  Stream live SLURM log output (default: gpu)"
+    echo "  du                              Show remote disk usage"
+    echo "  check                           Verify SSH connection and remote paths"
+    echo "  clear-logs [cpu|gpu]            Delete SLURM output/error log files"
+    echo ""
+    echo "  help                            Show this message"
+}
+
+# ---------------------------------------------------------------------------
 cmd="${1:-sync}"
+
+if [[ "$HELP_REQUESTED" -eq 1 ]]; then
+    print_help
+    exit 0
+fi
+
+if [[ "${2:-}" == "--no-data" ]]; then
+    SKIP_DATA=1
+fi
 
 echo ""
 echo "Project : ${PROJECT_NAME}"
@@ -160,17 +582,27 @@ echo "Remote  : ${REMOTE}"
 echo ""
 
 case "$cmd" in
-    push)   push ;;
-    pull)   pull ;;
-    sync)   push && echo "" && pull ;;
-    status) status ;;
+    push)            push ;;
+    pull)            pull ;;
+    logs)            pull_logs ;;
+    sync)            push && echo "" && pull ;;
+    push-data-init)  push_data_init ;;
+    pull-full)       pull_full ;;
+    status)          status ;;
+    submit)          submit "${2:-}" "${3:-}" ;;
+    push-submit)     push_submit "${2:-}" "${3:-}" ;;
+    jobs)            jobs_cmd ;;
+    sacct)           sacct_cmd ;;
+    cancel)          cancel "${2:-}" ;;
+    wait-and-pull)   wait_and_pull "${2:-60}" ;;
+    tail)            tail_logs "${2:-gpu}" ;;
+    du)              du_cmd ;;
+    check)           check_cmd ;;
+    clear-logs)      clear_logs "${2:-}" ;;
     *)
-        echo "Usage: $(basename "$0") [push|pull|sync|status]"
+        echo "Unknown command: ${cmd}"
         echo ""
-        echo "  push    Upload code, config, and data to the HPC"
-        echo "  pull    Download results from the HPC"
-        echo "  sync    push then pull (default)"
-        echo "  status  Dry run — show what would be transferred"
+        print_help
         exit 1
         ;;
 esac

--- a/hpc/sync.conf.example
+++ b/hpc/sync.conf.example
@@ -1,23 +1,31 @@
 # HPC sync configuration
 # ─────────────────────────────────────────────────────────────────────────────
 # Copy this file to hpc/sync.conf and fill in your values.
-# sync.conf is gitignored — it lives only on your local machine.
+# sync.conf is gitignored — it lives only on your local machine, and `hpc/sync`
+# never pushes it to the cluster.
 #
-# Once set, $HPC_BASE/$PROJECT_NAME is equivalent to $PROJECT_PATH used
-# inside the SLURM batch scripts, so activation and script paths stay consistent.
+# Once set, $HPC_BASE/$PROJECT_NAME is equivalent to the $PROJECT_PATH you
+# export before `sbatch`, so the paths in the batch scripts and the paths
+# `hpc/sync` transfers to are the same place.
 #
-# You can also export these as environment variables instead:
-#   export HPC_HOST=euclid_jump
-#   export HPC_BASE=/mnt/ral/jnightin
+# You can also export these as environment variables instead of editing a file:
+#   export HPC_HOST=your_hpc_ssh_alias
+#   export HPC_BASE=/path/to/large/storage/your_username
 #   hpc/sync push
 # ─────────────────────────────────────────────────────────────────────────────
 
-# SSH host alias (from ~/.ssh/config) or user@hostname
-HPC_HOST=euclid_jump
+# How to reach the cluster: an SSH host alias defined in your ~/.ssh/config, or
+# a plain user@hostname. An alias is worth setting up — it is the one place to
+# put a ProxyJump, an identity file or a non-standard port, and every `hpc/sync`
+# command (rsync, sbatch, squeue, tail) then inherits it.
+HPC_HOST=your_hpc_ssh_alias
 
-# Base directory on the HPC under which all your projects sit.
-# The full remote path will be $HPC_BASE/$PROJECT_NAME.
-HPC_BASE=/mnt/ral/jnightin
+# Base directory on the HPC under which all your projects sit — normally your
+# space on the large/scratch filesystem, not your home directory, since the
+# dataset and output trees get big. The full remote path this project syncs to
+# is $HPC_BASE/$PROJECT_NAME.
+HPC_BASE=/path/to/large/storage/your_username
 
-# Name of this project on the HPC (defaults to the local folder name if unset).
+# Name of this project's directory on the HPC, underneath $HPC_BASE.
+# Defaults to the name of your local project folder if left unset.
 PROJECT_NAME=euclid_strong_lens_modeling_pipeline

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,22 +10,22 @@ python scripts/initial_lens_model.py --sample=q1_walsmley --dataset=<name>
 
 All fitting pipelines share one argument parser (`util.parse_fit_args`) —
 `--dataset`, `--sample`, `--iterations_per_quick_update`, `--number_of_cores`,
-`--use_cpu`, `--skip_pix`. See the repository `README.md` for what each does.
+`--use_cpu`, `--stage`. See the repository `README.md` for what each does.
 
 # Fitting pipelines
 
 - `initial_lens_model.py`: **The entry point.** MGE lens light + SIE + shear mass
   + MGE source (`vis_lp`), then a pixelized Delaunay source (`vis_pix`). The
   repository root's `start_here.py` is a thin shim over this script's `fit()`.
-  `--skip_pix` returns after `vis_lp`.
+  `--stage=vis_lp` returns after `vis_lp`.
 - `sersic_lens_model.py`: Sersic lens and source fits with the mass model fixed
   to the initial fit, giving more accurate photometry for SED fitting. Chains off
-  `initial_lens_model.fit(..., skip_pix=True)` — `vis_pix` replaces the source
+  `initial_lens_model.fit(..., stage="vis_lp")` — `vis_pix` replaces the source
   bulge with a pixelization, so its instance cannot seed a Sersic source prior.
 - `lens_model_waveband.py`: After modeling the high resolution VIS imaging, model
   the lower resolution NIR / EXT imaging with the lens model held fixed.
 - `sersic_lens_model_waveband.py`: The **SED chain** driver — runs
-  `initial_lens_model --skip_pix`, then `sersic_lens_model`, then
+  `initial_lens_model --stage=vis_lp`, then `sersic_lens_model`, then
   `lens_model_waveband` over every band. Run it under its own
   `PYAUTO_OUTPUT_DIR` so the per-band results stay out of the main `output/`
   tree; both upstream stages cache-short-circuit if their result zips are

--- a/scripts/build_inspection_bundle.sh
+++ b/scripts/build_inspection_bundle.sh
@@ -58,12 +58,13 @@ fi
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_ROOT="$( cd -- "$SCRIPT_DIR/.." && pwd )"
 
-# On HPC, activate.sh activates the shared PyAuto venv under /mnt/ral and puts
-# its checkouts on PYTHONPATH. It is HPC-only — sourcing it elsewhere fails — so
-# it is used only when that venv is actually present and the caller has not
+# On HPC, activate.sh activates the shared PyAuto venv under PYAUTO_HPC_BASE and
+# puts its checkouts on PYTHONPATH. It is HPC-only — sourcing it elsewhere fails
+# — so it is used only when that venv is actually present and the caller has not
 # already set up an environment (PYAUTO_ROOT is exported by a worktree
-# activate.sh). Everywhere else the ambient install is used.
-HPC_BASE="${PYAUTO_HPC_BASE:-/mnt/ral/jnightin/PyAuto}"
+# activate.sh). Everywhere else the ambient install is used. Export
+# PYAUTO_HPC_BASE to point at your shared PyAuto checkout.
+HPC_BASE="${PYAUTO_HPC_BASE:-/path/to/large/storage/your_username/PyAuto}"
 if [ -z "${PYAUTO_ROOT:-}" ] && [ -d "$HPC_BASE" ] && [ -f "$PROJECT_ROOT/activate.sh" ]; then
     # shellcheck disable=SC1091
     source "$PROJECT_ROOT/activate.sh"

--- a/scripts/full_model.py
+++ b/scripts/full_model.py
@@ -22,7 +22,7 @@ script is that same idea generalised into five chained searches.
 This script accepts the shared pipeline arguments (``util.parse_fit_args``), but its
 ``fit`` function uses only ``--dataset``, ``--sample`` and
 ``--iterations_per_quick_update``. Every stage here runs on JAX and every stage is
-run, so ``--use_cpu``, ``--number_of_cores`` and ``--skip_pix`` have no effect.
+run, so ``--use_cpu``, ``--number_of_cores`` and ``--stage`` have no effect.
 
 __SLaM (Source, Light and Mass)__
 
@@ -952,7 +952,7 @@ if __name__ == "__main__":
         iterations_per_quick_update,
         number_of_cores,
         use_cpu,
-        skip_pix,
+        stage,
     ) = util.parse_fit_args()
     fit(
         dataset_name=dataset_name,

--- a/scripts/full_model.py
+++ b/scripts/full_model.py
@@ -602,13 +602,15 @@ def fit(
     the dataset contract it reads — including ``info.json``, which is where the mask
     radius comes from — is described in ``start_here.py``.
 
-    The sparse operator is then applied on top. It speeds up the linear algebra of
-    the pixelized searches, which is where this pipeline spends most of its time.
+    Every search in this script runs under JAX, so the dataset is fitted exactly as
+    it is loaded. The Numba sparse operator that ``scripts/initial_lens_model.py``
+    applies to its pixelized stage is the CPU route's tool, applied only under
+    ``--use_cpu``; under JAX the pixelized inversion uses JAX's own linear algebra
+    on the plain dataset.
     """
     d = util.load_vis_dataset(dataset_name, sample_name=sample_name)
 
-    # full_model uses a sparse operator for faster pixelisation fits
-    dataset = d.dataset.apply_sparse_operator()
+    dataset = d.dataset
 
     """
     __Settings AutoFit__

--- a/scripts/initial_lens_model.py
+++ b/scripts/initial_lens_model.py
@@ -619,10 +619,7 @@ def fit(
 
     On CPU the two searches are run as two separate processes: ``--stage vis_lp``
     first, with JAX on CPU, and then ``--stage vis_pix``, with the Numba sparse
-    operator and a multiprocessing pool of ``--number_of_cores``. They cannot
-    share one process, because a forked pool cannot be used in a process in which
-    JAX has already initialised — so the pool that this search wants is only
-    available to a process that never ran ``vis_lp``. The second process does not
+    operator and a multiprocessing pool of ``--number_of_cores``. The two stages run as separate Python processes. This is a conservative default: PyAutoFit documents an XLA deadlock for a forked worker whose likelihood touches JAX, and the DR1 science runs were submitted this way. A local control test (hpc/diagnostics/jax_fork_control.py) did not reproduce a hang for the CPU route, whose vis_pix likelihood is Numba; production sampler sizes and large pools are untested, so the boundary is kept until a cluster run passes. hpc/README.md has the measured table. The second process does not
     re-fit ``vis_lp``: it loads the completed result the first one wrote, and
     fails immediately if that result is missing (see "__Stage: vis_pix Requires A
     Completed vis_lp__" above). ``hpc/README.md`` documents the submission

--- a/scripts/initial_lens_model.py
+++ b/scripts/initial_lens_model.py
@@ -20,6 +20,11 @@ MGE lens light, an SIE + shear mass model and an MGE source together; ``vis_pix`
 fixes the lens light, frees the mass centre, and replaces the source with a pixelized
 Delaunay reconstruction. The prose below documents how each is built, line by line.
 
+``--stage`` selects which of the two runs: ``all`` (the default) runs both in this
+process, ``vis_lp`` stops after the first, and ``vis_pix`` runs only the second,
+loading the ``vis_lp`` result from disk. See "__Search: vis_pix__" below for why the
+CPU route splits the two into separate processes.
+
 ``scripts/full_model.py`` extends this fit with the full Source, Light and Mass (SLaM)
 chain — see ``start_here.py``, "__SLaM: Source, Light And Mass__".
 
@@ -41,7 +46,8 @@ def fit(
     iterations_per_quick_update: int = 5000,
     number_of_cores: int = 1,
     use_cpu: bool = False,
-    skip_pix: bool = False,
+    stage: str = "all",
+    skip_pix: bool = None,
 ):
     """
     Fit the initial Euclid lens model: an MGE light + SIE mass ``vis_lp`` search
@@ -59,11 +65,33 @@ def fit(
         Number of CPU cores used by the ``vis_pix`` Nautilus search.
     use_cpu
         Disable JAX and use the CPU sparse operator for the pixelization.
+    stage
+        Which of the two searches to run.
+
+        - ``"all"`` (default) — run ``vis_lp``, then ``vis_pix``, in this
+          process, and return the ``vis_pix`` result.
+        - ``"vis_lp"`` — run ``vis_lp`` and return its result without running
+          ``vis_pix``. Used by ``sersic_lens_model.py``, whose Sersic source
+          prior is seeded from ``galaxies.source.bulge`` — which the pixelized
+          fit replaces.
+        - ``"vis_pix"`` — run ``vis_pix`` only. The ``vis_lp`` search is not
+          re-run: its completed output must already be on disk, and is loaded
+          from there. If it is not complete this raises ``RuntimeError``
+          immediately, before any fitting, rather than silently re-running
+          ``vis_lp`` in a process configured for the pixelized stage.
     skip_pix
-        Return the ``vis_lp`` result without running the ``vis_pix`` search.
-        Used by ``sersic_lens_model.py``, whose Sersic source prior is seeded
-        from ``galaxies.source.bulge`` — which the pixelized fit replaces.
+        Deprecated alias for ``stage``: ``skip_pix=True`` means
+        ``stage="vis_lp"``. Kept so existing callers keep working; new code
+        should pass ``stage``.
     """
+    if skip_pix is not None and skip_pix:
+        stage = "vis_lp"
+
+    if stage not in ("all", "vis_lp", "vis_pix"):
+        raise ValueError(
+            f"stage must be one of 'all', 'vis_lp' or 'vis_pix', but got {stage!r}."
+        )
+
     from autolens import conf
 
     project_root = Path(__file__).parent.parent
@@ -221,11 +249,43 @@ def fit(
         n_like_max=200000,
     )
 
+    """
+    __Stage: vis_pix Requires A Completed vis_lp__
+
+    Under ``--stage vis_pix`` this process must not run ``vis_lp``; it must load
+    the one that a previous ``--stage vis_lp`` run left on disk. ``search.fit``
+    would do exactly that on its own — it short-circuits to
+    ``result_via_completed_fit`` when ``paths.is_complete`` — but if the result
+    is *not* there it would instead run the whole light-profile fit silently,
+    inside a process configured for the pixelized stage. So the condition is
+    checked here and the run is failed instead.
+
+    The check is the library's own, reached the same way ``search.fit`` reaches
+    it: attach the (analysis-modified) model and the unique tag to the paths so
+    the output directory and its identifier resolve, restore any zipped result,
+    and read ``paths.is_complete`` — the ``.completed`` marker file that
+    ``paths.completed()`` writes at the end of a successful fit.
+    """
+    if stage == "vis_pix":
+        search.paths.model = analysis.modify_model(model)
+        search.paths.unique_tag = search.unique_tag
+        search.paths.restore()
+
+        if not search.paths.is_complete:
+            sample_arg = f"--sample={sample_name} " if sample_name is not None else ""
+            raise RuntimeError(
+                f"--stage vis_pix requires a completed vis_lp result, but none "
+                f"was found at:\n\n    {search.paths.output_path}\n\n"
+                f"Run the light-profile stage first:\n\n"
+                f"    python scripts/initial_lens_model.py "
+                f"{sample_arg}--dataset={dataset_name} --stage vis_lp\n"
+            )
+
     source_lp_result = search.fit(
         model=model, analysis=analysis, **settings_search.fit_dict
     )
 
-    if skip_pix:
+    if stage == "vis_lp":
         return source_lp_result
 
     """
@@ -555,7 +615,19 @@ def fit(
     takes its parallelism from the batch of models it evaluates on the device,
     whereas this search is the one that benefits from a multiprocessing pool —
     which is why ``--use_cpu`` and ``--number_of_cores`` are usually passed
-    together.
+    together, and why ``--stage`` exists.
+
+    On CPU the two searches are run as two separate processes: ``--stage vis_lp``
+    first, with JAX on CPU, and then ``--stage vis_pix``, with the Numba sparse
+    operator and a multiprocessing pool of ``--number_of_cores``. They cannot
+    share one process, because a forked pool cannot be used in a process in which
+    JAX has already initialised — so the pool that this search wants is only
+    available to a process that never ran ``vis_lp``. The second process does not
+    re-fit ``vis_lp``: it loads the completed result the first one wrote, and
+    fails immediately if that result is missing (see "__Stage: vis_pix Requires A
+    Completed vis_lp__" above). ``hpc/README.md`` documents the submission
+    scripts that run the pair in order. On GPU there is no such constraint and
+    the default ``--stage all`` runs both searches in one process.
     """
     vis_pix_search_dict = {
         **settings_search.search_dict,
@@ -581,7 +653,7 @@ if __name__ == "__main__":
         iterations_per_quick_update,
         number_of_cores,
         use_cpu,
-        skip_pix,
+        stage,
     ) = util.parse_fit_args()
     fit(
         dataset_name=dataset_name,
@@ -589,5 +661,5 @@ if __name__ == "__main__":
         iterations_per_quick_update=iterations_per_quick_update,
         number_of_cores=number_of_cores,
         use_cpu=use_cpu,
-        skip_pix=skip_pix,
+        stage=stage,
     )

--- a/scripts/initial_lens_model.py
+++ b/scripts/initial_lens_model.py
@@ -324,24 +324,22 @@ def fit(
     A pixelized fit solves a large linear system at every likelihood evaluation,
     and the expensive ingredient in it is the PSF: the mapping between image
     pixels and source pixels has to be convolved before the source can be solved
-    for. The sparse operator precomputes the PSF-and-noise-map products that
-    convolution needs, once, when the dataset is built. Each likelihood evaluation
-    then reuses them instead of recomputing them. The operator is attached to the
-    returned dataset and picked up automatically by the fit, and it is applied
-    only here, because only a pixelized fit performs that inversion — ``vis_lp``
-    above runs on the plain ``d.dataset``.
+    for. The sparse operator is the CPU route's tool for that. It precomputes the
+    PSF-and-noise-map products the convolution needs, once, when the dataset is
+    built, in a Numba implementation; each likelihood evaluation then reuses them
+    instead of recomputing them. The operator is attached to the returned dataset
+    and picked up automatically by the fit, and it is applied only here, because
+    only a pixelized fit performs that inversion — ``vis_lp`` above runs on the
+    plain ``d.dataset``.
 
-    The two calls build the same operator by different routes.
-    ``apply_sparse_operator`` uses JAX, which is the GPU path;
-    ``apply_sparse_operator_cpu`` uses a Numba CPU implementation. ``--use_cpu``
-    selects the latter, and is the same switch that sets ``use_jax=False`` on the
-    analysis below — so it does not merely move the same arithmetic to another
-    device, it changes which implementation of the linear algebra is used.
+    It is applied only under ``--use_cpu``, the same switch that sets
+    ``use_jax=False`` on the analysis below. Under JAX — the GPU route — no sparse
+    operator is applied at all: the pixelized inversion uses JAX's own linear
+    algebra on the plain dataset, and applying the operator on top of that path
+    replaces the linear algebra JAX is fastest at with one it is not.
     """
     if use_cpu:
         dataset = dataset.apply_sparse_operator_cpu()
-    else:
-        dataset = dataset.apply_sparse_operator()
 
     """
     __Image Mesh__

--- a/scripts/lens_model_waveband.py
+++ b/scripts/lens_model_waveband.py
@@ -555,7 +555,7 @@ if __name__ == "__main__":
         iterations_per_quick_update,
         number_of_cores,
         use_cpu,
-        skip_pix,
+        stage,
     ) = util.parse_fit_args()
 
     """
@@ -572,7 +572,7 @@ if __name__ == "__main__":
     — where the bands are fitted against a Sersic VIS model instead — run
     ``scripts/sersic_lens_model_waveband.py``.
     """
-    # `skip_pix=True` is forced (the `--skip_pix` flag is not consulted here):
+    # `stage="vis_lp"` is forced (the `--stage` flag is not consulted here):
     # the multi-band model takes `vis_result.instance.galaxies.source.bulge`,
     # which only exists on the `vis_lp` result — `vis_pix` replaces the source
     # bulge with a pixelization.
@@ -582,7 +582,7 @@ if __name__ == "__main__":
         iterations_per_quick_update=iterations_per_quick_update,
         number_of_cores=number_of_cores,
         use_cpu=use_cpu,
-        skip_pix=True,
+        stage="vis_lp",
     )
 
     fit_waveband(

--- a/scripts/mge_lens_only.py
+++ b/scripts/mge_lens_only.py
@@ -596,7 +596,7 @@ if __name__ == "__main__":
         iterations_per_quick_update,
         number_of_cores,
         use_cpu,
-        skip_pix,
+        stage,
     ) = util.parse_fit_args()
 
     """
@@ -608,7 +608,7 @@ if __name__ == "__main__":
     The shared argument parser is used so that one command line works across all
     the pipelines, but this script only acts on ``--sample``, ``--dataset`` and
     ``--iterations_per_quick_update``. ``--number_of_cores``, ``--use_cpu`` and
-    ``--skip_pix`` are accepted and ignored: there is no pixelized stage to skip
+    ``--stage`` are accepted and ignored: there is no pixelized stage to skip
     and no CPU-parallel search to size, because every search here runs under
     JAX on a model with a handful of parameters. ``mask_radius`` is not an
     argument at all — it comes from the dataset's ``info.json``.

--- a/scripts/sersic_lens_model.py
+++ b/scripts/sersic_lens_model.py
@@ -38,7 +38,7 @@ already resolved. With the mass fixed, the whole twelve-parameter space is light
 
 __Why It Chains Off vis_lp, Not vis_pix__
 
-``initial_lens_model.fit`` is called with ``skip_pix=True``, so this script chains
+``initial_lens_model.fit`` is called with ``stage="vis_lp"``, so this script chains
 off the light-profile search ``vis_lp`` rather than the pixelized search
 ``vis_pix``. This is not an optimisation. The source Sersic's centre priors are
 read from ``galaxies.source.bulge``, and the pixelized stage replaces the source
@@ -59,7 +59,7 @@ same two stages and then ``fit_waveband`` over every remaining band.
 
 Of the shared pipeline arguments, ``--number_of_cores`` and ``--use_cpu`` are
 forwarded to the upstream ``vis_lp`` fit; the Sersic search itself always runs on
-JAX. ``--skip_pix`` is ignored: it is forced to ``True`` regardless, for the reason
+JAX. ``--stage`` is ignored: it is forced to ``"vis_lp"`` regardless, for the reason
 above.
 
 New to the pipeline? Read ``start_here.py`` in the repository root first: it covers
@@ -282,7 +282,7 @@ if __name__ == "__main__":
         iterations_per_quick_update,
         number_of_cores,
         use_cpu,
-        skip_pix,
+        stage,
     ) = util.parse_fit_args()
 
     # Bypass vis_pix — the Sersic fit only needs vis_lp (which has the MGE
@@ -294,7 +294,7 @@ if __name__ == "__main__":
         iterations_per_quick_update=iterations_per_quick_update,
         number_of_cores=number_of_cores,
         use_cpu=use_cpu,
-        skip_pix=True,
+        stage="vis_lp",
     )
 
     sersic_result = fit_sersic(

--- a/scripts/sersic_lens_model_waveband.py
+++ b/scripts/sersic_lens_model_waveband.py
@@ -47,10 +47,10 @@ if __name__ == "__main__":
         iterations_per_quick_update,
         number_of_cores,
         use_cpu,
-        skip_pix,
+        stage,
     ) = util.parse_fit_args()
 
-    # `skip_pix=True` is forced: the Sersic source prior is seeded from
+    # `stage="vis_lp"` is forced: the Sersic source prior is seeded from
     # `galaxies.source.bulge`, which the `vis_pix` stage replaces with a
     # pixelization.
     vis_lp_result = fit(
@@ -59,7 +59,7 @@ if __name__ == "__main__":
         iterations_per_quick_update=iterations_per_quick_update,
         number_of_cores=number_of_cores,
         use_cpu=use_cpu,
-        skip_pix=True,
+        stage="vis_lp",
     )
 
     sersic_result = fit_sersic(

--- a/start_here.py
+++ b/start_here.py
@@ -93,7 +93,9 @@ and install **PyAutoLens** afterwards. If **PyAutoLens** is installed without a
 working GPU setup a warning is printed; the pipeline still runs, just on CPU.
 
 For scale: ``scripts/initial_lens_model.py`` fits a lens in around 10 minutes on
-a GPU, and around 20 minutes on an 8-core CPU. Over a sample of a few thousand
+a GPU, and around 20 minutes on an 8-core CPU (times from the DR1 science runs
+under their own ``config/``; ``hpc/README.md`` has the times measured with the
+committed one). Over a sample of a few thousand
 candidates that difference decides whether the run is a coffee break or a
 cluster allocation.
 

--- a/start_here.py
+++ b/start_here.py
@@ -130,8 +130,12 @@ The arguments, all of which this file forwards unchanged:
   searches.
 - ``--use_cpu`` (default: off) — CPU mode: disables JAX and applies the CPU
   sparse operator to the pixelized stage.
-- ``--skip_pix`` (default: off) — return after the light-profile fit, skipping
-  the pixelized source stage.
+- ``--stage`` (default: ``all``) — which of the two searches to run. ``all``
+  runs ``vis_lp`` and then ``vis_pix`` in one process; ``vis_lp`` returns after
+  the light-profile fit, skipping the pixelized source stage; ``vis_pix`` runs
+  only the pixelized stage, loading the ``vis_lp`` result from disk and failing
+  immediately if it is not there. ``--skip_pix`` is still accepted as a
+  deprecated spelling of ``--stage vis_lp``.
 
 Note what is *not* on that list: ``mask_radius``. It is not a command-line
 argument. It is always read from the dataset's ``info.json``, so that the mask
@@ -393,10 +397,19 @@ Delaunay mesh. Because this stage starts from a converged mass model, its
 positional constraint can be tightened using the ``vis_lp`` result, which is
 what keeps the reconstruction physical.
 
-``--skip_pix`` stops after ``vis_lp`` and returns its result. That is not just a
-speed switch: ``scripts/sersic_lens_model.py`` uses it because its Sersic source
+``--stage vis_lp`` stops after ``vis_lp`` and returns its result. That is not just
+a speed switch: ``scripts/sersic_lens_model.py`` uses it because its Sersic source
 prior is seeded from ``galaxies.source.bulge``, and the pixelized fit replaces
 that bulge with a pixelization, leaving nothing to seed from.
+
+``--stage vis_pix`` is the other half of that split: it runs only the pixelized
+stage, loading the completed ``vis_lp`` result from ``output/`` rather than
+re-fitting it, and refusing to start if that result is not there. It exists for
+the CPU route, where the two searches have to run as two separate processes —
+``vis_pix`` wants a multiprocessing pool, and a forked pool cannot be used in a
+process where JAX has already initialised. On GPU, leave ``--stage`` at its
+``all`` default and both searches run in one go. ``--skip_pix`` remains a
+deprecated spelling of ``--stage vis_lp``.
 
 __Pixelized Sources__
 
@@ -568,7 +581,7 @@ full; one line each:
   pixelized Delaunay source (``vis_pix``).
 - ``scripts/sersic_lens_model.py`` — Sersic lens and source fits with the mass
   model fixed to the initial fit, giving the cleaner photometry that SED fitting
-  needs. Chains off ``initial_lens_model`` run with ``--skip_pix``.
+  needs. Chains off ``initial_lens_model`` run with ``--stage vis_lp``.
 - ``scripts/lens_model_waveband.py`` — fits the lower-resolution NIR and EXT
   bands with the VIS lens model held fixed.
 - ``scripts/sersic_lens_model_waveband.py`` — the **SED chain** driver, running
@@ -652,7 +665,7 @@ if __name__ == "__main__":
         iterations_per_quick_update,
         number_of_cores,
         use_cpu,
-        skip_pix,
+        stage,
     ) = util.parse_fit_args()
     fit(
         dataset_name=dataset_name,
@@ -660,5 +673,5 @@ if __name__ == "__main__":
         iterations_per_quick_update=iterations_per_quick_update,
         number_of_cores=number_of_cores,
         use_cpu=use_cpu,
-        skip_pix=skip_pix,
+        stage=stage,
     )

--- a/start_here.py
+++ b/start_here.py
@@ -97,6 +97,10 @@ a GPU, and around 20 minutes on an 8-core CPU. Over a sample of a few thousand
 candidates that difference decides whether the run is a coffee break or a
 cluster allocation.
 
+For SLURM clusters, ``hpc/README.md`` explains how to choose between the
+one-job GPU route and the two-stage CPU route by sample size, and holds the
+submission scripts.
+
 __Running The Pipeline__
 
 Every script in this repository is run from the repository root, and they all
@@ -405,9 +409,7 @@ that bulge with a pixelization, leaving nothing to seed from.
 ``--stage vis_pix`` is the other half of that split: it runs only the pixelized
 stage, loading the completed ``vis_lp`` result from ``output/`` rather than
 re-fitting it, and refusing to start if that result is not there. It exists for
-the CPU route, where the two searches have to run as two separate processes —
-``vis_pix`` wants a multiprocessing pool, and a forked pool cannot be used in a
-process where JAX has already initialised. On GPU, leave ``--stage`` at its
+the CPU route, where ``vis_pix`` wants a multiprocessing pool. The two stages run as separate Python processes. This is a conservative default: PyAutoFit documents an XLA deadlock for a forked worker whose likelihood touches JAX, and the DR1 science runs were submitted this way. A local control test (hpc/diagnostics/jax_fork_control.py) did not reproduce a hang for the CPU route, whose vis_pix likelihood is Numba; production sampler sizes and large pools are untested, so the boundary is kept until a cluster run passes. hpc/README.md has the measured table. On GPU, leave ``--stage`` at its
 ``all`` default and both searches run in one go. ``--skip_pix`` remains a
 deprecated spelling of ``--stage vis_lp``.
 

--- a/start_here.py
+++ b/start_here.py
@@ -473,9 +473,11 @@ compiles it and dispatches it to a GPU if one is available. That is where the
 50x comes from.
 
 ``--use_cpu`` turns JAX off and takes the CPU path. This is not simply "the same
-thing, slower": the pixelized stage applies a **CPU sparse operator** in place of
-the dense GPU-friendly one, because the linear algebra that is fastest dense on
-a GPU is fastest sparse on a CPU. When you pass ``--use_cpu``, pass
+thing, slower": the pixelized stage applies a **CPU sparse operator**, a Numba
+precomputation of the PSF products the inversion needs, because that is the
+fastest way to do this linear algebra on a CPU. It is the CPU route's tool and is
+applied only under ``--use_cpu`` — the JAX path applies no sparse operator and
+fits the plain dataset. When you pass ``--use_cpu``, pass
 ``--number_of_cores`` as well — that is the argument the ``vis_pix`` search uses
 to parallelise across CPU cores.
 

--- a/tests/test_stage_guard.py
+++ b/tests/test_stage_guard.py
@@ -1,0 +1,142 @@
+"""
+The ``--stage`` fail-fast guard in ``scripts/initial_lens_model.py``.
+
+``--stage vis_pix`` exists so the CPU route can run the two searches as two
+processes: ``vis_lp`` with JAX, then ``vis_pix`` with the Numba sparse operator
+and a multiprocessing pool, which a process that has initialised JAX cannot
+fork. The second process must therefore *load* the ``vis_lp`` result rather than
+produce it — and the failure mode that matters is the silent one: with no
+completed ``vis_lp`` on disk, ``search.fit`` would simply run the whole
+light-profile fit again, in the process configured for the pixelized stage, and
+the user would only find out hours later.
+
+So ``fit`` checks ``search.paths.is_complete`` — PyAutoFit's own predicate, the
+``.completed`` marker that ``paths.completed()`` writes, and the same condition
+``AbstractSearch.fit`` short-circuits on — before running ``vis_lp``, and raises
+if it is not set.
+
+These tests run **no search**. The first stops at the guard (that is the whole
+point of a fail-fast guard: it fires before any fitting), and the second never
+gets as far as loading the dataset. They run under the CI test-mode environment
+with ``conf`` and ``output/`` redirected into ``tmp_path``, so nothing is
+written into the repository tree.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+
+import initial_lens_model  # noqa: E402
+
+
+EXAMPLE_SAMPLE = "q1_walsmley"
+EXAMPLE_DATASET = "102018665_NEG570040238507752998"
+
+
+# The environment CI runs the smoke suite under. `fit` reads
+# `PYAUTO_OUTPUT_DIR` and joins it onto the repository root; an absolute path
+# replaces that root outright (pathlib), which is how `output/` is redirected
+# into `tmp_path` here.
+TEST_MODE_ENV = {
+    "PYAUTO_TEST_MODE": "2",
+    "PYAUTO_SKIP_FIT_OUTPUT": "1",
+    "PYAUTO_SKIP_VISUALIZATION": "1",
+    "PYAUTO_SKIP_CHECKS": "1",
+    "PYAUTO_DISABLE_JAX": "1",
+    "JAX_ENABLE_X64": "True",
+}
+
+
+@pytest.fixture
+def isolated_output(monkeypatch, tmp_path):
+    """
+    Run ``fit`` under the CI test-mode environment with its output tree inside
+    ``tmp_path``, then restore the repository's own ``conf`` push — ``fit``
+    pushes ``conf.instance`` and there is no pop, so a later test module in the
+    same session would otherwise inherit ``tmp_path``.
+    """
+    for key, value in TEST_MODE_ENV.items():
+        monkeypatch.setenv(key, value)
+
+    monkeypatch.setenv("PYAUTO_OUTPUT_DIR", str(tmp_path / "output"))
+
+    yield tmp_path
+
+    from autolens import conf
+
+    conf.instance.push(
+        new_path=PROJECT_ROOT / "config", output_path=PROJECT_ROOT / "output"
+    )
+
+
+def test_stage_vis_pix_without_a_completed_vis_lp_fails_fast(isolated_output):
+    with pytest.raises(RuntimeError) as exc_info:
+        initial_lens_model.fit(
+            dataset_name=EXAMPLE_DATASET,
+            sample_name=EXAMPLE_SAMPLE,
+            stage="vis_pix",
+            use_cpu=True,
+        )
+
+    message = str(exc_info.value)
+
+    # The message has to be actionable: the path that was looked for, and the
+    # command that produces it.
+    assert "--stage vis_lp" in message
+    assert "vis_lp" in message
+    assert EXAMPLE_DATASET in message
+    assert EXAMPLE_SAMPLE in message
+
+
+def test_unknown_stage_is_rejected():
+    with pytest.raises(ValueError) as exc_info:
+        initial_lens_model.fit(
+            dataset_name=EXAMPLE_DATASET,
+            sample_name=EXAMPLE_SAMPLE,
+            stage="bogus",
+        )
+
+    assert "bogus" in str(exc_info.value)
+
+
+class _Sentinel(Exception):
+    """Raised in place of loading a dataset, to stop ``fit`` past the guards."""
+
+
+def test_skip_pix_true_still_means_stage_vis_lp(monkeypatch, isolated_output):
+    """
+    ``skip_pix=True`` — the deprecated keyword the chain scripts still pass —
+    is resolved to ``stage="vis_lp"`` *before* the stage is validated, so it
+    overrides whatever ``stage`` holds instead of colliding with it.
+
+    Proven without running a search: the dataset load, the first thing ``fit``
+    does after the guards, is replaced with a sentinel. Reaching it means both
+    guards passed.
+    """
+    import inspect
+
+    import util
+
+    signature = inspect.signature(initial_lens_model.fit)
+
+    assert signature.parameters["stage"].default == "all"
+    assert signature.parameters["skip_pix"].default is None
+
+    def _no_dataset(*args, **kwargs):
+        raise _Sentinel()
+
+    monkeypatch.setattr(util, "load_vis_dataset", _no_dataset)
+
+    with pytest.raises(_Sentinel):
+        initial_lens_model.fit(
+            dataset_name=EXAMPLE_DATASET,
+            sample_name=EXAMPLE_SAMPLE,
+            stage="bogus",
+            skip_pix=True,
+        )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -116,13 +116,13 @@ def test_parse_fit_args_defaults(monkeypatch):
     result = util.parse_fit_args()
 
     assert len(result) == 6
-    sample, dataset, iterations, cores, use_cpu, skip_pix = result
+    sample, dataset, iterations, cores, use_cpu, stage = result
     assert sample is None
     assert dataset == "abc"
     assert iterations == 5000
     assert cores == 1
     assert use_cpu is False
-    assert skip_pix is False
+    assert stage == "all"
 
 
 def test_parse_fit_args_all_flags(monkeypatch):
@@ -136,17 +136,66 @@ def test_parse_fit_args_all_flags(monkeypatch):
             "--iterations_per_quick_update=250",
             "--number_of_cores=8",
             "--use_cpu",
-            "--skip_pix",
+            "--stage=vis_pix",
         ],
     )
 
-    sample, dataset, iterations, cores, use_cpu, skip_pix = util.parse_fit_args()
+    sample, dataset, iterations, cores, use_cpu, stage = util.parse_fit_args()
 
     assert (sample, dataset) == ("xyz", "abc")
     assert (iterations, cores) == (250, 8)
     assert isinstance(iterations, int) and isinstance(cores, int)
     assert use_cpu is True
-    assert skip_pix is True
+    assert stage == "vis_pix"
+
+
+@pytest.mark.parametrize("stage", ["all", "vis_lp", "vis_pix"])
+def test_parse_fit_args_stage_round_trips(monkeypatch, stage):
+    monkeypatch.setattr(sys, "argv", ["prog", "--dataset=abc", "--stage", stage])
+
+    result = util.parse_fit_args()
+
+    assert len(result) == 6
+    assert result[-1] == stage
+
+
+def test_parse_fit_args_rejects_unknown_stage(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["prog", "--dataset=abc", "--stage=bogus"])
+
+    with pytest.raises(SystemExit):
+        util.parse_fit_args()
+
+
+def test_parse_fit_args_skip_pix_is_a_deprecated_alias(monkeypatch, capsys):
+    """
+    ``--skip_pix`` still resolves, to the string ``"vis_lp"``, and says so once
+    on stderr. The tuple stays six elements long.
+    """
+    monkeypatch.setattr(sys, "argv", ["prog", "--dataset=abc", "--skip_pix"])
+
+    result = util.parse_fit_args()
+
+    assert len(result) == 6
+    assert result[-1] == "vis_lp"
+    assert "--skip_pix is deprecated; use --stage vis_lp" in capsys.readouterr().err
+
+
+def test_parse_fit_args_skip_pix_with_matching_stage_is_allowed(monkeypatch):
+    monkeypatch.setattr(
+        sys, "argv", ["prog", "--dataset=abc", "--skip_pix", "--stage=vis_lp"]
+    )
+
+    assert util.parse_fit_args()[-1] == "vis_lp"
+
+
+@pytest.mark.parametrize("stage", ["all", "vis_pix"])
+def test_parse_fit_args_skip_pix_conflicts_with_other_stages(monkeypatch, stage):
+    monkeypatch.setattr(
+        sys, "argv", ["prog", "--dataset=abc", "--skip_pix", f"--stage={stage}"]
+    )
+
+    with pytest.raises(SystemExit):
+        util.parse_fit_args()
 
 
 def test_parse_fit_args_requires_dataset(monkeypatch):

--- a/util.py
+++ b/util.py
@@ -962,10 +962,19 @@ def parse_fit_args():
     Returns
     -------
     (sample_name, dataset_name, iterations_per_quick_update, number_of_cores,
-     use_cpu, skip_pix)
-        ``mask_radius`` is always read from the dataset's ``info.json``.
+     use_cpu, stage)
+        ``stage`` is one of ``"all"``, ``"vis_lp"`` or ``"vis_pix"``, and
+        selects which of the two searches in ``scripts/initial_lens_model.py``
+        the run performs. ``mask_radius`` is always read from the dataset's
+        ``info.json``.
+
+        The tuple's last element used to be the boolean ``skip_pix``.
+        ``--skip_pix`` is still accepted as a deprecated alias for
+        ``--stage vis_lp`` — it emits a deprecation line on stderr and resolves
+        to the string ``"vis_lp"``, so the tuple is still six elements long.
     """
     import argparse
+    import sys
 
     parser = argparse.ArgumentParser(description="PyAutoLens Euclid Pipeline")
     parser.add_argument(
@@ -1002,17 +1011,46 @@ def parse_fit_args():
         help="CPU mode: disables JAX and applies the sparse operator for vis_pix.",
     )
     parser.add_argument(
+        "--stage",
+        metavar="name",
+        required=False,
+        choices=["all", "vis_lp", "vis_pix"],
+        default=None,
+        help=(
+            "Which of the two searches to run: 'all' (default) runs vis_lp and "
+            "then vis_pix in one process; 'vis_lp' runs the MGE light-profile "
+            "fit only and returns its result; 'vis_pix' runs the pixelized "
+            "source fit only, and requires a completed vis_lp result on disk "
+            "(it fails immediately if there is none)."
+        ),
+    )
+    parser.add_argument(
         "--skip_pix",
         action="store_true",
         default=False,
-        help="Skip the pixelization stage and return after the MGE light-profile fit.",
+        help="Deprecated alias for --stage vis_lp.",
     )
     args = parser.parse_args()
+
+    stage = args.stage
+
+    if args.skip_pix:
+        if stage is not None and stage != "vis_lp":
+            parser.error(
+                f"--skip_pix is the deprecated spelling of --stage vis_lp and "
+                f"cannot be combined with --stage {stage}."
+            )
+        print("--skip_pix is deprecated; use --stage vis_lp", file=sys.stderr)
+        stage = "vis_lp"
+
+    if stage is None:
+        stage = "all"
+
     return (
         args.sample,
         args.dataset,
         int(args.iterations_per_quick_update),
         int(args.number_of_cores),
         args.use_cpu,
-        args.skip_pix,
+        stage,
     )


### PR DESCRIPTION
## Summary

Phase 4 of the `euclid-dr1-prep` epic. The DR1 science runs fit `initial_lens_model.py` in two stages — `vis_lp` under JAX, then `vis_pix` with the Numba sparse operator and a forked Nautilus pool — submitted as two separate SLURM jobs so that JAX and `multiprocessing` never share a process. That route existed only in a private science tree. This branch brings it into the public pipeline repo, investigates whether the process boundary is still needed, and documents both routes with measured numbers.

Nine commits:

- **`f3af83b`** — `--stage {all,vis_lp,vis_pix}` in `util.parse_fit_args` and `initial_lens_model.fit`, default `all` so existing callers and CI are unchanged. `--stage vis_pix` fails fast with an error naming the missing output directory and the `--stage vis_lp` command to run first, instead of silently re-fitting `vis_lp` (which could also collide with a `vis_lp` job still running on the same lens). `--skip_pix` kept as a deprecated alias.
- **`2f685bd`** — `hpc/batch_cpu/submit_initial_lens_model_{vis_lp,vis_pix,two_stage}`. The `two_stage` script runs both stages as two consecutive `python3` calls inside one allocation, each with its own `env` block, so the JAX variables set for stage 1 cannot leak into stage 2 — one submission, one queue place, process boundary preserved. `hpc/sync` gains `submit` / `push-submit` / `jobs` / `sacct` / `cancel` / `tail` / `logs` / `wait-and-pull` / `du` / `check`. Personal email and host values scrubbed from the committed scripts and `sync.conf.example`; `activate.sh` now follows the assistant pattern (local `.venv`, else `PYAUTO_HPC_BASE`).
- **`5e6a16e`** — `hpc/diagnostics/jax_fork_control.py`, a measured three-leg control test for the JAX-then-forked-pool question.
- **`2dee505`** — `hpc/README.md` as the single home for route choice; `README.md`, `AGENTS.md` and `start_here.py` point at it.
- **`076101e`** — `hpc/batch_cpu/submit_jax_fork_control`, the control test as a SLURM job, so the pooled legs are measured at the size a production `vis_pix` fit actually forks.
- **`cd0228a`** — every `batch_gpu/` script checks `jax.default_backend()` before it starts. This came out of the acceptance run below.
- **`34fe3fb`** — the measured RAL evidence folded into `hpc/README.md`, and the GPU script's wall raised 2 h → 4 h.
- **`d32d58e`** — the sparse-operator drift below, fixed. `scripts/initial_lens_model.py` no longer applies `apply_sparse_operator()` on the JAX path (the `else:` branch is gone), and `scripts/full_model.py` — a JAX-only script with no `use_cpu` — no longer applies it at all. The operator is the CPU route's Numba tool, applied only under `--use_cpu`; under JAX the pixelized inversion uses JAX's own linear algebra on the plain dataset, which is what the science tree does.
- **`f092efe`** — the GPU route re-measured with that fix in place, and what the re-run does and does not show, folded into `hpc/README.md`.

## Acceptance on RAL

Both routes ran end to end from this repository's own submission scripts, on the committed example lens `q1_walsmley/102018665_NEG570040238507752998`, with `PYAUTO_OUTPUT_DIR` split per route so neither could resume against the other's cache.

| Route | Script | Job | Allocation | `vis_lp` | `vis_pix` | Total | Outcome |
|---|---|---|---|---|---|---|---|
| GPU | `hpc/batch_gpu/submit_initial_lens_model` | 342248_0 | A100 80GB PCIe (`euclid-ral-gpu-2`), 1 core | 30.2 min | 42.4 min | 1 h 14 min | COMPLETED |
| GPU, re-run after `d32d58e` | `hpc/batch_gpu/submit_initial_lens_model` | 342264_0 | A100 80GB PCIe (`euclid-ral-gpu-1`), 1 core | 37.7 min | 63.8 min | 1 h 44 min | COMPLETED |
| Two-stage CPU | `hpc/batch_cpu/submit_initial_lens_model_two_stage` | 342244_0 | `euclid-ral-compute-1`, 8 cores / 8 pool workers | 25.5 min | 2 h 51 min | 3 h 17 min | COMPLETED |

The re-run is the sparse-operator fix measured, and it did not speed the GPU route
up. `vis_lp` never touched the operator and took exactly 15 quick-update blocks in
both runs, so it is a clean node-speed probe: 2.01 min per block against 2.51, a
**25% slower node** on the re-run. `vis_pix` went from 3.26 to 4.55 min per block, a
factor of 1.40; divide out the 1.25 node factor and about 1.12 is left, one run
against one run on a shared cluster. Quick-update cost is unchanged (13.8 s against
13.2 s mean). So `d32d58e` stands as a correctness fix, not a performance fix, and
the gap to the documented ~10 min per lens comes from somewhere else.

The CPU chain's second process logged `Fit Already Completed: skipping non-linear search` for `vis_lp` and went straight to `vis_pix` — the new `--stage vis_pix` guard picking up the cached result rather than re-fitting it.

A first GPU attempt (342243_0) was allocated an A100 in MIG mode with **no instances configured**: `cuInit(0)` failed with `CUDA_ERROR_NO_DEVICE`, JAX fell back to its CPU backend, and the job ran the fit on its single allocated core until the 2 h wall killed it, with `nvidia-smi` reporting a healthy A100 throughout. Commit `cd0228a` is the fix: a GPU job whose JAX backend is CPU now exits within seconds naming the node.

### The reset question: measured, boundary kept

`hpc/diagnostics/jax_fork_control.py`, three legs, two machines — no hang reproduced anywhere:

| Leg | Laptop (WSL2, 4 workers) | RAL `euclid-ral-compute-1` (16 workers, `n_like_max` 2000) |
|---|---|---|
| `control` (JAX likelihood in-process, then a `use_jax=False` pooled Nautilus) | PASS, 265 s | PASS, 216 s |
| `control_real` (the script's own `fit(stage="vis_lp")` then `fit(stage="vis_pix", use_cpu=True)` in one process) | PASS, 494 s | PASS, 378 s |
| `subprocess` (JAX stage in a child of a JAX-free parent) | PASS, 220 s | PASS, 220 s |

PyAutoFit's documented deadlock concerns a forked worker whose *likelihood* touches JAX; the `vis_pix` likelihood under `--use_cpu` is Numba, which is consistent with this. What remains untested is production sampler size (`n_live` 750/300 against 50) and multi-hour walls, so the process boundary stays as the conservative default — it costs nothing with the single-submission chain script — and the single-process route is filed as `PyAutoMind/draft/feature/euclid/single_process_cpu_route_jax_vis_lp_numba_vis_pix.md`. `forkserver`/`spawn` are not an option: PyAutoFit pins `fork` (PyAutoFit#1437).

## Scripts Changed

- `scripts/initial_lens_model.py` — `fit()` takes `stage` (`skip_pix=` kept for back-compat); `--stage vis_pix` checks the `vis_lp` search is complete and raises with the command to run first. The JAX path no longer applies the sparse operator, and the `__Sparse Operator__` block no longer describes `apply_sparse_operator` as "the GPU path".
- `scripts/full_model.py` — the unconditional `apply_sparse_operator()` call and its prose removed; a JAX-only script (no `use_cpu`, `use_jax=True` in all five searches) fits the plain dataset.
- `util.py` — `parse_fit_args` gains `--stage {all,vis_lp,vis_pix}`; `--skip_pix` maps onto it as a deprecated alias.
- `start_here.py` — chain call updated for `stage`; the `__JAX And GPUs__` / `__Running The Pipeline__` prose points at `hpc/README.md`, and the ~10 min figure is now attributed to the DR1 science configuration.
- `scripts/{full_model,lens_model_waveband,mge_lens_only,sersic_lens_model,sersic_lens_model_waveband}.py` — the shared `parse_fit_args` signature change.
- `README.md`, `AGENTS.md`, `scripts/README.md`, `docs/drift_report.md` — route guide cross-references.
- `hpc/README.md` (new) — route table with measured per-lens times, the `--stage` contract, the process-boundary verdict with both machines' control-test rows, the RAL acceptance section, cluster setup, `sync` verbs.
- `hpc/batch_cpu/submit_initial_lens_model_{vis_lp,vis_pix,two_stage}` (new), `hpc/batch_cpu/submit_jax_fork_control` (new), `hpc/batch_cpu/{submit_initial_lens_model,template}`, `hpc/batch_gpu/{submit_initial_lens_model,submit_full_model,submit_sersic_waveband}` — the two routes, the backend guard, the 4 h GPU wall.
- `hpc/diagnostics/jax_fork_control.py` (new) — the control test; registered in `config/build/no_run.yaml` so a discovery mega-run does not execute it.
- `hpc/sync`, `hpc/sync.conf.example`, `activate.sh` — richer verbs, personal values scrubbed.
- `tests/test_stage_guard.py` (new), `tests/test_util.py` — the `--stage` mapping and the fail-fast guard.

## Test Plan

- [x] `pytest tests/` — 72 passed
- [x] Smoke suite — 9/9 PASS (`scripts/simulator.py`, `start_here.py`, `initial_lens_model.py`, `full_model.py`, `lens_model_waveband.py`, `mge_lens_only.py`, `sersic_lens_model.py`, `sersic_lens_model_waveband.py`, `tools/diagnose_latent.py`)
- [x] Both HPC routes COMPLETED on RAL, plus the post-fix GPU re-run (table above)

## Flags for review

1. **Timing discrepancy, still open.** `README.md` and `start_here.py` quote ~10 min per lens on a GPU and ~20 min on an 8-core CPU. Measured with the committed `config/`: 1 h 14 min to 1 h 44 min and 3 h 17 min. Quick updates every ~2.5 min at ~14 s each are only about 10% overhead, and the sparse-operator drift below turned out not to explain it either, so the ~7x gap is still unaccounted for. This branch attributes the claim to the DR1 science configuration rather than silently keeping or deleting it, and the investigation stays filed as `PyAutoMind/draft/bug/euclid/gpu_per_lens_time_vs_documented_10_min.md`, re-scoped to the remaining candidates (the science `config/`, per-sample latent JIT, visualisation, or a claim made for a different lens or setting).
2. **Sparse-operator drift — fixed in `d32d58e`.** `scripts/initial_lens_model.py` applied `dataset.apply_sparse_operator()` on the JAX path (the `else:` branch) where the science tree's copy has no `else`, and `scripts/full_model.py:611` applied it unconditionally. Both are corrected; the re-measurement above is the evidence, and it shows the drift was a correctness problem rather than the source of the slowness.
3. **Oversubscription documented, not fixed.** The single-process Numba-only script `hpc/batch_cpu/submit_initial_lens_model` still gives `vis_pix` workers full BLAS thread counts; its header says so rather than silently changing behaviour.

## Readiness

Heart is **RED** at ship time, for reasons unrelated to this repository — verbatim: `PyAutoLens: CI failure`, `release validation FAILED (stage integrate)`, `PyAutoArray: open PR 11d old`. This is a workspace-only change with no library dependency and no upstream PR, so it carries no `pending-release` label and no library-first gate. PR opened, **not merged** — merge is a human decision.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7wa7a5M5kmFRREAWg7Wi3

