### PR TITLE
fix: pass the interior vertex count as the vis_pix Delaunay `pixels`

### DIFF
--- a/hpc/diagnostics/jax_fork_control.py
+++ b/hpc/diagnostics/jax_fork_control.py
@@ -429,7 +429,7 @@ def pooled_pix_fit(dataset: str, sample: str, output_path: Path, cores: int, n_l
                 pixelization=af.Model(
                     al.Pixelization,
                     mesh=al.mesh.Delaunay(
-                        pixels=image_plane_mesh_grid.shape[0],
+                        pixels=HILBERT_PIXELS,
                         zeroed_pixels=EDGE_PIXELS_TOTAL,
                     ),
                     regularization=al.reg.AdaptSplit,

--- a/scripts/full_model.py
+++ b/scripts/full_model.py
@@ -782,7 +782,7 @@ def fit(
         analysis=analysis,
         source_lp_result=source_lp_result,
         mesh_init=al.mesh.Delaunay(
-            pixels=image_plane_mesh_grid.shape[0],
+            pixels=image_plane_mesh_grid.shape[0] - edge_pixels_total,
             zeroed_pixels=edge_pixels_total,
         ),
         regularization_init=al.reg.AdaptSplit,
@@ -859,7 +859,7 @@ def fit(
         source_lp_result=source_lp_result,
         source_pix_result_1=source_pix_result_1,
         mesh=al.mesh.Delaunay(
-            pixels=image_plane_mesh_grid.shape[0],
+            pixels=hilbert_pixels,
             zeroed_pixels=edge_pixels_total,
         ),
         regularization=al.reg.AdaptSplit,

--- a/scripts/initial_lens_model.py
+++ b/scripts/initial_lens_model.py
@@ -588,7 +588,7 @@ def fit(
                 pixelization=af.Model(
                     al.Pixelization,
                     mesh=al.mesh.Delaunay(
-                        pixels=image_plane_mesh_grid.shape[0],
+                        pixels=hilbert_pixels,
                         zeroed_pixels=edge_pixels_total,
                     ),
                     regularization=al.reg.AdaptSplit,

--- a/tests/test_delaunay_edge_ring.py
+++ b/tests/test_delaunay_edge_ring.py
@@ -1,0 +1,106 @@
+"""
+The ``vis_pix`` Delaunay edge ring is really zeroed.
+
+``scripts/initial_lens_model.py`` and ``scripts/full_model.py`` append a ring of
+``edge_pixels_total`` points just outside the mask edge and hold their reconstructed
+values at zero through ``zeroed_pixels`` on the ``Delaunay`` mesh. Until 2026-09 the
+scripts passed the *appended* grid length as ``pixels`` while the mesh added
+``zeroed_pixels`` on top, so ``mesh.pixels`` overstated the parameter count by the
+ring size (PyAutoArray#526). This module mirrors the scripts' construction on a
+small grid and asserts the zeroed indices are exactly the appended ring, inside the
+grid, and that the counts the scripts pass add up to the grid they build.
+
+Deliberately **JAX-free** and fit-free: it exercises the mesh-grid construction and
+the mesh's index arithmetic only.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+import autolens as al  # noqa: E402
+
+EDGE_PIXELS_TOTAL = 30
+MASK_RADIUS = 1.5
+PIXEL_SCALE = 0.1
+
+
+def _appended_grid():
+    """
+    The ``full_model.py`` SOURCE PIX 1 construction: a uniform ``Overlay`` grid clipped
+    to a circular mask, then ``append_with_circle_edge_points`` at ``mask_radius`` plus
+    half a pixel. Returns the interior grid and the appended grid.
+    """
+    mask = al.Mask2D.circular(
+        shape_native=(40, 40), pixel_scales=PIXEL_SCALE, radius=MASK_RADIUS
+    )
+
+    image_plane_mesh_grid = al.image_mesh.Overlay(shape=(10, 10)).image_plane_mesh_grid_from(
+        mask=mask
+    )
+
+    appended = al.image_mesh.append_with_circle_edge_points(
+        image_plane_mesh_grid=image_plane_mesh_grid,
+        centre=mask.mask_centre,
+        radius=MASK_RADIUS + mask.pixel_scale / 2.0,
+        n_points=EDGE_PIXELS_TOTAL,
+    )
+
+    return image_plane_mesh_grid, appended
+
+
+def test__appended_ring__is_the_last_edge_pixels_total_points_of_the_grid():
+    interior, appended = _appended_grid()
+
+    assert appended.shape[0] == interior.shape[0] + EDGE_PIXELS_TOTAL
+    assert np.allclose(np.asarray(appended)[: interior.shape[0]], np.asarray(interior))
+
+    ring = np.asarray(appended)[interior.shape[0] :]
+    radii = np.hypot(ring[:, 0], ring[:, 1])
+
+    assert np.allclose(radii, MASK_RADIUS + PIXEL_SCALE / 2.0)
+
+
+def test__mesh_built_as_the_scripts_build_it__zeroes_exactly_the_ring():
+    """
+    ``pixels`` is the interior count (``hilbert_pixels`` in ``initial_lens_model.py``,
+    ``image_plane_mesh_grid.shape[0] - edge_pixels_total`` in ``full_model.py``). The
+    zeroed indices the inversion will use are the mesh's ``zeroed_pixels_from`` at the
+    appended grid's length: the ring, and nothing else.
+    """
+    interior, appended = _appended_grid()
+
+    mesh = al.mesh.Delaunay(
+        pixels=appended.shape[0] - EDGE_PIXELS_TOTAL, zeroed_pixels=EDGE_PIXELS_TOTAL
+    )
+
+    assert mesh.pixels == interior.shape[0]
+    assert mesh.zeroed_pixels == EDGE_PIXELS_TOTAL
+    assert mesh.total_pixels == appended.shape[0]
+
+    zeroed = mesh.zeroed_pixels_from(pixels=appended.shape[0])
+
+    assert zeroed.shape == (EDGE_PIXELS_TOTAL,)
+    assert zeroed.min() == interior.shape[0]
+    assert zeroed.max() == appended.shape[0] - 1
+    assert (zeroed == np.arange(interior.shape[0], appended.shape[0])).all()
+
+
+def test__ring_is_zeroed_whatever_pixels_the_mesh_was_told():
+    """
+    The regression: the pre-fix form passed the appended length as ``pixels``. The
+    ring is resolved against the grid the mapper receives, so both forms zero the same
+    vertices — the archived ``vis_pix`` results (one mapper) were not affected.
+    """
+    interior, appended = _appended_grid()
+
+    expected = np.arange(interior.shape[0], appended.shape[0])
+
+    for pixels in (interior.shape[0], appended.shape[0]):
+        mesh = al.mesh.Delaunay(pixels=pixels, zeroed_pixels=EDGE_PIXELS_TOTAL)
+
+        assert (mesh.zeroed_pixels_from(pixels=appended.shape[0]) == expected).all()


### PR DESCRIPTION
## Summary

Workspace leg of PyAutoLabs/PyAutoArray#526 (`draft/bug/euclid/delaunay_edge_ring_never_zeroed.md`).

`scripts/initial_lens_model.py`, both Delaunay stages of `scripts/full_model.py` and `hpc/diagnostics/jax_fork_control.py` passed the appended grid length as `pixels` while `zeroed_pixels` was added on top, so `mesh.pixels` overstated the mapper's parameter count by the 30-point ring. They now pass the interior count: `hilbert_pixels` for the Hilbert stages, `image_plane_mesh_grid.shape[0] - edge_pixels_total` for the uniform SOURCE PIX 1 grid.

The ring itself was zeroed all along on these single-mapper fits (the over-count cancels in `zeroed_ids_to_keep`), and the library now resolves it against the mapper's real grid, so **no archived `vis_pix` result changes** and Cortex phase 4's numerics witness is unaffected.

## Upstream PR

- PyAutoLabs/PyAutoArray — the library fix (this PR's CI checks the library chain out at the same-named branch, `claude/delaunay-edge-ring-zeroed-8l4u1z`). Library-first: merge that before this.

## Scripts Changed

- `scripts/initial_lens_model.py` — `pixels=hilbert_pixels`
- `scripts/full_model.py` — SOURCE PIX 1 `pixels=image_plane_mesh_grid.shape[0] - edge_pixels_total`; SOURCE PIX 2 `pixels=hilbert_pixels`
- `hpc/diagnostics/jax_fork_control.py` — `pixels=HILBERT_PIXELS`
- `tests/test_delaunay_edge_ring.py` (new) — mirrors the scripts' mesh construction on a small grid and asserts the zeroed indices are exactly the appended ring, inside the grid, under both call forms

## Test Plan

- [x] `pytest tests/ -m "not slow"` — 74 passed (with the PyAutoArray branch installed)
- [ ] CI `unit` job

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCQK1pjQx7YH5e9dtWrX76

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCQK1pjQx7YH5e9dtWrX76)_