### PR TITLE
fix: bound vis_lp source MGE ell_comps inside the unit disk

### DIFF
--- a/scripts/initial_lens_model.py
+++ b/scripts/initial_lens_model.py
@@ -199,6 +199,29 @@ def fit(
         centre=d.dataset_centre,
     )
 
+    # Bound the source ell_comps to [-0.7, 0.7] per component: 0.7^2 + 0.7^2 =
+    # 0.98 < 1, the largest axis-aligned box inside the unit disk, so |e| >= 1
+    # (which raises ModelParameterException at instance construction) is
+    # unreachable by construction. On-axis this still admits q down to ~0.18.
+    # This is not the lens cap's reasoning: [-0.5, 0.5] above is a lens-light
+    # systematic (multi-blob MGE absorbing source flux), whereas this is pure
+    # geometry (unit-disk validity) and so keeps nearly all of the range the
+    # library default meant to offer. That default box is [-1, 1] per component
+    # with its corner at |e| = sqrt(2) — 21.5% of the box is unphysical — which
+    # killed RAL 342301 task 3 at its first quick update (PyAutoFit#1567).
+    #
+    # gaussian_per_basis defaults to 1, so this is one basis of 20 gaussians
+    # sharing a single ell_comps prior pair; reassign one fresh pair to keep it.
+    source_ell_0 = af.TruncatedGaussianPrior(
+        mean=0.0, sigma=0.3, lower_limit=-0.7, upper_limit=0.7
+    )
+    source_ell_1 = af.TruncatedGaussianPrior(
+        mean=0.0, sigma=0.3, lower_limit=-0.7, upper_limit=0.7
+    )
+    for g in source_bulge.profile_list:
+        g.ell_comps.ell_comps_0 = source_ell_0
+        g.ell_comps.ell_comps_1 = source_ell_1
+
     model = af.Collection(
         galaxies=af.Collection(
             lens=af.Model(


### PR DESCRIPTION
## Summary
Bound the `vis_lp` source MGE `ell_comps` priors to `[-0.7, 0.7]` per component so the sampled box lies inside the unit disk by construction. RAL array 342301 task 3 died at its first quick update because the source basis kept the library default `[-1, 1]` box, whose corner is at |e| = √2 (21.5 % of the box is unphysical); the running max-likelihood vector landed at magnitude 1.009 and `ModelParameterException` killed the run (PyAutoLabs/PyAutoFit#1567).

This is the pipeline leg of a two-leg fix. The library leg (PyAutoFit, same issue) guards the quick-update hook so an unphysical max-likelihood vector logs a skip instead of terminating the search. Nautilus has no clipper/bijector hook, so the opt-in `ClipperPriorBoxJoint` projection from PyAutoFit#1538 is not available here; a prior-bound change is the pipeline's lever.

Why `±0.7` and not the lens block's `±0.5`: the lens cap is a lens-light systematic (multi-blob MGE absorbing source flux); the source cap is geometry (unit-disk validity) and keeps nearly all of the range the library default meant to offer (on-axis q down to ≈0.18).

## Scripts Changed
- `scripts/initial_lens_model.py` — after `source_bulge = al.model_util.mge_model_from(...)`, one fresh `TruncatedGaussianPrior(mean=0, sigma=0.3, lower=-0.7, upper=0.7)` pair is shared across all 20 source Gaussians (free ell parameter count unchanged at 2). `vis_pix` builds no MGE with default priors; untouched.

## Test Plan
- [x] The edited lines executed against a stub dataset descriptor: 20 Gaussians, exactly one shared prior object per component, limits `(-0.7, 0.7)`, corner |e| = 0.99 < 1.
- [x] `python -m py_compile scripts/initial_lens_model.py`.
- [ ] Cortex follow-up (not this PR): relaunch RAL 342301 task 3 (`Tile102007903RA0668831429074DECNEG0648901814905`) after both PRs merge and `HPCPullPyAuto` syncs.

## Related
- Library PR: PyAutoLabs/PyAutoFit#1568 (merge first)
- Issue: PyAutoLabs/PyAutoFit#1567
- Channel map: PyAutoFit#1487 closed the results-write channel; PyAutoFit#1538 / PyAutoGalaxy#589 shipped the opt-in gradient-lane disk projection; #1567 closes the quick-update channel.

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5K4AXFBYMCPhbNFYA24YX
