### PR TITLE
docs: decision note on the two-fold label degeneracy in the vis_lp lens-light MGE (#54)

### DIFF
--- a/docs/mge_label_degeneracy.md
+++ b/docs/mge_label_degeneracy.md
@@ -152,7 +152,8 @@ can enforce it under JAX. The pipeline should apply it locally first.
    actually separates "ordered" from "one mode found".
 4. **PyAutoGalaxy.** Add an ordering option to `mge_model_from` for `gaussian_per_basis > 1`, so
    every user gets the fix rather than this pipeline alone.
-5. **Meanwhile.** Apply (d) in the results layer, for runs already on disk and for reporting.
+5. **Meanwhile.** Nothing. Decision 2026-09-08: the tiles will be rerun from scratch once (1)
+   and (2) land, which also gives the speed comparison, so (d) is not implemented.
 
 ## 6. Interim guidance for reading current results
 

--- a/docs/mge_label_degeneracy.md
+++ b/docs/mge_label_degeneracy.md
@@ -1,0 +1,215 @@
+# The Two-Fold Label Degeneracy in the Euclid Lens-Light MGE
+
+- **Date**: 2026-09-08
+- **Issue**: [#54](https://github.com/PyAutoLabs/euclid_strong_lens_modeling_pipeline/issues/54)
+- **Status**: recommendation, awaiting a human decision
+- **Scope**: research note. No code changed on this branch; it records the mechanism, the
+  measurements that establish it, and the option matrix a future session should implement from.
+
+## 1. Symptom and evidence
+
+Comparing the May run of the DR1 tiles (the `euclid` project, RAL job 306843) against the
+September run (`euclid_dr1_prelim`, RAL job 342301) on byte-identical data, 6 of the 8
+well-determined tiles show the two lens-light MGE sets exchanged. Tile 102005065 is the clearest
+case: set A's position angle moves from 0 to 90 degrees and set B's from 90 to 0. In every tile
+the *unordered pair* of ellipticities is conserved, and the mass ell_comps, the centres, the
+Einstein radii and the log evidence are unchanged. Read one set at a time, this looks like a sign
+flip or a genuine change in the inferred lens light. It is neither.
+
+A session scratch script (Appendix A) reproduced the underlying symmetry directly, on the real
+shipped example tile `q1_walsmley/102018665_NEG570040238507752998`. Building the exact model
+`scripts/initial_lens_model.py:162-236` composes, then evaluating the analysis at random points in
+the prior box and again with the two sets' ell_comps swapped, the log likelihood is unchanged:
+differences of 0.0, 1.8e-12 and 0.0 on the NumPy backend and exactly 0.0 on all three JAX
+evaluations. The 1.8e-12 is floating-point summation order, not a real difference.
+
+## 2. Mechanism
+
+The lens light is `al.model_util.mge_model_from(..., total_gaussians=20, gaussian_per_basis=2)`
+(`scripts/initial_lens_model.py:162-168`), giving a Basis of 40 linear Gaussians as two sets of
+20. Three properties make the two sets exchangeable:
+
+1. **The sigma ladders are identical, value for value.** `mge_model_from` computes one
+   `log10_sigma_list` before the basis loop
+   (`PyAutoGalaxy/autogalaxy/analysis/model_util.py:119`) and reuses it for every basis, so both
+   sets run from 1e-4 to the mask radius over the same 20 values. The demo confirms
+   `set A sigma ladder == set B sigma ladder: True`, with a first sigma of 1e-4 and a last of 3.5
+   in both. These are `af.Constant`, not priors, so they contribute no non-linear parameters and
+   cannot distinguish the sets.
+2. **The ell_comps priors are identically distributed and independent.**
+   `_make_ell_comps_priors()` (`model_util.py:146-172`) is called once per basis, so each set gets
+   its own prior pair drawn from the same distribution. The pipeline then replaces both pairs with
+   its own tighter `TruncatedGaussianPrior(mean=0.0, sigma=0.3, lower_limit=-0.5, upper_limit=0.5)`
+   in the loop at `scripts/initial_lens_model.py:179-189`, preserving that structure exactly. The
+   demo shows four distinct prior ids, two per set, each shared across 20 Gaussians.
+3. **The centre is shared and the intensities are linear.** Both sets sit at the same centre, and
+   the 40 intensities are solved jointly at every likelihood evaluation rather than sampled.
+
+Swapping the two sets' ell_comps therefore permutes columns of the linear design matrix. The
+column set is unchanged, so the solved intensities are the same values in permuted order and the
+model image is bit-identical. This is an exact symmetry of the likelihood, not an approximate one,
+and the prior is symmetric under the same swap. The posterior consequently has two exactly equal
+modes. `af.Nautilus` is constructed without a `seed` (`scripts/initial_lens_model.py:266-272`;
+`seed` defaults to `None` at `PyAutoFit/autofit/non_linear/search/nest/nautilus/search.py:103`),
+so which set lands in which mode is a coin flip per run.
+
+## 3. What it does and does not affect
+
+**Affected.** The per-set marginal posteriors are two-mode mixtures. A single set's position angle
+or ellipticity from an unordered run is therefore not a citable quantity; only the unordered pair
+is. Unseeded reruns are not reproducible at the parameter level, even with identical data and
+identical library versions.
+
+**Not affected.** The fit quality is identical by construction. `vis_pix` freezes the `vis_lp`
+maximum-likelihood lens light as an instance (`scripts/initial_lens_model.py:603-604`, explained
+at `:559-566`), so the downstream fit sees the same 40 Gaussians with the same intensities
+whichever labelling won; only the frozen numbers, and any identifier that hashes them, differ.
+Mass ell_comps, centres, Einstein radii and log evidence are unaffected, which is exactly what the
+May/September comparison found.
+
+**The log evidence is a weak diagnostic here.** Imposing an ordering halves the prior volume but
+renormalises over that half, so an ordered model has the same log Z as an unordered one whose
+sampler visited both modes. A run that visited only one mode is low by ln 2 = 0.69. The prompt's
+witness accepts log Z within 1.0 of the 9492.7 baseline, so it cannot distinguish "both modes
+found" from "one mode found". The witness should therefore also compare the **per-set marginal
+widths**: a bimodal marginal is visibly wide, and it collapsing is the sharper evidence that the
+symmetry is gone.
+
+## 4. Options
+
+| | exact? | fit quality | run time | log Z | vis_pix propagation | identifier | reproducibility | belongs |
+|---|---|---|---|---|---|---|---|---|
+| (a) ordering assertion | yes | unchanged | ~unchanged | unchanged | frozen values now canonical | changes | full | pipeline after the PyAutoFit fix, library later |
+| (b) different sigma ladders | no (offset) / model change (split) | changed | changed | changed | changed | changes | partial | rejected |
+| (c) explicit Nautilus seed | no | unchanged | unchanged | unchanged | unchanged | changes | run-to-run only | pipeline, with (a) |
+| (d) post-hoc relabelling | yes, at read time | unchanged | none | unchanged | unchanged | none | reporting only | results layer |
+
+**(a) Ordering assertion.** After the `af.Collection` is composed, attach
+`model.add_assertion((eA0**2 + eA1**2) > (eB0**2 + eB1**2))`, following the precedent at
+`autolens_workspace/scripts/guides/modeling/cookbook.py:311-317`. This removes the symmetry
+exactly, leaves the likelihood untouched, and should cost little run time: half the prior volume
+is rejected and the rejected region is a smooth half-space that Nautilus's bounds learn quickly.
+The demo confirms it attaches cleanly, with `prior_count` still 15 and one assertion on the model.
+
+**It cannot run on this pipeline's JAX path today.** `Fitness.call`
+(`PyAutoFit/autofit/non_linear/fitness.py:380-394`) catches `exc.FitException` and returns the
+resample sentinel only on the NumPy branch; the JAX branch has no such `except`. The demo shows
+all three behaviours: NumPy returns -1e+99 for a violating vector; the non-vmapped JAX `Fitness`
+lets `FitException` escape from `check_assertions`
+(`PyAutoFit/autofit/mapper/prior_model/abstract.py:193-226`, reached from
+`instance_for_arguments` at `:1600-1628`), which would kill the run at the first violating sample;
+and the vmapped `Fitness` that Nautilus actually builds (`use_jax_vmap=True` by default,
+`nautilus/search.py:116, 242-256`) raises `jax.errors.TracerBoolConversionError` at trace time for
+satisfying and violating vectors alike, so the assertion cannot even compile. Option (a) is
+therefore gated on a PyAutoFit change: evaluate `_assertions` with the array module inside the
+traced path and fold the result into the log likelihood with `xp.where` onto the resample
+sentinel, rather than raising. That is precisely the penalty term the traced sibling
+`__model_constraint__` anticipates in its module docstring
+(`PyAutoFit/autofit/mapper/prior_model/constraint.py`), whose non-negative violation measure is
+consumed today only by diagnostic counters. Until then (a) works only under `--use_cpu`.
+
+A sibling variant, (a') reparametrising instead of rejecting (for example `eB1 = eA1 - delta` with
+`delta` positive), is rejected: it distorts set B's prior, can push B outside the +/-0.5 box the
+pipeline deliberately imposes, and changes the evidence.
+
+**(b) Different sigma ladders.** Offset or interleaved ladders over the same radial range leave
+the two sets near-exchangeable: the degeneracy becomes approximate rather than exact, which is
+worse than either extreme, because two near-equal modes still split the posterior but no longer
+cancel cleanly. Radially split ladders (one set inner, one outer) do break it, but they change the
+physics, allowing an isophote twist with radius that the current model forbids, and they change
+the evidence. That is a model change, not a degeneracy fix. Rejected.
+
+**(c) Explicit seed.** Pass `seed=<int>` to `af.Nautilus` at
+`scripts/initial_lens_model.py:266-272`. Note that the prompt's suggested location,
+`config/non_linear/nest.yaml`, does not exist: the pipeline's `config/non_linear/` holds only
+`GridSearch.yaml`, and there is no `nest.yaml` anywhere in PyAutoFit. `seed` is a search
+identifier field (`nautilus/search.py:84`), so setting it changes the run identifier. It buys
+reproducibility only; the posterior stays bimodal and any library or data change can still flip
+the labelling. Cheap, and worth applying in the same edit as (a).
+
+**(d) Post-hoc canonical relabelling.** Order the two sets by ellipticity magnitude wherever
+results are read (results layer, aggregator, CSV export). This fixes the reading of runs already
+on disk, changes nothing about the sampler, the evidence or the identifier, and requires no rerun.
+It does not remove the bimodality, so per-set marginal *widths* stay inflated even though the
+reported point estimates become stable.
+
+**Placement.** The symmetry is created by `mge_model_from` for every user who passes
+`gaussian_per_basis > 1` (`PyAutoGalaxy/autogalaxy/analysis/model_util.py:7`), not by anything
+specific to this pipeline. The ordering therefore belongs upstream as an option, once PyAutoFit
+can enforce it under JAX. The pipeline should apply it locally first.
+
+## 5. Recommendation and rollout
+
+1. **PyAutoFit.** Make assertions traceable: evaluate them with the array module inside
+   `Fitness.call`'s JAX branch and fold the violation into the log likelihood via `xp.where` onto
+   the resample sentinel, with a test that pins the vmapped path. This is the blocking step.
+2. **Pipeline.** Add the ordering assertion and an explicit `seed` to the `vis_lp` search in
+   `scripts/initial_lens_model.py`. Both change the run identifier and so force fresh runs; land
+   them **between phases only**. `euclid_dr1_prelim` phase 4 is live on RAL as of this note.
+3. **Witness.** Two independent unseeded `vis_lp` runs on tile 102005065 must give set-A and set-B
+   ell_comps agreeing run-to-run to 0.05 per component, with log Z within 1.0 of the 9492.7
+   baseline, **plus** the per-set marginal-width check from section 3, which is the part that
+   actually separates "ordered" from "one mode found".
+4. **PyAutoGalaxy.** Add an ordering option to `mge_model_from` for `gaussian_per_basis > 1`, so
+   every user gets the fix rather than this pipeline alone.
+5. **Meanwhile.** Apply (d) in the results layer, for runs already on disk and for reporting.
+
+## 6. Interim guidance for reading current results
+
+Compare the **unordered pair** of ellipticities between runs; it is conserved. Never cite one
+set's position angle or ellipticity from an unordered run, and do not report a change in one set
+between two runs as a physical result without first checking whether the pair as a whole moved.
+The mass model, the source, the centres, the Einstein radii and the log evidence are unaffected
+and can be read as usual.
+
+## Appendix A: demo summary
+
+Produced by a session scratch script (not committed; it composes the model exactly as
+`scripts/initial_lens_model.py:162-236` does, evaluates the analysis on the shipped example tile
+with and without the sets swapped, and exercises the three `Fitness` paths). Verbatim:
+
+```
+=== SUMMARY ===
+dataset                  : real shipped Euclid VIS example q1_walsmley/102018665_NEG570040238507752998, (100, 100) native, 3852 masked pixels, pixel_scales=(0.1, 0.1), mask_radius=3.5, dataset_centre=(0.0, 0.0)
+prior_count before/after : 15 / 15
+assertions on model      : 1
+swap diff (numpy, x3)    : [0.0, 1.8189894035458565e-12, 0.0]
+swap diff (jax,   x3)    : [0.0, 0.0, 0.0]
+numpy  violating         : -1e+99
+numpy  satisfying        : array(15581.54895082)
+jax    violating         : 'RAISED FitException'
+jax    satisfying        : 'RETURNED Array(15581.54895082, dtype=float64)'
+jax/vmap violating       : 'RAISED TracerBoolConversionError'
+jax/vmap satisfying      : 'RAISED TracerBoolConversionError'
+versions                 : af=2026.8.17.1 ag=2026.8.17.1 al=2026.8.17.1
+=== END SUMMARY ===
+```
+
+The run also recorded `general.test.exception_override = False`, which matters because assertions
+are skipped entirely when it is True.
+
+## Appendix B: code references
+
+- `scripts/initial_lens_model.py:162-236` - `vis_lp` model composition; the lens MGE is 2 sets of
+  20, with the +/-0.5 ell_comps prior loop at `:179-189`.
+- `scripts/initial_lens_model.py:266-272` - `af.Nautilus(name="vis_lp", ..., n_live=750, ...)`, no
+  `seed`.
+- `scripts/initial_lens_model.py:603-604` - `vis_pix` freezes the `vis_lp` maximum-likelihood lens
+  light as an instance; prose at `:559-566`.
+- `PyAutoGalaxy/autogalaxy/analysis/model_util.py:7` - `mge_model_from`; the shared
+  `log10_sigma_list` at `:119`, the per-basis `_make_ell_comps_priors()` at `:146-172`.
+- `PyAutoFit/autofit/non_linear/fitness.py:380-394` - `Fitness.call`; the JAX branch has no
+  `except exc.FitException`.
+- `PyAutoFit/autofit/mapper/prior_model/abstract.py:193-226` - `check_assertions`, which raises
+  `FitException`; `:1600-1628` - `instance_for_arguments`, which calls it unless
+  `exception_override` or `ignore_assertions`.
+- `PyAutoFit/autofit/non_linear/search/nest/nautilus/search.py:116, 242-256` - Nautilus builds
+  `Fitness` with `use_jax_vmap=True` by default; `:84, 103` - `seed` as a search kwarg and
+  identifier field.
+- `PyAutoFit/autofit/non_linear/paths/abstract.py:274-292` - the run identifier hashes the search
+  and the model together.
+- `PyAutoFit/autofit/mapper/prior_model/constraint.py` - `__model_constraint__`, the traced
+  per-class non-negative violation measure; consumed today by diagnostic counters, with the module
+  docstring anticipating the penalty term step 1 above needs.
+- `autolens_workspace/scripts/guides/modeling/cookbook.py:311-317` - the ordering-assertion
+  precedent.


### PR DESCRIPTION
## Summary
Research note for #54. The vis_lp lens-light MGE is two sets of 20 linear Gaussians with identical sigma ladders, a shared centre and identically distributed `ell_comps` priors, so swapping the two sets' ellipticities is an exact label symmetry; unseeded Nautilus runs pick either labelling at random (6/8 well-determined DR1 tiles swapped between jobs 306843 and 342301). The note pins the mechanism on the shipped tile 102018665 (swap difference 0.0 on JAX, 1.8e-12 on NumPy), scores the four candidate fixes, and recommends an ordering assertion on the two sets' ellipticity magnitudes plus an explicit Nautilus seed.

The decisive finding: on the JAX path the pipeline runs, `add_assertion` cannot be used today. A non-vmapped JAX `Fitness` lets the `FitException` propagate uncaught (run dies on the first violating sample) and the vmapped `Fitness` Nautilus actually builds raises a tracer-conversion error at trace time for satisfying and violating vectors alike. So the fix is gated on PyAutoFit evaluating assertions as a traced penalty. Post-hoc canonical relabelling is the interim measure for runs already on disk. Follow-ups are filed in `PyAutoMind/ideas.md`; the witness (two unseeded vis_lp runs on tile 102005065) belongs to the implementation follow-up, not this note.

## Scripts Changed
- `docs/mge_label_degeneracy.md` — new decision note (no script, config or notebook changes)

## Test Plan
- [x] Docs-only change; no workspace script touched, so no smoke run applies
- [x] `pytest tests/test_repo_invariants.py` green in the task worktree

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RALRY9yekWDTtbVfok64a
