### PR TITLE
hpc/sync: honour PYAUTO_PULL_DIRS from the caller

### DIFF
--- a/hpc/sync
+++ b/hpc/sync
@@ -111,6 +111,20 @@ LOG_DIRS=(
 # A directory that does not exist on the HPC is skipped rather than failing.
 PULL_DIRS=(output output_sed inspect)
 
+# Extra roots the caller asks for, space-separated — the Cortex check-in passes
+# the `output*` roots its tasks declare, so a run written to a custom
+# PYAUTO_OUTPUT_DIR is pulled without this list being edited by hand. The
+# expansion is deliberately unquoted: word-splitting is how the list is parsed,
+# which is why only `output*` names are ever passed. Appended, never replacing —
+# this project's own roots always pull, and an unset variable leaves the pull
+# exactly as it was.
+if [[ -n "${PYAUTO_PULL_DIRS:-}" ]]; then
+    for _extra in ${PYAUTO_PULL_DIRS}; do
+        [[ " ${PULL_DIRS[*]} " == *" ${_extra} "* ]] || PULL_DIRS+=("${_extra}")
+    done
+    unset _extra
+fi
+
 # ---------------------------------------------------------------------------
 # rsync options
 #   -a          archive (timestamps, permissions, symlinks)

--- a/hpc/sync.conf.example
+++ b/hpc/sync.conf.example
@@ -29,3 +29,11 @@ HPC_BASE=/path/to/large/storage/your_username
 # Name of this project's directory on the HPC, underneath $HPC_BASE.
 # Defaults to the name of your local project folder if left unset.
 PROJECT_NAME=euclid_strong_lens_modeling_pipeline
+
+# Extra output roots to pull, space-separated. The Cortex check-in sets this for
+# you from the `output*` folders your tasks declare, so a run pointed at a custom
+# PYAUTO_OUTPUT_DIR comes down without PULL_DIRS being edited by hand:
+#   PYAUTO_PULL_DIRS="output_ordered_witness" hpc/sync pull
+# Appended to this project's own PULL_DIRS, never replacing them. Leave it unset
+# for the ordinary pull.
+# PYAUTO_PULL_DIRS=


### PR DESCRIPTION
## The bug

`hpc/sync` hard-codes `PULL_DIRS=(output output_sed inspect)`, and both `pull`
and `pull-full` iterate that same array — so a run written to a custom
`PYAUTO_OUTPUT_DIR` is never fetched. On 2026-09-09, 173 MB of
`euclid_dr1_prelim` ordered-MGE results sat unpulled on RAL and the Cortex
check-in reported those tasks as FAILED.

## The fix

The Cortex check-in (PyAutoLabs/PyAutoBrain#372/#373) derives the `output*`
roots this project's tasks declare in their `## Where to look` bullets and
passes them via the `PYAUTO_PULL_DIRS` environment variable. `hpc/sync` now
appends any names it finds there to its own `PULL_DIRS`, extending the
override convention `hpc/sync.conf.example` already documents for
`HPC_HOST` / `HPC_BASE` / `PROJECT_NAME`. An unset variable reproduces
today's pull exactly, and `pull-full` inherits the change for free because it
iterates the same array.

## Why only `output*`

A pull rsyncs **remote → local**. Real tasks name `results/`, `wiki/…` and
`scripts/…` in the same bullets as their output roots — passing those through
would overwrite this project's own source with the cluster's copy. The Brain
side only ever derives `output*`-shaped roots, and a dedicated test
(`test_only_output_shaped_roots_are_ever_offered_to_a_pull`) guards it.

## Evidence

- `bash -n hpc/sync` passes.
- Behavioural harness: unset `PYAUTO_PULL_DIRS` reproduces today's list
  (`output output_sed inspect`) exactly; `PYAUTO_PULL_DIRS=output_ordered_witness`
  appends it (`output output_sed inspect output_ordered_witness`); an
  already-present root is not duplicated.
- Live dry-run witness against RAL (`euclid_dr1_prelim`): without the seam
  the pull enumerated `output/`, `output_sed/` (absent) and `inspect/`
  (absent), never mentioning `output_ordered_witness/`. With
  `PYAUTO_PULL_DIRS=output_ordered_witness` it listed `output_ordered_witness/`
  and did not report it missing. A direct `rsync --dry-run --stats` shows
  that root holds 115 files (90 regular, 25 dirs), 173,465,562 bytes on RAL.

Heart readiness is RED on five organism-scope reasons unrelated to this
change; the human has acknowledged them in-session for this task (recorded in
`PyAutoMind/active.md`). Nothing in this PR is in the release chain.

Part of PyAutoLabs/PyAutoBrain#372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKSwTBuNwcJc2FPNpSCrkp