### PR TITLE
feat: ordered MGE + low-disk output for DR1-prelim reruns (#60, phase 1)

### DIFF
--- a/catalogue/scripts/deblending.py
+++ b/catalogue/scripts/deblending.py
@@ -178,7 +178,7 @@ def main():
         print(dataset_name)
 
         agg = Aggregator.from_directory(
-            directory=sample_root / dataset_name, completed_only=True
+            directory=sample_root / dataset_name, completed_only=True, unzip_temporary=True
         )
 
         agg_query = agg.query(agg.unique_tag == args.unique_tag)

--- a/catalogue/scripts/lens_mass.py
+++ b/catalogue/scripts/lens_mass.py
@@ -119,7 +119,7 @@ def main():
     """
     # One aggregator over the whole sample. completed_only filters out lenses
     # whose search has not produced a `.completed` marker.
-    agg = Aggregator.from_directory(directory=sample_root, completed_only=True)
+    agg = Aggregator.from_directory(directory=sample_root, completed_only=True, unzip_temporary=True)
 
     """
     __Query: Pipeline Stage And Search__

--- a/catalogue/scripts/lens_sersic.py
+++ b/catalogue/scripts/lens_sersic.py
@@ -120,7 +120,7 @@ def main():
         print(f"no sample directory at {sample_root}; nothing to do")
         return
 
-    agg = Aggregator.from_directory(directory=sample_root, completed_only=True)
+    agg = Aggregator.from_directory(directory=sample_root, completed_only=True, unzip_temporary=True)
 
     agg_query = agg.query(agg.unique_tag == args.unique_tag)
     agg_query = agg_query.query(agg_query.search.name == args.search_name)

--- a/catalogue/scripts/magnitudes.py
+++ b/catalogue/scripts/magnitudes.py
@@ -108,16 +108,29 @@ def latest_result_per_lens_band(aggregator, sample_root: Path):
 
     __How The Key Is Built__
 
-    The result's directory is taken relative to the sample root, which makes its
-    parts ``<lens>/<stage>/<band>/<hash>/...``; the first three are the key and
-    the fourth is what varies between duplicates. A path with fewer than four
-    parts is not a per-band result folder and is skipped.
+    The key is the last four parts of the result's directory,
+    ``<lens>/<stage>/<band>/<hash>``; the first three are the key and the fourth
+    is what varies between duplicates. A path with fewer than four parts is not
+    a per-band result folder and is skipped.
 
-    Recency is the zipped result's timestamp where one exists — PyAutoFit writes
-    the zip when the search finishes, so it dates the *completion* rather than
-    any later touch of the directory — and the directory's own timestamp
-    otherwise, which is the unzipped case (an interrupted run, or a test-mode
-    one). The full directory string breaks ties, so the selection is
+    The tail is used rather than ``relative_to(sample_root)`` because the
+    aggregator is opened with ``unzip_temporary=True``, and under
+    ``config/general.yaml``'s ``hpc.hpc_mode: true`` a completed search leaves
+    only its zip: with no extracted directory beside it the aggregator extracts
+    to a temporary root instead (``autofit/aggregator/aggregator.py``), so
+    ``result.directory`` is no longer under ``sample_root`` at all and
+    ``relative_to`` would raise. That temporary root mirrors the scanned layout,
+    so the trailing four parts are the same in both cases.
+
+    Recency is the timestamp of the result's zip **under the sample root**,
+    reconstructed from that same tail. PyAutoFit writes the zip when the search
+    finishes, so it dates the *completion*. It must not be read from
+    ``result.directory``: in the temporary-extraction case there is no zip
+    beside it, and the extracted directory's own mtime is the time this process
+    unpacked it — identical for every result, which would make the choice
+    between duplicates arbitrary. Where no zip is found (an interrupted or
+    test-mode run, which stays unzipped in place) the directory's own timestamp
+    is used. The full directory string breaks ties, so the selection is
     deterministic rather than dependent on iteration order.
 
     The survivors are wrapped back into an ``Aggregator``, so everything
@@ -128,12 +141,21 @@ def latest_result_per_lens_band(aggregator, sample_root: Path):
 
     selected = {}
     for result in aggregator:
-        relative = result.directory.relative_to(sample_root)
-        if len(relative.parts) < 4:
+        try:
+            tail = result.directory.relative_to(sample_root).parts
+        except ValueError:
+            # A temporary extraction: outside `sample_root` entirely. The
+            # temporary root mirrors the scanned layout, so the trailing four
+            # parts are the same `<lens>/<stage>/<band>/<hash>` they would be
+            # in place. The short-path guard below is left to the branch above,
+            # where a stray directory really does yield fewer than four parts;
+            # taking the tail of an absolute path would always yield four.
+            tail = result.directory.parts[-4:]
+        if len(tail) < 4:
             continue
-        lens_name, stage, band = relative.parts[:3]
+        lens_name, stage, band = tail[:3]
         key = (lens_name, stage, band)
-        zip_path = Path(f"{result.directory}.zip")
+        zip_path = Path(f"{Path(sample_root).joinpath(*tail)}.zip")
         timestamp = (
             zip_path.stat().st_mtime
             if zip_path.exists()
@@ -184,7 +206,7 @@ def main():
         print(f"no sample directory at {sample_root}; nothing to do")
         return
 
-    agg = Aggregator.from_directory(directory=sample_root, completed_only=True)
+    agg = Aggregator.from_directory(directory=sample_root, completed_only=True, unzip_temporary=True)
     agg_query = agg.query(agg.unique_tag == args.unique_tag)
     agg_query = latest_result_per_lens_band(agg_query, sample_root=sample_root)
 

--- a/catalogue/scripts/multi_wavelength.py
+++ b/catalogue/scripts/multi_wavelength.py
@@ -181,7 +181,7 @@ def main():
         print(dataset_name)
 
         agg = Aggregator.from_directory(
-            directory=sample_root / dataset_name, completed_only=True
+            directory=sample_root / dataset_name, completed_only=True, unzip_temporary=True
         )
 
         agg_query = agg.query(agg.unique_tag == args.unique_tag)

--- a/catalogue/scripts/source_sersic.py
+++ b/catalogue/scripts/source_sersic.py
@@ -98,7 +98,7 @@ def main():
         print(f"no sample directory at {sample_root}; nothing to do")
         return
 
-    agg = Aggregator.from_directory(directory=sample_root, completed_only=True)
+    agg = Aggregator.from_directory(directory=sample_root, completed_only=True, unzip_temporary=True)
 
     agg_query = agg.query(agg.unique_tag == args.unique_tag)
     agg_query = agg_query.query(agg_query.search.name == args.search_name)

--- a/config/general.yaml
+++ b/config/general.yaml
@@ -15,8 +15,8 @@ inversion:
   use_border_relocator: true          # If True, by default a pixelization's border is used to relocate all pixels outside its border to the border.
   reconstruction_vmax_factor: 0.5   # Plots of an Inversion's reconstruction use the reconstructed data's bright value multiplied by this factor.
 hpc:
-  hpc_mode: false                   # If True, use HPC mode, which disables GUI visualization, logging to screen and other settings which are not suited to running on a super computer.
-  iterations_per_quick_update: 10000 #  Non-linear search iterations between every quick update, which just displays the maximum likelihood model fit.  
+  hpc_mode: true                    # If True, use HPC mode, which disables GUI visualization, logging to screen and other settings which are not suited to running on a super computer. Also forces `remove_files`, so a search's unzipped output is deleted once it has been zipped.
+  iterations_per_quick_update: 1e99  # Non-linear search iterations between every quick update, which just displays the maximum likelihood model fit. 1e99 disables on-the-fly quick updates: HPC mode swaps this whole `hpc:` block in, so this is the value that applies, not the one under `updates:`.
   iterations_per_full_update: 1e99  # Non-linear search iterations between every full update, which outputs all visuals and result fits (e.g. model.result, search.summary), this exits the search and can be slow.
 adapt:
   adapt_minimum_percent: 0.01

--- a/config/output.yaml
+++ b/config/output.yaml
@@ -14,7 +14,7 @@ default: true # If true then files which are not explicitly listed here are outp
 # the `samples_summary.json` file. However, without a `samples.csv` file these types of tasks cannot be performed
 # after the fit is complete, for example via the database.
 
-samples: true
+samples: false
 
 # The `samples.csv` file contains every accepted sampled value of every free parameter with its log likelihood and
 # weight. For certain searches, the majority of samples have a very low weight and have no numerical impact on the

--- a/scripts/full_model.py
+++ b/scripts/full_model.py
@@ -670,6 +670,8 @@ def fit(
         gaussian_per_basis=2,
         centre_prior_is_uniform=True,
         centre=d.dataset_centre,
+        ell_comps_limit=0.5,
+        order_bases=True,
     )
 
     mass = af.Model(al.mp.Isothermal)
@@ -687,7 +689,10 @@ def fit(
         mass=mass,
         shear=af.Model(al.mp.ExternalShear),
         source_bulge=al.model_util.mge_model_from(
-            mask_radius=d.mask_radius, total_gaussians=20, centre_prior_is_uniform=False
+            mask_radius=d.mask_radius,
+            total_gaussians=20,
+            centre_prior_is_uniform=False,
+            ell_comps_limit=0.7,
         ),
         redshift_lens=redshift_lens,
         redshift_source=redshift_source,
@@ -900,6 +905,8 @@ def fit(
             gaussian_per_basis=2,
             centre_prior_is_uniform=True,
             centre=d.dataset_centre,
+            ell_comps_limit=0.5,
+            order_bases=True,
         ),
         lens_disk=None,
         iterations_per_quick_update=iterations_per_quick_update,

--- a/scripts/mge_lens_only.py
+++ b/scripts/mge_lens_only.py
@@ -183,6 +183,8 @@ def fit(
         gaussian_per_basis=2,
         centre_prior_is_uniform=True,
         centre=d.dataset_centre,
+        ell_comps_limit=0.5,
+        order_bases=True,
     )
 
     model = af.Collection(

--- a/tests/test_latent_run_level.py
+++ b/tests/test_latent_run_level.py
@@ -42,6 +42,7 @@ the 100x100 masked simulated VIS image, non-JAX).
 import inspect
 import json
 import shutil
+import zipfile
 import sys
 from pathlib import Path
 
@@ -224,6 +225,22 @@ def _fit(tmp_path, monkeypatch):
         search.fit(model=model, analysis=analysis)
 
         summaries = list((tmp_path / "output").rglob("latent/latent_summary.json"))
+
+        if not summaries:
+            # `config/general.yaml` sets `hpc.hpc_mode: true`, which forces
+            # PyAutoFit's `remove_files` (paths/abstract.py): the search zips its
+            # output and deletes the unzipped tree, so the summary survives only
+            # inside `<identifier>.zip`. Read it from there rather than turning
+            # HPC mode off, so this test keeps exercising the production config.
+            zips = list((tmp_path / "output").rglob("*.zip"))
+            assert len(zips) == 1, (
+                "a real-mode fit must leave exactly one search output zip; "
+                f"found {zips}"
+            )
+            extracted = tmp_path / "extracted"
+            with zipfile.ZipFile(zips[0]) as archive:
+                archive.extractall(extracted)
+            summaries = list(extracted.rglob("latent/latent_summary.json"))
 
         assert len(summaries) == 1, (
             "a real-mode fit must write exactly one "

--- a/tests/test_magnitudes_dedup.py
+++ b/tests/test_magnitudes_dedup.py
@@ -1,0 +1,151 @@
+"""
+``latest_result_per_lens_band`` must survive temporary zip extraction.
+
+``catalogue/scripts/magnitudes.py`` opens its aggregator with
+``unzip_temporary=True``, and ``config/general.yaml`` sets
+``hpc.hpc_mode: true``. Together those mean a completed search leaves **only**
+its ``<hash>.zip``: with no extracted directory beside it the aggregator
+extracts into a temporary root instead of in place, so ``result.directory``
+points into ``/tmp`` rather than under ``sample_root``.
+
+Two things broke on that path, and this module pins both:
+
+* the de-duplication key was ``result.directory.relative_to(sample_root)``,
+  which raises ``ValueError`` for a temporary directory — a crash that takes
+  down stage 7 of ``scripts/build_inspection_bundle.sh``;
+* recency was ``Path(f"{result.directory}.zip").stat().st_mtime``, and no zip
+  sits beside a temporary extraction, so it fell through to the extracted
+  directory's own mtime — the time *this process* unpacked it, which is
+  effectively identical for every result and makes the choice between
+  duplicates arbitrary. That one produces a wrong catalogue rather than an
+  error, so it is the more dangerous of the two.
+
+The fix keys off the trailing ``<lens>/<stage>/<band>/<hash>`` parts (the
+temporary root mirrors the scanned layout, so they are the same either way) and
+reconstructs the zip under ``sample_root`` to date completion. These tests use a
+stub aggregator: the logic under test is purely path and timestamp arithmetic,
+and building real ``SearchOutput``s would test ``autofit``'s loader instead.
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+_SPEC = importlib.util.spec_from_file_location(
+    "_magnitudes_under_test",
+    PROJECT_ROOT / "catalogue" / "scripts" / "magnitudes.py",
+)
+magnitudes = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(magnitudes)
+
+TAIL = ("TileABC", "sersic_lens_model", "VIS", "0" * 32)
+
+
+class _Result:
+    """A ``SearchOutput`` stand-in: the function only reads ``.directory``."""
+
+    def __init__(self, directory):
+        self.directory = Path(directory)
+
+
+class _Aggregator(list):
+    """``latest_result_per_lens_band`` iterates its argument and takes ``len``."""
+
+    grid_search_outputs = []
+
+
+def _zipped(sample_root, tail, mtime):
+    """Write the zip a completed search leaves under ``sample_root``."""
+    zip_path = sample_root.joinpath(*tail[:-1]) / f"{tail[-1]}.zip"
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    zip_path.write_bytes(b"")
+    os.utime(zip_path, (mtime, mtime))
+    return zip_path
+
+
+def test_a_temporary_extraction_does_not_raise(tmp_path):
+    """
+    The regression: a directory outside ``sample_root`` used to raise
+    ``ValueError`` from ``relative_to``.
+    """
+    sample_root = tmp_path / "output_sed" / "dr1_prelim_grade_ab"
+    _zipped(sample_root, TAIL, mtime=1_000_000)
+
+    temporary = tmp_path / "autofit_aggregator_xyz"
+    result = _Result(temporary.joinpath(*TAIL))
+    result.directory.mkdir(parents=True)
+
+    selected = magnitudes.latest_result_per_lens_band(
+        _Aggregator([result]), sample_root=sample_root
+    )
+
+    assert len(selected) == 1
+
+
+def test_recency_comes_from_the_zip_not_the_extraction(tmp_path):
+    """
+    Two extractions of the same lens/band, unpacked in the *opposite* order to
+    their completion. The newer **zip** must win, so extraction order cannot
+    decide the catalogue.
+    """
+    sample_root = tmp_path / "output_sed" / "dr1_prelim_grade_ab"
+    older_tail = TAIL[:-1] + ("a" * 32,)
+    newer_tail = TAIL[:-1] + ("b" * 32,)
+    _zipped(sample_root, older_tail, mtime=1_000_000)
+    _zipped(sample_root, newer_tail, mtime=2_000_000)
+
+    temporary = tmp_path / "autofit_aggregator_xyz"
+    results = []
+    # Unpack the newer result first so its extraction mtime is the *older* of
+    # the two: keying on extraction time would pick the wrong one.
+    for tail in (newer_tail, older_tail):
+        directory = temporary.joinpath(*tail)
+        directory.mkdir(parents=True)
+        results.append(_Result(directory))
+    os.utime(results[0].directory, (10, 10))
+    os.utime(results[1].directory, (20, 20))
+
+    selected = magnitudes.latest_result_per_lens_band(
+        _Aggregator(results), sample_root=sample_root
+    )
+
+    assert len(selected) == 1
+    assert list(selected)[0].directory.name == newer_tail[-1]
+
+
+def test_in_place_extraction_still_works(tmp_path):
+    """
+    The non-HPC case — an unzipped directory beside its zip, under
+    ``sample_root`` — must behave exactly as before.
+    """
+    sample_root = tmp_path / "output_sed" / "dr1_prelim_grade_ab"
+    _zipped(sample_root, TAIL, mtime=1_000_000)
+
+    result = _Result(sample_root.joinpath(*TAIL))
+    result.directory.mkdir(parents=True, exist_ok=True)
+
+    selected = magnitudes.latest_result_per_lens_band(
+        _Aggregator([result]), sample_root=sample_root
+    )
+
+    assert len(selected) == 1
+
+
+def test_a_short_path_is_skipped(tmp_path):
+    """A directory with fewer than four parts is not a per-band result."""
+    sample_root = tmp_path / "output_sed"
+    sample_root.mkdir(parents=True)
+    result = _Result(sample_root / "stray")
+    result.directory.mkdir()
+
+    selected = magnitudes.latest_result_per_lens_band(
+        _Aggregator([result]), sample_root=sample_root
+    )
+
+    assert len(selected) == 0

--- a/workflow/csv_make.py
+++ b/workflow/csv_make.py
@@ -88,7 +88,7 @@ Set up the aggregator which will load results from the output folder of the mode
 """
 from autofit.aggregator.aggregator import Aggregator
 
-agg = Aggregator.from_directory(directory=Path("output"), completed_only=True)
+agg = Aggregator.from_directory(directory=Path("output"), completed_only=True, unzip_temporary=True)
 
 """
 Use a query on the aggregator to only get results for the `mass_total[1]` model-fit, which contains the final lens

--- a/workflow/fits_make.py
+++ b/workflow/fits_make.py
@@ -92,7 +92,7 @@ Set up the aggregator which will load results from the output folder of the mode
 """
 from autofit.aggregator.aggregator import Aggregator
 
-agg = Aggregator.from_directory(directory=Path("output"), completed_only=True)
+agg = Aggregator.from_directory(directory=Path("output"), completed_only=True, unzip_temporary=True)
 
 """
 Use a query on the aggregator to only get results for the `mass_total[1]` model-fit, which contains the final lens

--- a/workflow/png_make.py
+++ b/workflow/png_make.py
@@ -94,7 +94,7 @@ Set up the aggregator which will load results from the output folder of the mode
 """
 from autofit.aggregator.aggregator import Aggregator
 
-agg = Aggregator.from_directory(directory=Path("output"), completed_only=True)
+agg = Aggregator.from_directory(directory=Path("output"), completed_only=True, unzip_temporary=True)
 
 """
 Use a query on the aggregator to only get results for the `mass_total[1]` model-fit, which contains the final lens


### PR DESCRIPTION
Phase 1 of #60 — the changes the `euclid_dr1_prelim` reruns are blocked on. Phase 2 (RAL catalogue-build submit script, row-level catalogue comparator, `lens_mass.py` empty-aggregator fix) follows on its own branch against the same issue.

## Disk

The local `output/` tree was **501 MB** for ten tiles: 130 MB of zips plus ~371 MB of extracted copies beside them — all 17 zips had such a sibling. Inside the zips: `samples.csv` 79.0 MB (61%), `image/` 48.1 MB (37%), `search.log` 0.1 MB (0.03%).

| change | effect |
|---|---|
| `hpc.hpc_mode: true` | forces PyAutoFit's `remove_files`, so a completed search leaves only its zip |
| `unzip_temporary=True` ×9 | reading a zip-only tree no longer writes a permanent extraction back into it |
| `samples: false` | drops 61% of the zip payload |

`search.log` and `image/` are **deliberately kept** — `search.log` is worth 0.03% and carries useful information, and the visualisation output is wanted.

## The trap in turning HPC mode on

`hpc.iterations_per_quick_update` is set to `1e99` **in the same edit** as `hpc_mode`. HPC mode swaps the whole `hpc:` block in (`autofit/non_linear/search/abstract_search.py`), so the previous `10000` would have switched on-the-fly quick updates *on* — the opposite of the intent, and a quick update is what killed run `342301_3`.

## MGE ordering

`order_bases=True` and `ell_comps_limit` now reach the MGE builders that lacked them — `full_model.py`'s two two-basis lens models and its source, and `mge_lens_only.py` — matching `initial_lens_model.py` (0.5 lens, 0.7 source). Single-basis models take the limit only, as there is nothing to order. `hpc/diagnostics/jax_fork_control.py` is left unordered on purpose: it is a control. `sersic_lens_model.py` and `lens_model_waveband.py` build no MGE, so they need nothing.

## Two consequences of removing the unzipped tree

Both found by auditing what reads loose files under `output/`, and fixed here:

- **`tests/test_latent_run_level.py`** globbed for `files/latent/latent_summary.json` on disk. It now falls back to reading it out of the zip, so it keeps exercising the production config rather than turning HPC mode off for itself.
- **`catalogue/scripts/magnitudes.py`** — the serious one. `latest_result_per_lens_band` keyed on `result.directory.relative_to(sample_root)` and dated recency from a zip beside that directory. With no extracted sibling the aggregator extracts to a temporary root, so the first raised `ValueError` (crashing stage 7 of `build_inspection_bundle.sh`) and the second fell through to the *extraction* mtime — identical for every result, making the choice between duplicates arbitrary. That second one produces a wrong catalogue rather than an error. It now keys off the trailing `<lens>/<stage>/<band>/<hash>` parts **in the temporary case only** (taking the tail of an absolute path unconditionally would kill the short-path guard) and reconstructs the zip under `sample_root` so recency always dates completion.

`tests/test_magnitudes_dedup.py` is new and pins all four cases: temporary extraction does not raise, recency comes from the zip and not the extraction order, in-place extraction is unchanged, and a short path is still skipped.

## Verification

A real fit under the new config leaves exactly:

```
output/latent_run_level/drawer/66b98be79b8257a91e87364f48c62b21.zip
```

— nothing else — with **no `samples.csv`** inside it, and `search.log` and `image/` intact. **92 tests pass.**

## Known, not fixed here

Three diagnostic tools read loose output files and break under HPC mode: `scripts/tools/diagnose_latent.py`, `scripts/tools/diagnose_latent_vis_pix.py`, and `scripts/simulator.py --from-result`. All three are invisible to CI because the smoke profile sets `PYAUTO_SKIP_FIT_OUTPUT=1`, which suppresses zipping entirely. They are not on the catalogue path; they are queued for phase 2 rather than widening this PR.

Closes nothing on its own — #60 stays open for phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsGeXEmGmSJzvxzC7GUpZo
