### PR TITLE
fix: catalogue producers request latents with a retired `latent.` prefix (#64)

### DIFF
--- a/catalogue/scripts/lens_mass.py
+++ b/catalogue/scripts/lens_mass.py
@@ -227,13 +227,17 @@ def main():
     full posterior instead of one number carried over from a best fit. That is
     why it takes the same five value flavours as everything above.
 
-    The ``latent.`` prefix is what selects it. ``add_variable`` reads a plain
-    ``galaxies...`` argument out of the samples and a ``latent.<name>`` argument
-    out of the latent summary the fit wrote beside them. The name has to match a
-    key of ``util.LatentEuclid``, whose catalogue "__Latent Variables__" in
-    ``start_here.py`` describes and ``config/latent.yaml`` enables —
-    ``effective_einstein_radius`` is one of the library latents that file turns
-    on.
+    Nothing in the argument marks it out as a latent, and nothing needs to.
+    ``add_variable`` looks its argument up in one merged dictionary: the model
+    paths read out of the samples summary, together with the keys of the latent
+    summary the fit wrote beside them, under exactly the names
+    ``util.LatentEuclid`` gave them. A latent is therefore selected by naming it
+    bare — ``effective_einstein_radius``, one of the library latents
+    ``config/latent.yaml`` enables and the "__Latent Variables__" catalogue in
+    ``start_here.py`` describes. There is no prefix to add, and adding one is
+    the thing to avoid: an argument matching neither side of that dictionary is
+    not raised, it is written blank, so a wrong name here empties a column
+    without ever saying so.
 
     Two consequences worth knowing before you read a CSV. A fit run in test mode
     writes no latent summary at all, so these columns are present but blank; and
@@ -242,10 +246,10 @@ def main():
     ``einstein_radius`` parameter three columns to its left.
     """
     # Latent: effective Einstein radius, computed by `util.LatentEuclid` on each
-    # sample. `add_variable` pulls from latent_summary for a "latent.<name>"
-    # argument.
+    # sample. Named bare, exactly as the latent summary writes it: `add_variable`
+    # reads the samples' model paths and the latent keys from one merged dict.
     agg_csv.add_variable(
-        argument="latent.effective_einstein_radius",
+        argument="effective_einstein_radius",
         name="effective_einstein_radius",
         value_types=value_types_all,
     )

--- a/catalogue/scripts/magnitudes.py
+++ b/catalogue/scripts/magnitudes.py
@@ -276,8 +276,12 @@ def main():
     None of the eight variables below is a model parameter. Each is a latent
     variable: recomputed from the model on every sample by ``util.LatentEuclid``,
     so each arrives with a posterior rather than as a number derived once from a
-    best fit. The ``latent.`` prefix is what tells ``add_variable`` to read the
-    latent summary rather than the samples.
+    best fit. Nothing in the arguments below marks that out. ``add_variable``
+    looks each one up in a single merged dictionary — the model paths of the
+    samples summary together with the keys of the latent summary written beside
+    them — so a latent is named exactly as ``util.LatentEuclid`` writes it, with
+    no prefix. An argument matching neither side is not raised, it is written
+    blank, so a wrong name here empties a column silently.
 
     They come in two groups, which is why the argument names look inconsistent.
     The first are library latents that ``config/latent.yaml`` enables — the total
@@ -286,7 +290,7 @@ def main():
     ``util.LatentEuclid.APERTURE_LATENT_KEYS`` rather than in the library,
     because they need PSF arguments that only this pipeline supplies. ``name``
     shortens every header to the DR1 catalogue's form, so the CSV says
-    ``lens_flux`` where the argument says ``latent.total_lens_flux_mujy``.
+    ``lens_flux`` where the argument says ``total_lens_flux_mujy``.
 
     The units matter more than anything else here. A fitted flux is in the
     image's own units, which differ from band to band and are useless for an SED.
@@ -317,14 +321,14 @@ def main():
     # latents enabled in config/latent.yaml, then the four Euclid-only FWHM
     # aperture-flux latents. Column names keep the shorter DR1 catalogue form.
     latent_args = [
-        ("latent.total_lens_flux_mujy", "lens_flux"),
-        ("latent.total_lens_flux_1_fwhm_mujy", "lens_flux_1_fwhm"),
-        ("latent.total_lens_flux_2_fwhm_mujy", "lens_flux_2_fwhm"),
-        ("latent.total_lens_flux_3_fwhm_mujy", "lens_flux_3_fwhm"),
-        ("latent.total_lens_flux_4_fwhm_mujy", "lens_flux_4_fwhm"),
-        ("latent.total_lensed_source_flux_mujy", "lensed_source_flux"),
-        ("latent.total_source_flux_mujy", "source_flux"),
-        ("latent.magnification", "magnification"),
+        ("total_lens_flux_mujy", "lens_flux"),
+        ("total_lens_flux_1_fwhm_mujy", "lens_flux_1_fwhm"),
+        ("total_lens_flux_2_fwhm_mujy", "lens_flux_2_fwhm"),
+        ("total_lens_flux_3_fwhm_mujy", "lens_flux_3_fwhm"),
+        ("total_lens_flux_4_fwhm_mujy", "lens_flux_4_fwhm"),
+        ("total_lensed_source_flux_mujy", "lensed_source_flux"),
+        ("total_source_flux_mujy", "source_flux"),
+        ("magnification", "magnification"),
     ]
     for argument, name in latent_args:
         agg_csv.add_variable(argument=argument, name=name, value_types=value_types)

--- a/tests/test_catalogue_latent_columns.py
+++ b/tests/test_catalogue_latent_columns.py
@@ -1,0 +1,433 @@
+"""
+The catalogue's latent columns must actually carry numbers.
+
+``catalogue/scripts/lens_mass.py`` and ``catalogue/scripts/magnitudes.py`` asked
+``af.AggregateCSV`` for their latents under a ``latent.`` prefix
+(``latent.effective_einstein_radius``, ``latent.total_lens_flux_mujy``, ...).
+That prefix is retired. ``Row.median_pdf_sample_kwargs`` merges the latent
+summary's kwargs into the *same* dictionary as the model paths, under the bare
+keys the fit wrote (``("effective_einstein_radius",)``), and
+``Column.path`` is ``tuple(argument.split("."))`` — so the prefixed argument
+looked up ``("latent", "effective_einstein_radius")``, found nothing, and
+``Column.value`` turned that ``KeyError`` into ``None``.
+
+Which is why nobody noticed. A missing argument is not raised, it is written
+**blank**: the header stayed the full DR1 width and every latent cell under it
+was empty — one blank column in ``lens_mass.csv`` and all eight variables, the
+whole photometry table, in ``magnitudes.csv``.
+
+``tests/test_catalogue_parity.py`` could not see it, because a blank cell and a
+full one produce the same header, and that module deliberately runs nothing.
+So this one runs the real thing:
+
+* ``test_lens_mass_writes_no_blank_cells`` /
+  ``test_magnitudes_writes_no_blank_cells`` build a completed result tree on
+  disk with PyAutoFit's own serializers — ``DirectoryPaths.save_all`` for
+  ``model.json`` / ``search.json``, ``save_samples_summary`` for
+  ``samples_summary.json`` and for ``latent/latent_summary.json``, exactly as
+  ``SearchUpdater._compute_latent_samples`` writes it — then run the producer's
+  own ``main()`` over it and assert every cell of every row is non-empty, and
+  that the header is still the DR1 header the parity test protects. A
+  re-prefixed argument empties cells while leaving that header intact, so the
+  two assertions together are the pin.
+* ``test_every_non_model_argument_is_a_latent_key`` reads the ``argument``
+  string of every ``add_variable`` call out of the producers' syntax trees and
+  requires each one that is not a ``galaxies...`` model path to be, exactly, a
+  key of ``util.LatentEuclid``. That catches a re-introduced prefix and a
+  renamed latent without touching the disk.
+
+JAX-free and search-free, as the fast suite requires: no fit is run, the results
+are written by hand from PyAutoFit's serializers and the latent values are
+arbitrary constants — what is under test is the *lookup*, not the physics.
+"""
+
+import ast
+import csv
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(Path(__file__).parent))
+
+import util  # noqa: E402
+
+# The ``ast`` reader below extends `test_catalogue_parity`'s, and shares its two
+# node helpers rather than growing a second copy of them.
+from test_catalogue_parity import _keyword, _literal  # noqa: E402
+
+
+CATALOGUE_SCRIPTS = PROJECT_ROOT / "catalogue" / "scripts"
+DR1_HEADERS = Path(__file__).parent / "data" / "dr1_headers"
+
+PRODUCERS = ["lens_mass", "magnitudes"]
+
+SAMPLE = "pytest_latent_columns"
+LENS_NAMES = ("TileAAA", "TileBBB")
+BANDS = ("vis", "nir_h")
+
+# Enough samples for `SamplesPDF.summary()` to quantile a median and 1σ / 3σ
+# bounds; the values themselves are arbitrary.
+SAMPLE_COUNT = 5
+
+# Written into `files/wcs.json`, which `magnitudes.py` reads for its third label
+# column. `util.AnalysisImaging` writes this file beside a real result.
+CRVAL_RA_DEG = 150.1234
+
+
+def _latent_keys():
+    """
+    The authoritative Euclid latent names: the library latents
+    ``config/latent.yaml`` enables plus ``LatentEuclid.APERTURE_LATENT_KEYS``.
+
+    ``LatentEuclid.keys`` takes the analysis only to satisfy the ``Latent``
+    extension-point signature and never reads it, so no fit is needed here.
+    """
+    return list(util.LatentEuclid.keys(None))
+
+
+def _samples_for(model, offset):
+    """
+    A ``SamplesPDF`` over ``model`` with ``SAMPLE_COUNT`` samples, built the way
+    a search builds one so that ``summary()`` produces a genuine
+    ``SamplesSummary`` (median, max-likelihood and the 1σ / 3σ bounds).
+    """
+    from autofit.non_linear.samples.pdf import SamplesPDF
+    from autofit.non_linear.samples.sample import Sample
+
+    count = model.prior_count
+
+    return SamplesPDF(
+        model=model,
+        sample_list=Sample.from_lists(
+            model=model,
+            parameter_lists=[
+                [offset + 0.1 * index + 0.01 * parameter for parameter in range(count)]
+                for index in range(SAMPLE_COUNT)
+            ],
+            log_likelihood_list=[float(index) for index in range(SAMPLE_COUNT)],
+            log_prior_list=[0.0] * SAMPLE_COUNT,
+            weight_list=[1.0] * SAMPLE_COUNT,
+        ),
+    )
+
+
+def _latent_samples_for(keys, offset):
+    """
+    The latent samples a fit computes, mirrored from
+    ``autofit.non_linear.analysis.latent.latent_samples_from``: one ``Sample``
+    per posterior sample whose kwargs are the **bare** latent names, over a
+    model built from those kwargs by ``simple_model_for_kwargs``.
+    """
+    from autofit.non_linear.samples.pdf import SamplesPDF
+    from autofit.non_linear.samples.sample import Sample
+    from autofit.non_linear.samples.util import simple_model_for_kwargs
+
+    sample_list = [
+        Sample(
+            log_likelihood=float(index),
+            log_prior=0.0,
+            weight=1.0,
+            kwargs={
+                key: offset + 0.1 * index + 0.01 * position
+                for position, key in enumerate(keys)
+            },
+        )
+        for index in range(SAMPLE_COUNT)
+    ]
+
+    return SamplesPDF(
+        model=simple_model_for_kwargs(sample_list[0].kwargs),
+        sample_list=sample_list,
+    )
+
+
+def _write_result(model, *, path_prefix, name, unique_tag, offset, files=None):
+    """
+    Write one completed search output, using PyAutoFit's own writers.
+
+    ``save_all`` writes ``files/model.json`` and ``files/search.json`` (the
+    sentinel ``Aggregator.from_directory`` scans for, and the source of
+    ``path_prefix`` / ``name`` / ``unique_tag``); the two
+    ``save_samples_summary`` calls write ``files/samples_summary.json`` and
+    ``files/latent/latent_summary.json`` under the names the search updater
+    uses; ``completed()`` drops the ``.completed`` marker ``completed_only=True``
+    filters on.
+    """
+    import autofit as af
+
+    search = af.Drawer(
+        name=name,
+        path_prefix=path_prefix,
+        unique_tag=unique_tag,
+        total_draws=SAMPLE_COUNT,
+    )
+
+    paths = search.paths
+    paths.model = model
+    paths.search = search
+    paths.save_all()
+    paths.save_samples_summary(_samples_for(model, offset).summary())
+    paths.save_samples_summary(
+        _latent_samples_for(_latent_keys(), offset).summary(),
+        "latent/latent_summary",
+    )
+    for file_name, value in (files or {}).items():
+        paths.save_json(file_name, value)
+    paths.completed()
+
+    return paths.output_path
+
+
+def _run_producer(producer, monkeypatch, output_path, inspect_path):
+    """
+    Load a producer by path (it is a script, not an importable package member)
+    and run its real ``main()`` over ``output_path``.
+    """
+    spec = importlib.util.spec_from_file_location(
+        f"_{producer}_under_test", CATALOGUE_SCRIPTS / f"{producer}.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            f"{producer}.py",
+            f"--sample={SAMPLE}",
+            f"--output_path={output_path}",
+            f"--inspect_dir={inspect_path}",
+        ],
+    )
+    module.main()
+
+
+def _assert_no_blank_cells(csv_path, producer):
+    """
+    Every cell of every row carries a value, and the header is still the DR1
+    one. A missing ``add_variable`` argument is written blank rather than
+    raised, so this is the only place the bug is visible.
+    """
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        header = reader.fieldnames
+        rows = list(reader)
+
+    expected_header = (DR1_HEADERS / f"{producer}.txt").read_text().strip()
+
+    assert ",".join(header) == expected_header, (
+        f"{producer}.csv must carry the DR1 header; a producer whose columns "
+        "have drifted is a different failure from a blank cell"
+    )
+    assert rows, f"{producer}.csv has a header but no rows; the fixture was not scraped"
+
+    for number, row in enumerate(rows):
+        for column, value in row.items():
+            assert value is not None and value.strip() != "", (
+                f"{producer}.csv row {number} ('{row.get('lens_name')}') has an "
+                f"empty '{column}' cell: `add_variable` found nothing for that "
+                "argument and wrote a blank rather than raising"
+            )
+
+
+@pytest.fixture
+def pipeline_config(tmp_path):
+    """
+    Push the pipeline's own ``config/`` with the results root inside
+    ``tmp_path``, so ``DirectoryPaths`` writes the fixture there, and restore
+    the repository config afterwards (``conf.instance`` has no pop).
+    """
+    from autolens import conf
+
+    output_path = tmp_path / "output"
+    conf.instance.push(new_path=PROJECT_ROOT / "config", output_path=output_path)
+    try:
+        yield output_path
+    finally:
+        conf.instance.push(
+            new_path=PROJECT_ROOT / "config", output_path=PROJECT_ROOT / "output"
+        )
+
+
+def test_lens_mass_writes_no_blank_cells(tmp_path, monkeypatch, pipeline_config):
+    """
+    The whole ``lens_mass.csv``, produced by the real ``main()`` over a real
+    aggregator: seven mass parameters and the ``effective_einstein_radius``
+    latent, five columns each, none of them empty.
+    """
+    import autofit as af
+    import autolens as al
+
+    # The `vis_pix` mass model: exactly the 7 free parameters `mass_args` names.
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=0.5,
+                mass=al.mp.Isothermal,
+                shear=al.mp.ExternalShear,
+            )
+        )
+    )
+    assert model.total_free_parameters == 7
+
+    for offset, lens_name in enumerate(LENS_NAMES):
+        _write_result(
+            model,
+            path_prefix=Path(SAMPLE) / lens_name,
+            name="vis_pix",
+            unique_tag="initial_lens_model",
+            offset=1.0 + offset,
+        )
+
+    inspect_path = tmp_path / "inspect"
+    _run_producer("lens_mass", monkeypatch, pipeline_config, inspect_path)
+
+    _assert_no_blank_cells(inspect_path / "lens_mass.csv", "lens_mass")
+
+
+def test_magnitudes_writes_no_blank_cells(tmp_path, monkeypatch, pipeline_config):
+    """
+    ``magnitudes.csv`` is the table the bug emptied completely: every one of its
+    value columns is a latent. One row per ``(lens, waveband)``, and the three
+    label columns (``lens_name``, ``waveband`` from ``search.name``,
+    ``crval_ra_deg`` from the ``wcs.json`` the analysis writes) must be filled
+    too, or a blank cell would prove nothing about the latents.
+    """
+    import autofit as af
+    import autolens as al
+
+    model = af.Collection(
+        galaxies=af.Collection(lens=af.Model(al.Galaxy, redshift=0.5, bulge=al.lp.Sersic))
+    )
+
+    offset = 1.0
+    for lens_name in LENS_NAMES:
+        for band in BANDS:
+            _write_result(
+                model,
+                path_prefix=Path(SAMPLE) / lens_name,
+                name=band,
+                unique_tag="sersic_lens_model",
+                offset=offset,
+                files={"wcs": {"crval_ra_deg": CRVAL_RA_DEG}},
+            )
+            offset += 1.0
+
+    inspect_path = tmp_path / "inspect"
+    _run_producer("magnitudes", monkeypatch, pipeline_config, inspect_path)
+
+    csv_path = inspect_path / "magnitudes.csv"
+    _assert_no_blank_cells(csv_path, "magnitudes")
+
+    with open(csv_path, newline="") as f:
+        rows = list(csv.DictReader(f))
+
+    assert len(rows) == len(LENS_NAMES) * len(BANDS), (
+        "magnitudes.csv carries one row per (lens, waveband); a different count "
+        "means the de-duplication dropped a band"
+    )
+
+
+def arguments_from(path):
+    """
+    The ordered ``argument`` strings a producer hands to ``add_variable``, read
+    out of the module's syntax tree.
+
+    The same shapes ``test_catalogue_parity.column_specs_from`` recognises —
+    a direct ``agg_csv.add_variable(argument="...", ...)`` call, and a
+    ``for argument, name in <list of pairs>:`` loop unrolled over its literal —
+    but keyed on the argument rather than the column name, because it is the
+    argument that decides whether a value is found at all.
+    """
+    tree = ast.parse(path.read_text(), filename=str(path))
+
+    environment = {}
+    arguments = []
+
+    def add_variable_calls(node):
+        return [
+            call
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "add_variable"
+        ]
+
+    def visit(statements):
+        for statement in statements:
+            if isinstance(statement, ast.Assign) and len(statement.targets) == 1:
+                target = statement.targets[0]
+                if isinstance(target, ast.Name):
+                    literal = _literal(statement.value)
+                    if literal is not None:
+                        environment[target.id] = literal
+                continue
+
+            if isinstance(statement, ast.Expr) and isinstance(
+                statement.value, ast.Call
+            ):
+                call = statement.value
+                if (
+                    isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "add_variable"
+                ):
+                    argument = _literal(_keyword(call, "argument"))
+                    if argument is not None:
+                        arguments.append(argument)
+                continue
+
+            if isinstance(statement, ast.For):
+                pairs = (
+                    environment.get(statement.iter.id)
+                    if isinstance(statement.iter, ast.Name)
+                    else None
+                )
+                calls = add_variable_calls(statement)
+                if pairs is not None and isinstance(statement.target, ast.Tuple) and calls:
+                    for _call in calls:
+                        for argument, _name in pairs:
+                            arguments.append(argument)
+                    continue
+
+            for field in ("body", "orelse", "finalbody"):
+                nested = getattr(statement, field, None)
+                if nested:
+                    visit(nested)
+
+    visit(tree.body)
+
+    return arguments
+
+
+@pytest.mark.parametrize("producer", PRODUCERS)
+def test_every_non_model_argument_is_a_latent_key(producer):
+    """
+    The hermetic half: a re-introduced ``latent.`` prefix, or a latent renamed
+    on one side only, must fail here — naming the argument — rather than
+    quietly emptying a column of the DR1 catalogue.
+    """
+    arguments = arguments_from(CATALOGUE_SCRIPTS / f"{producer}.py")
+
+    assert arguments, (
+        f"no add_variable arguments found in catalogue/scripts/{producer}.py; "
+        "the syntax-tree reader has drifted from the producer"
+    )
+
+    latent_keys = _latent_keys()
+
+    for argument in arguments:
+        if argument.startswith("galaxies."):
+            continue
+        assert argument in latent_keys, (
+            f"catalogue/scripts/{producer}.py asks add_variable for "
+            f"'{argument}', which is neither a 'galaxies...' model path nor a "
+            f"key of util.LatentEuclid ({sorted(latent_keys)}). "
+            "`add_variable` looks its argument up in one merged dictionary of "
+            "model paths and bare latent names, and writes a blank cell when it "
+            "misses — so this would empty a DR1 column silently."
+        )

--- a/workflow/example/csv/lens_mass.py
+++ b/workflow/example/csv/lens_mass.py
@@ -190,12 +190,12 @@ The external shear field is parameterized by two components `gamma_1` and `gamma
 See the **PyAutoLens** API docs for a full description of the External Shear model.
 """
 agg_csv.add_variable(
-    argument="galaxies.lens.shear.gamma_0",
-    name="mass_ell_comps_0",
+    argument="galaxies.lens.shear.gamma_1",
+    name="mass_shear_gamma_1",
 )
 agg_csv.add_variable(
-    argument="galaxies.lens.shear.gamma_1",
-    name="mass_ell_comps_1",
+    argument="galaxies.lens.shear.gamma_2",
+    name="mass_shear_gamma_2",
 )
 
 agg_csv.save(path=workflow_path / "csv_q1_mass_model.csv")


### PR DESCRIPTION
## Summary

Fixes #64. `catalogue/scripts/lens_mass.py` and `catalogue/scripts/magnitudes.py` requested their latent variables from `af.AggregateCSV` under a retired `latent.` prefix. autofit's `Row` merges the latent summary into the same kwargs dict as the model paths, under the **bare** keys the fit wrote (`("effective_einstein_radius",)`), and `Column.value` turns the resulting `KeyError` into `None` — so every latent column was written blank while the header kept its full DR1 width. Measured on the ten `euclid_dr1_prelim` tiles of RAL job 342398: the five `effective_einstein_radius*` columns of `lens_mass.csv` empty on 10/10 rows; 48 of `magnitudes.csv`'s 52 columns would be once the SED chain lands.

The fix names the latents exactly as `util.LatentEuclid` writes them. Column names are unchanged, so the DR1 header parity (`tests/test_catalogue_parity.py`) is untouched. The 3σ latent bounds reading autofit's 1σ values is a separate PyAutoFit `aggregate_csv` fix and stays out of scope here.

## Scripts Changed

- `catalogue/scripts/lens_mass.py` — `argument="latent.effective_einstein_radius"` → `"effective_einstein_radius"`; the `__The Effective Einstein Radius Latent__` docstring now describes the merged lookup and why a wrong name is silent
- `catalogue/scripts/magnitudes.py` — the eight `latent_args` de-prefixed; the `__The Flux Latents…__` docstring rewritten the same way
- `workflow/example/csv/lens_mass.py` — the tutorial twin requested shear `gamma_0`/`gamma_1` under `mass_ell_comps_0/1` (a dead path; `ExternalShear` has `gamma_1`/`gamma_2`) → `gamma_1`/`gamma_2` as `mass_shear_gamma_1/2`
- `tests/test_catalogue_latent_columns.py` (new, fast suite, ~3 s, no search, no JAX) — builds a completed result tree with PyAutoFit's own writers (`DirectoryPaths.save_all`, `save_samples_summary` for both `samples_summary.json` and `latent/latent_summary.json`, `completed()`), runs each producer's real `main()` over it and asserts every cell is non-empty **and** the header is the DR1 one; plus a hermetic guard reading every `add_variable` argument out of the producers' syntax trees and requiring each non-`galaxies.` argument to be a `util.LatentEuclid` key

## Test Plan

- [x] Fast suite serial: 93 passed (89 before + 4 new)
- [x] Fail-before/pass-after: with the old arguments restored, all four new tests fail naming the offending argument / empty cell (`effective_einstein_radius`, `lens_flux`, `latent.effective_einstein_radius`, `latent.total_lens_flux_mujy`); with the fix, 4 passed
- [x] `tests/test_repo_invariants.py` + `tests/test_catalogue_parity.py`: 20 passed
- [ ] CI `unit` + `slow` jobs (ubuntu × py3.12/3.13)

Gate notes: shipped from a web session (no task worktree, no `pyauto-heart`), so the readiness gate is the fast suite above; both producers are in `config/build/no_run.yaml`, so the smoke runner never exercises them. Pre-existing and unrelated: `tests/test_util.py` has one or two `FileNotFoundError` failures under `pytest -n auto` on `main` too (serial is clean) — not touched here.

Science follow-up after merge: rebuild the catalogue from the 342398 results and re-score the Cortex task `euclid_dr1_prelim/ordered_rerun_catalogue_parity` before the SED chain is submitted.

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpSbN9hUU3H8EEtMPK15B7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpSbN9hUU3H8EEtMPK15B7)_