### PR TITLE
fix(latent): trace LatentEuclid.variables under the latent engine's jax.jit

### DIFF
--- a/tests/test_catalogue_parity.py
+++ b/tests/test_catalogue_parity.py
@@ -48,12 +48,18 @@ class _EmptyRow:
     whether the lookup hits or misses, so an empty row yields exactly the
     suffixes — in exactly the order — that ``AggregateCSV`` would write, with no
     aggregator, no results and no disk access.
+
+    ``known_paths`` is the keyspace ``Column._check_argument`` consults before
+    it reads the four kwargs dicts (PyAutoFit#1598): empty, every argument
+    misses cleanly and the non-strict column logs one warning and emits its
+    columns with empty values, which is exactly the miss this stub wants.
     """
 
     median_pdf_sample_kwargs: dict = {}
     max_likelihood_kwargs: dict = {}
     values_at_sigma_1_kwargs: dict = {}
     values_at_sigma_3_kwargs: dict = {}
+    known_paths: frozenset = frozenset()
 
 
 def _column_names_from(name, value_type_names):

--- a/tests/test_compute_latent_variable.py
+++ b/tests/test_compute_latent_variable.py
@@ -41,7 +41,12 @@ latents the source swap may and may not change; the mesh areas the integral uses
 are version-dependent, so no tolerance against ``truth.json`` is claimed there.
 
 These tests are deliberately **JAX-free** (``use_jax=False`` everywhere, as
-``AGENTS.md`` requires) and run no non-linear search. The whole module is a
+``AGENTS.md`` requires) with one deliberate exception at the end of the module:
+``test_latent_euclid_variables_traces_under_jax_jit`` evaluates
+``LatentEuclid.variables`` under ``jax.jit``, because that is the one property
+of it no NumPy test can hold — the latent engine jits the call per sample, and
+a value that cannot be traced there is silently written as NaN (PyAutoLens#732,
+issue #66). They run no non-linear search. The whole module is a
 handful of seconds: the dataset is loaded and each set of latents evaluated
 once, in session-scoped fixtures.
 """
@@ -98,6 +103,12 @@ ADAPT_IMAGE_FLOOR = 0.01
 # pixelized model's galaxies are named `lens` / `source` (as the pipeline names
 # them) rather than `galaxy_0` / `galaxy_1` (as `truth.json` does).
 SOURCE_PATH = "('galaxies', 'source')"
+
+# The redshifts the `vis_lp` model the JAX trace test builds is composed at:
+# the pipeline's own placeholders, as in `tests/test_vis_lp_model.py`. Its mask
+# radius and centre come off the loaded dataset, the way `fit` takes them.
+REDSHIFT_LENS = 0.5
+REDSHIFT_SOURCE = 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -184,7 +195,7 @@ def truth_model(truth):
     )
 
 
-def _analysis_from(euclid_dataset, adapt_images=None):
+def _analysis_from(euclid_dataset, adapt_images=None, use_jax=False):
     """
     The pipeline ``AnalysisImaging`` exactly as ``scripts/simulator.py`` builds
     it when it writes ``truth["latents"]`` — same kwargs, ``use_jax=False``.
@@ -193,12 +204,15 @@ def _analysis_from(euclid_dataset, adapt_images=None):
     reproduces the simulator's call byte for byte. The pixelized-source tests
     pass an ``al.AdaptImages`` here, the way ``scripts/initial_lens_model.py``
     hands the ``vis_pix`` stage its image-plane mesh grid.
+
+    ``use_jax`` defaults to ``False``, so every known-answer caller is
+    unchanged; only the JAX trace test at the end of the module flips it.
     """
     return util.AnalysisImaging(
         dataset=euclid_dataset.dataset,
         adapt_images=adapt_images,
         positions_likelihood_list=None,
-        use_jax=False,
+        use_jax=use_jax,
         dataset_main_path=euclid_dataset.dataset_main_path,
         title_prefix="VIS",
         plot_rgb=False,
@@ -218,6 +232,16 @@ def euclid_dataset():
 @pytest.fixture(scope="session")
 def analysis(euclid_dataset):
     return _analysis_from(euclid_dataset)
+
+
+@pytest.fixture(scope="session")
+def jax_analysis(euclid_dataset):
+    """
+    The same pipeline ``AnalysisImaging`` on the JAX backend, for the one trace
+    test at the end of the module. Session-scoped: the module has no conftest,
+    and building it twice would load the dataset twice.
+    """
+    return _analysis_from(euclid_dataset, use_jax=True)
 
 
 @pytest.fixture(scope="session")
@@ -699,4 +723,132 @@ def test_pixelized_source_latents_stage_invariance(pixelized_latents, latents):
             f"latent '{key}' depends on the source model and must differ "
             "between a Sersic source and a Delaunay pixelization; got "
             f"{pixelized_latents[key]!r} against {latents[key]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The one JAX test: the latents must survive the latent engine's jax.jit
+# ---------------------------------------------------------------------------
+
+
+JIT_VS_EAGER_REL = 1e-3
+
+
+def _vis_lp_model(euclid_dataset):
+    """
+    The ``vis_lp`` model, as ``scripts/initial_lens_model.py`` composes it at
+    this dataset's mask radius and centre.
+
+    Built here rather than from ``truth.json`` because the trace failure this
+    test pins is a property of *this* model: ``order_bases=True`` attaches an
+    ordering assertion to the two lens-light MGE bases, and it is checking that
+    assertion inside the jit that raises. The truth model has no assertion (and
+    no free parameters), so it cannot exercise it.
+    """
+    sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+    import initial_lens_model
+
+    return initial_lens_model.vis_lp_model_from(
+        mask_radius=euclid_dataset.mask_radius,
+        dataset_centre=euclid_dataset.dataset_centre,
+        redshift_lens=REDSHIFT_LENS,
+        redshift_source=REDSHIFT_SOURCE,
+    )
+
+
+def _ordered_median_vector(model):
+    """
+    A parameter vector that satisfies the ordering assertion.
+
+    The two lens bases' ``ell_comps_1`` priors are identical, so the median
+    vector puts them at the same value and the assertion ("basis 0 above basis
+    1") is not satisfied by it. The two entries are therefore separated about
+    their median, which is all the assertion asks for; every other parameter
+    stays at its prior median. The vector is not a fit — the latents it
+    produces are whatever this arbitrary model gives, and the test compares the
+    two backends on it rather than against any truth.
+    """
+    vector = list(model.physical_values_from_prior_medians)
+
+    priors = model.priors_ordered_by_id
+    profile_list = model.galaxies.lens.bulge.profile_list
+    gaussians_per_basis = len(profile_list) // 2
+
+    first = priors.index(profile_list[0].ell_comps.ell_comps_1)
+    second = priors.index(profile_list[gaussians_per_basis].ell_comps.ell_comps_1)
+
+    midpoint = 0.5 * (vector[first] + vector[second])
+    vector[first] = midpoint + 0.1
+    vector[second] = midpoint - 0.1
+
+    return vector
+
+
+def test_latent_euclid_variables_traces_under_jax_jit(
+    euclid_dataset, analysis, jax_analysis, monkeypatch
+):
+    """
+    ``LatentEuclid.variables`` must be traceable under ``jax.jit``.
+
+    The PyAutoFit latent engine evaluates the latents inside a per-sample
+    ``jax.jit`` (``LatentLens.BATCH_MODE = "jit"``), and nothing may raise
+    inside a trace: a raise is caught and written as a NaN row for **every**
+    sample, so the JAX ``vis_lp`` stage silently produced no latent output at
+    all (RAL 342398, all ten ``euclid_dr1_prelim`` tiles; PyAutoLens#732).
+    Calling ``variables`` eagerly, as every other test in this module does,
+    cannot see that: both failures are trace-time only.
+
+    The two failures this pins are ``instance_from_vector`` checking the
+    ordered-MGE-bases assertion with a Python ``not`` on a traced boolean
+    (``TracerBoolConversionError``) and ``Grid2D.from_mask`` reaching
+    ``jnp.nonzero`` with a traced size (``ConcretizationTypeError``).
+
+    ``effective_einstein_radius`` is asserted finite but not compared across
+    backends: the two paths use different solvers (the NumPy path contours the
+    tangential critical curve, the JAX path runs ``ZeroSolver``), and on this
+    deliberately unfitted median-prior mass model the curve is multi-valued, so
+    the two need not agree. Every other latent is compared, which is what
+    catches a traced value that is quietly wrong rather than merely finite.
+    """
+    monkeypatch.delenv("PYAUTO_SMALL_DATASETS", raising=False)
+
+    import jax
+    import jax.numpy as jnp
+
+    model = _vis_lp_model(euclid_dataset)
+    vector = _ordered_median_vector(model)
+
+    keys = util.LatentEuclid.keys(analysis)
+
+    eager = util.LatentEuclid.variables(
+        analysis=analysis, parameters=vector, model=model
+    )
+
+    traced = jax.jit(
+        lambda parameters: util.LatentEuclid.variables(
+            analysis=jax_analysis, parameters=parameters, model=model
+        )
+    )(jnp.asarray(vector))
+
+    values = dict(zip(keys, [float(value) for value in traced]))
+
+    assert len(values) == len(keys) == 12, (
+        "the jitted call must return one value per latent key; got "
+        f"{len(values)} against {len(keys)}"
+    )
+
+    for key, value in values.items():
+        assert np.isfinite(value), (
+            f"latent '{key}' is {value!r} under jax.jit — a raise inside the "
+            "trace is written as NaN for every sample, which is how the JAX "
+            "vis_lp stage came back with no latents at all (PyAutoLens#732)"
+        )
+
+    for key, eager_value in zip(keys, [float(value) for value in eager]):
+        if key == "effective_einstein_radius":
+            continue
+        assert values[key] == pytest.approx(eager_value, rel=JIT_VS_EAGER_REL), (
+            f"latent '{key}' traced to {values[key]!r} under jax.jit but "
+            f"evaluates to {eager_value!r} eagerly on NumPy (rel="
+            f"{JIT_VS_EAGER_REL})"
         )

--- a/util.py
+++ b/util.py
@@ -507,13 +507,26 @@ class LatentEuclid(al.LatentLens):
         the dataset, or naming a band not in the cut-out) the four values are
         NaN and are dropped from the written latent summary; the fit itself is
         unaffected.
+
+        The instance is built with ``latent_instance_from`` rather than
+        ``model.instance_from_vector``, because this method overrides
+        ``LatentLens.variables`` and so must build its own: the latent engine
+        evaluates it inside a per-sample ``jax.jit``, where checking the
+        ``vis_lp`` ordered-MGE-bases assertion applies a Python ``not`` to a
+        traced boolean and raises ``TracerBoolConversionError``, which the
+        engine turns into a NaN row for every sample — no latent output at all
+        (PyAutoLens#732).
         """
-        from autolens.analysis.latent import LATENT_FUNCTIONS, latent_keys_enabled
+        from autolens.analysis.latent import (
+            LATENT_FUNCTIONS,
+            latent_instance_from,
+            latent_keys_enabled,
+        )
 
         xp = analysis._xp
         magzero = analysis.kwargs.get("magzero", None)
 
-        instance = model.instance_from_vector(vector=parameters)
+        instance = latent_instance_from(model=model, parameters=parameters, xp=xp)
         fit = analysis.fit_from(instance=instance)
         context = {"fit": fit, "magzero": magzero, "xp": xp}
 
@@ -620,8 +633,14 @@ class LatentEuclid(al.LatentLens):
 
         try:
             tracer = fit.tracer_linear_light_profiles_to_light_profiles
+            # The reference grid is built on NumPy, without ``xp``: the mask is
+            # static, and under JAX ``Grid2D.from_mask`` reaches ``jnp.nonzero``,
+            # which needs a size known at trace time -> ``ConcretizationTypeError``
+            # inside the latent engine's per-sample ``jax.jit`` (PyAutoLens#732).
+            # The traced quantity is the source image evaluated on it, so ``xp``
+            # stays on ``image_2d_from`` below.
             grid_uniform = al.Grid2D.from_mask(
-                mask=fit.dataset.grids.lp.mask, over_sample_size=4, xp=xp
+                mask=fit.dataset.grids.lp.mask, over_sample_size=4
             )
             source_image = tracer.galaxies[-1].image_2d_from(grid=grid_uniform, xp=xp)
         except (AttributeError, IndexError):


### PR DESCRIPTION
Fixes #66

The JAX (GPU) `vis_lp` stage wrote **no** latents at all — RAL 342398, all ten `euclid_dr1_prelim` tiles. The PyAutoFit latent engine evaluates the latents inside a per-sample `jax.jit` (`LatentLens.BATCH_MODE = "jit"`), nothing may raise inside a trace, and the engine turns a raise into a NaN row for *every* sample. Two independent trace failures in `util.py`, both trace-time only and so invisible to the module's eager known-answer tests:

1. **`LatentEuclid.variables`** built its instance with `model.instance_from_vector`, which checks the `vis_lp` ordered-MGE-bases assertion (`order_bases=True`, added 2026-09-08) by applying a Python `not` to a traced boolean → `jax.errors.TracerBoolConversionError`. It now goes through `autolens.analysis.latent.latent_instance_from`, which skips the assertions under JAX and threads `xp`, exactly as `Fitness` does. `LatentEuclid` overrides `LatentLens.variables` (it has to, for the four Euclid aperture latents), so it builds its own instance and could not inherit the library-side fix.
2. **`_source_flux_latents_on_uniform_grid`** built the uniform reference grid with `al.Grid2D.from_mask(..., xp=xp)`, reaching `jnp.nonzero` with a size not known at trace time → `jax.errors.ConcretizationTypeError`. The mask is static, so the grid is built on NumPy; `xp` stays on the `image_2d_from` that evaluates the source on it, which is the traced quantity.

Diagnosis and the library half: PyAutoLens#732 / PyAutoLens#734.

## Scripts Changed

| File | Change |
|------|--------|
| `util.py` | `LatentEuclid.variables` builds its instance with `latent_instance_from`; `_source_flux_latents_on_uniform_grid` builds the uniform reference grid on NumPy (no `xp`), keeping `xp` on `image_2d_from`; docstring/comment on both, naming PyAutoLens#732. |
| `tests/test_compute_latent_variable.py` | One new test, `test_latent_euclid_variables_traces_under_jax_jit`, plus the `use_jax` flag on `_analysis_from`, a session-scoped `jax_analysis` fixture, and the module docstring's "deliberately JAX-free" sentence amended to name the exception. |
| `tests/test_catalogue_parity.py` | The `_EmptyRow` stub gains `known_paths: frozenset = frozenset()` — PyAutoFit#1598 made `Column._check_argument` consult that keyspace, and the stub predates it, so all four parametrized header cases were failing on `main` with `AttributeError`. |

The new test jits the **whole** `variables` call (an eager call cannot see either failure) on the `vis_lp` model — the model that actually carries the ordering assertion, built via `scripts/initial_lens_model.py:vis_lp_model_from` at the simulated dataset's own mask radius and centre — with a median-prior vector whose two lens-basis `ell_comps_1` entries are separated so the assertion is satisfied. It asserts all twelve `LatentEuclid.keys` are present and finite, and equal to the eager NumPy evaluation on the same vector (`rel=1e-3`). `effective_einstein_radius` is asserted finite but not compared: the two backends use different solvers (NumPy contours the tangential critical curve, JAX runs `ZeroSolver`), and on this deliberately unfitted median-prior mass model the curve is multi-valued, so they need not agree — that is a pre-existing library property, not something this PR changes.

## Test evidence

Serial, in the task worktree with `activate.sh` sourced:

- `pytest -q -m "not slow" tests` → **94 passed, 3 deselected, 0 failed**. Four of those (`test_catalogue_parity.py::test_catalogue_columns_reproduce_the_dr1_header[lens_mass|lens_sersic|source_sersic|magnitudes]`) were failing on `main` at 22abf6a with `AttributeError: '_EmptyRow' object has no attribute 'known_paths'` — drift from PyAutoFit#1598, which made `Column.value` consult `row.known_paths`. Fixed here in the second commit by giving the test-only stub that attribute; the parity contract itself is unchanged.
- Revert-check, one hunk at a time, new test only:
  - hunk 1 reverted (`model.instance_from_vector`) → `E jax.errors.TracerBoolConversionError: Attempted boolean conversion of traced array with shape bool[]` (1 failed).
  - hunk 2 reverted (`xp=xp` back on `Grid2D.from_mask`) → `E jax.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected: traced array with shape int64[]` (1 failed).
  - both in place → 1 passed (34 s, dataset load + compile included; unmarked, it belongs in the fast job).

## Gates

- **Library-first gate: satisfied** — the PyAutoLens half (PyAutoLens#734, `latent_instance_from`) is already merged on `main` (`0da06de6`); no library PR is pending for this task.
- **Heart: YELLOW, no RED** at ship time — `workspace validation not passing (5 failed, 2 timeout, cloud#34099198772: autolens multi_dataset/modeling, autolens_test imaging/delaunay, +4 more)`, three `profiling drift: runtime/imaging/{mge,mge_mass_jax,pixelization_numba_mge_mass}/…` rows, and `release validation incomplete: no rehearsal for current source`. All organism-scope; none touches this repository or the latent path.
- **RAL witness out of scope for this PR.** The prompt's witness — tile 102005065 rerun on the 342398 config writing `files/latent/latent_summary.json` with all twelve latents populated — needs the RAL libraries refreshed to the merged PyAutoLens `main`. That is a later science phase; this PR carries the unit-test half of the witness (`variables` under `jax.jit`, every value finite).

## CI note

PyAutoHeart's reusable `smoke-tests.yml` skips its matrix on PRs when no path under `scripts/`, `config/` or `.github/` changed. This diff touches only `util.py` and `tests/`, so the `unit` job of `.github/workflows/tests.yml` may be skipped by that path filter even though it is exactly the job that would exercise the new test. The checks below confirm it: `unit / smoke`, `slow / smoke` and `smoke / smoke` all report `skipping`, so no pytest ran in CI and the evidence for this PR is the local serial run above — the same basis pipeline PR #65 was merged on today. The gap itself is filed as `PyAutoMind/draft/bug/pyautoheart/smoke_gate_skips_pytest_runners_on_pr.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CybZmqjyQRDpfK3Cs1JaW2
