### PR TITLE
feat(catalogue): phase 2 of #60 — RAL catalogue build, row-level comparator, empty-aggregator guard

### DIFF
--- a/catalogue/scripts/lens_mass.py
+++ b/catalogue/scripts/lens_mass.py
@@ -141,7 +141,29 @@ def main():
     agg_query = agg.query(agg.unique_tag == args.unique_tag)
     agg_query = agg_query.query(agg_query.search.name == args.search_name)
 
-    agg_csv = af.AggregateCSV(aggregator=agg_query)
+    """
+    __An Empty Query Is Not An Error__
+
+    ``AggregateCSV`` raises ``ValueError("The aggregator is empty.")`` when the
+    two queries above match nothing — a results tree holding only the other
+    stage, which is the ordinary case for a ``vis_lp``-only tree scraped with
+    the default ``--search_name=vis_pix``.
+
+    That is caught and reported rather than raised, exactly as
+    ``deblending.py`` and ``magnitudes.py`` already do, because
+    ``scripts/build_inspection_bundle.sh`` runs under ``set -e``: a raised
+    ``ValueError`` here aborts every later stage of the bundle over a lens
+    stage that simply has not run yet. Returning early leaves no CSV, which is
+    the honest record of "nothing matched" and is what the later stages and the
+    per-lens split both already handle.
+    """
+    try:
+        agg_csv = af.AggregateCSV(aggregator=agg_query)
+    except ValueError as e:
+        print(
+            f"no completed {args.unique_tag}/{args.search_name} results: {e}"
+        )
+        return
 
     """
     __The lens_name Column__

--- a/catalogue/scripts/lens_sersic.py
+++ b/catalogue/scripts/lens_sersic.py
@@ -125,7 +125,29 @@ def main():
     agg_query = agg.query(agg.unique_tag == args.unique_tag)
     agg_query = agg_query.query(agg_query.search.name == args.search_name)
 
-    agg_csv = af.AggregateCSV(aggregator=agg_query)
+    """
+    __An Empty Query Is Not An Error__
+
+    ``AggregateCSV`` raises ``ValueError("The aggregator is empty.")`` when the
+    two queries above match nothing — a results tree holding only the other
+    stage, which is the ordinary case for a ``vis_lp``-only tree scraped with
+    the default ``--search_name=vis_pix``.
+
+    That is caught and reported rather than raised, exactly as
+    ``deblending.py`` and ``magnitudes.py`` already do, because
+    ``scripts/build_inspection_bundle.sh`` runs under ``set -e``: a raised
+    ``ValueError`` here aborts every later stage of the bundle over a lens
+    stage that simply has not run yet. Returning early leaves no CSV, which is
+    the honest record of "nothing matched" and is what the later stages and the
+    per-lens split both already handle.
+    """
+    try:
+        agg_csv = af.AggregateCSV(aggregator=agg_query)
+    except ValueError as e:
+        print(
+            f"no completed {args.unique_tag}/{args.search_name} results: {e}"
+        )
+        return
 
     """
     __Row Identity And Value Flavours__

--- a/catalogue/scripts/source_sersic.py
+++ b/catalogue/scripts/source_sersic.py
@@ -103,7 +103,29 @@ def main():
     agg_query = agg.query(agg.unique_tag == args.unique_tag)
     agg_query = agg_query.query(agg_query.search.name == args.search_name)
 
-    agg_csv = af.AggregateCSV(aggregator=agg_query)
+    """
+    __An Empty Query Is Not An Error__
+
+    ``AggregateCSV`` raises ``ValueError("The aggregator is empty.")`` when the
+    two queries above match nothing — a results tree holding only the other
+    stage, which is the ordinary case for a ``vis_lp``-only tree scraped with
+    the default ``--search_name=vis_pix``.
+
+    That is caught and reported rather than raised, exactly as
+    ``deblending.py`` and ``magnitudes.py`` already do, because
+    ``scripts/build_inspection_bundle.sh`` runs under ``set -e``: a raised
+    ``ValueError`` here aborts every later stage of the bundle over a lens
+    stage that simply has not run yet. Returning early leaves no CSV, which is
+    the honest record of "nothing matched" and is what the later stages and the
+    per-lens split both already handle.
+    """
+    try:
+        agg_csv = af.AggregateCSV(aggregator=agg_query)
+    except ValueError as e:
+        print(
+            f"no completed {args.unique_tag}/{args.search_name} results: {e}"
+        )
+        return
 
     """
     __Row Identity__

--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -16,6 +16,7 @@
 #   the underlying bug, and remove the NEEDS_FIX marker.
 
 - scripts/tools/diagnose_latent_vis_pix.py  # Population sweep over every vis_pix result in a sample; it takes no --dataset argument, so the runner's global args_default (--dataset=... --sample=...) is rejected by argparse. Its single-result sibling scripts/tools/diagnose_latent.py is smoked instead.
+- scripts/tools/compare_catalogues.py  # Row-level comparator between two *built* catalogues. It takes two catalogue directories as positional arguments, not the runner's global args_default (--dataset=... --sample=...), and there is no second catalogue in a checkout to compare against. tests/test_compare_catalogues.py runs it end to end on synthetic CSV pairs instead.
 - scripts/tools/build_inspect.py  # Collects the six inspection-bundle PNGs out of finished result zips. PYAUTO_FAST_PLOTS=1 in the smoke profile suppresses all PNG output, so there is nothing for it to collect.
 - catalogue/scripts/deblending.py  # Catalogue producer: needs a finished sersic_lens_model fit in every waveband to extract the deblended pre_psf.fits / model.fits.
 - catalogue/scripts/lens_mass.py  # Catalogue producer: aggregates converged initial_lens_model/vis_pix samples; test-mode samples carry no meaningful posterior.

--- a/hpc/README.md
+++ b/hpc/README.md
@@ -16,6 +16,7 @@ Read this page once to pick a route. Everything else about the fits themselves i
 | A large sample and many CPU cores, or no GPU | **Two-stage CPU** | `batch_cpu/submit_initial_lens_model_two_stage` | One submission; `vis_lp` under JAX on the CPU backend, then `vis_pix` with the Numba sparse operator and a process pool, as two consecutive Python processes. Measured on 8 cores with the committed config: 3 h 17 min per lens (26 min `vis_lp`, 2 h 51 min `vis_pix`). |
 | As above, but you want different walltime, memory or core counts per stage, or to re-run one stage alone | **Two-stage CPU, two jobs** | `batch_cpu/submit_initial_lens_model_vis_lp` then `batch_cpu/submit_initial_lens_model_vis_pix` | The same two stages as two array jobs. Submit the second once the first has finished. |
 | A cluster where JAX is unavailable or broken | **Numba only** | `batch_cpu/submit_initial_lens_model` | Both stages in one process with JAX disabled. The `vis_lp` stage is markedly slower this way. |
+| The fits are finished and you want the catalogue built where the results already live | **Catalogue build** | `batch_cpu/submit_build_inspection_bundle` | No fitting: runs `scripts/build_inspection_bundle.sh` over an existing results tree and writes `inspect/<sample>[_<run_tag>]/`. 4 cores, 8 GB, 6 h, partition `ral`. `SAMPLE`, `RUN_TAG`, `OUTPUT_DIR` and `SED_OUTPUT_DIR` are `--export` overrides. |
 
 Both figures come from the acceptance runs recorded below, with the committed,
 laptop-friendly `config/`. The "around 10 minutes per lens" quoted in the
@@ -181,8 +182,11 @@ shell profile.
 2. **The project path.** Export `PROJECT_PATH` to the project's root on the cluster
    before submitting; the scripts read it and it is the same location as
    `$HPC_BASE/$PROJECT_NAME` in `sync.conf`.
-3. **The partition names.** The scripts use `--partition=cpu` and `--partition=gpu`.
-   Rename them to your cluster's partitions, or override on the command line:
+3. **The partition names.** The fitting scripts use `--partition=cpu` and
+   `--partition=gpu`; `batch_cpu/submit_build_inspection_bundle` uses
+   `--partition=ral`, because RAL — the cluster the DR1 catalogue is built on —
+   has no `cpu` partition. Rename them to your cluster's partitions, or override
+   on the command line:
    `sbatch --partition=<name> hpc/batch_cpu/submit_initial_lens_model_two_stage`.
 4. **Submit from the script's directory**, or via `hpc/sync submit`. The `-o` / `-e`
    directives are relative paths into `output/` and `error/` beside the script, and

--- a/hpc/batch_cpu/submit_build_inspection_bundle
+++ b/hpc/batch_cpu/submit_build_inspection_bundle
@@ -1,0 +1,125 @@
+#!/bin/bash -l
+#
+# Build the inspection bundle (the catalogue) for one sample, on the cluster.
+#
+# WHAT THIS DOES
+#   Runs `scripts/build_inspection_bundle.sh` — the seven catalogue producers in
+#   dependency order — over a results tree that is already on the cluster, and
+#   leaves the bundle in `inspect/<sample>[_<run_tag>]/`. It fits nothing: every
+#   number it writes was produced by a fit that has already finished, so this is
+#   a read-and-scrape job, not a modelling job.
+#
+# WHY IT IS A CLUSTER JOB AT ALL
+#   The scrape itself is cheap per lens, but a DR1-sized sample is thousands of
+#   them and the aggregator unzips each result to read it. Doing that where the
+#   results already live avoids pulling tens of GB of `output/` down first, and
+#   the login node is the wrong place for an hours-long walk over the tree.
+#
+# RESOURCES
+#   One task, four CPUs, 8 GB, six hours, partition `ral`. The producers are
+#   serial Python and the work is dominated by unzip-and-read I/O rather than by
+#   arithmetic, so more cores buy nothing; the four are for the odd threaded
+#   numpy call and for headroom. 8 GB is comfortably above the working set — one
+#   result's samples summary at a time, plus the master CSV held in memory —
+#   and six hours covers a full DR1-prelim sample with margin.
+#
+# HOW TO SUBMIT
+#   From your machine, through the sync helper (which cds into this directory on
+#   the cluster and sbatches the basename, so `output/` and `error/` beside this
+#   script are where the logs land):
+#
+#     hpc/sync submit cpu submit_build_inspection_bundle
+#
+#   `hpc/sync push-submit cpu submit_build_inspection_bundle` pushes the code
+#   first. Do NOT push while fits are still running against the same tree.
+#
+#   Or, in a shell on the cluster, from this directory:
+#
+#     sbatch submit_build_inspection_bundle
+#
+#   Overrides go on the sbatch line, because `sbatch` does not carry your login
+#   shell's exports into the job unless you pass them:
+#
+#     sbatch --export=ALL,SAMPLE=dr1_prelim_grade_ab,RUN_TAG=run250 \
+#         submit_build_inspection_bundle
+
+#SBATCH -J euclid_build_inspection_bundle
+#SBATCH -n 1
+#SBATCH --cpus-per-task=4
+#SBATCH -o output/output.%A.out
+#SBATCH -e error/error.%A.err
+#SBATCH --partition=ral
+#SBATCH -t 06:00:00
+#SBATCH --mem=8gb
+#SBATCH --mail-type=END,FAIL
+#SBATCH --mail-user=your.email@institution.ac.uk
+
+# -----------------------------------------------------------------------------
+# Environment
+#
+# PROJECT_PATH is the project root on the cluster (the same location as
+# $HPC_BASE/$PROJECT_NAME in hpc/sync.conf) and PYAUTO_HPC_BASE the shared
+# PyAuto virtualenv beside the library checkouts. Both carry the RAL defaults
+# and both honour a value passed in with --export, so a different cluster or a
+# different project checkout needs no edit here.
+#
+# activate.sh is sourced by build_inspection_bundle.sh itself when
+# PYAUTO_HPC_BASE names a real directory and PYAUTO_ROOT is unset; it is sourced
+# here as well so that a failure to activate is reported by this script, at the
+# top of the log, rather than silently leaving the bundle to run against a
+# system Python.
+# -----------------------------------------------------------------------------
+export PROJECT_PATH="${PROJECT_PATH:-/mnt/ral/jnightin/euclid_dr1_prelim}"
+export PYAUTO_HPC_BASE="${PYAUTO_HPC_BASE:-/mnt/ral/jnightin/PyAuto}"
+
+source "$PROJECT_PATH/activate.sh"
+
+# Stop at the first failing stage rather than reporting success for a partial
+# bundle. build_inspection_bundle.sh runs under `set -e` itself.
+set -e
+
+# Nothing here is JAX or Numba work, but an incidental import must not reach for
+# a GPU that was not allocated, and Numba's on-disk cache is unreliable on NFS.
+export JAX_PLATFORM_NAME=cpu
+export JAX_PLATFORMS=cpu
+
+THREADS=$SLURM_CPUS_PER_TASK
+export OPENBLAS_NUM_THREADS=$THREADS
+export MKL_NUM_THREADS=$THREADS
+export OMP_NUM_THREADS=$THREADS
+export VECLIB_MAXIMUM_THREADS=$THREADS
+export NUMEXPR_NUM_THREADS=$THREADS
+
+# -----------------------------------------------------------------------------
+# What to build
+#
+# SAMPLE     the subdirectory of dataset/ (and of the results tree) to scrape.
+# RUN_TAG    an optional suffix on the bundle directory, so two builds of one
+#            sample do not overwrite each other: inspect/<sample>_<run_tag>/.
+#
+# OUTPUT_DIR / SED_OUTPUT_DIR / SKIP_SED / CREATE_ARCHIVE / DATASET_PREFIX are
+# read by build_inspection_bundle.sh straight out of the environment, so they
+# are exported here untouched rather than being re-implemented: pass any of them
+# with --export and the bundle builder honours it.
+# -----------------------------------------------------------------------------
+SAMPLE="${SAMPLE:-dr1_prelim_grade_ab}"
+RUN_TAG="${RUN_TAG:-}"
+
+export OUTPUT_DIR="${OUTPUT_DIR:-output}"
+export SED_OUTPUT_DIR="${SED_OUTPUT_DIR:-output_sed}"
+
+echo "=========================================="
+echo "Project    : $PROJECT_PATH"
+echo "Sample     : $SAMPLE"
+echo "Run tag    : ${RUN_TAG:-<none>}"
+echo "Output dir : $OUTPUT_DIR"
+echo "SED dir    : $SED_OUTPUT_DIR"
+echo "CPUs       : $THREADS"
+date
+
+cd "$PROJECT_PATH"
+bash scripts/build_inspection_bundle.sh "$SAMPLE" "$RUN_TAG"
+
+echo ""
+echo "Finished bundle: $SAMPLE ${RUN_TAG}"
+date

--- a/hpc/sync
+++ b/hpc/sync
@@ -332,6 +332,7 @@ submit_usage() {
     echo "    $(basename "$0") ${verb} cpu submit_initial_lens_model_two_stage"
     echo "    $(basename "$0") ${verb} cpu submit_initial_lens_model_vis_lp"
     echo "    $(basename "$0") ${verb} cpu submit_initial_lens_model_vis_pix"
+    echo "    $(basename "$0") ${verb} cpu submit_build_inspection_bundle"
 }
 
 submit() {
@@ -568,6 +569,7 @@ print_help() {
     echo "                                    submit_initial_lens_model_two_stage"
     echo "                                    submit_initial_lens_model_vis_lp"
     echo "                                    submit_initial_lens_model_vis_pix"
+    echo "                                    submit_build_inspection_bundle"
     echo "                                  GPU scripts:"
     echo "                                    submit_initial_lens_model"
     echo "                                    submit_full_model"

--- a/scripts/tools/compare_catalogues.py
+++ b/scripts/tools/compare_catalogues.py
@@ -1,0 +1,1089 @@
+"""
+Euclid Pipeline: Row-Level Catalogue Comparator
+===============================================
+
+Diff two built catalogues row by row and say, with a single PASS/FAIL, whether
+the second reproduces the first.
+
+``tests/test_catalogue_parity.py`` compares producer *headers*: it reads the
+``add_variable`` calls out of the producers' syntax trees and checks the column
+names they would write against stored DR1 fixtures. It runs nothing and reads no
+values, so a rebuild that emits the right header full of wrong — or blank —
+numbers passes it. This script is the other half: it reads the numbers.
+
+The question it answers is the DR1 rebuild's: the ``euclid_dr1_prelim`` fits are
+being repeated under ordered MGE bases and a low-disk output configuration, and
+the rebuilt catalogue has to be shown to be the same catalogue as the June
+reference at ``catalogue/catalogue/dr1_prelim_grade_ab_catalogue_csvs_20260623/``
+before any science is read off it.
+
+Usage
+-----
+::
+
+    python scripts/tools/compare_catalogues.py <catalogue_dir_A> <catalogue_dir_B>
+    python scripts/tools/compare_catalogues.py A B --tiles Tile102005065...,Tile102007299...
+    python scripts/tools/compare_catalogues.py A B --report parity.md
+
+Each directory is a bundle as ``scripts/build_inspection_bundle.sh`` writes one:
+a ``lens_mass.csv`` at its root, and optionally ``lens_sersic.csv``,
+``source_sersic.csv`` and ``magnitudes.csv`` beside it. ``lens_mass.csv`` is
+required on both sides; every other product is compared when both sides have it
+and reported as absent when they do not.
+
+A is the catalogue under test and B the reference, and the two are not
+symmetric: the latent-completeness checks below run on **A only**, because they
+ask whether the new build produced usable numbers, not whether the old one did.
+
+__What Counts As Agreement__
+
+Two independent nested-sampling runs of the same model on the same data are not
+bitwise reproducible, so most of this is a tolerance question rather than an
+equality question. Four rules, one per kind of quantity:
+
+**Tile identity — exact.** Rows are keyed by ``lens_name`` (and, for
+``magnitudes.csv``, by ``(lens_name, waveband)``, which is the row identity that
+producer writes). The key is compared as a string, with no normalisation: a tile
+present on one side only is reported and fails the check. Only the tiles common
+to both sides are carried into the value checks, so a partial rebuild is
+compared on what it built rather than being drowned in absences — but the
+identity check still records, and fails on, the difference.
+
+**Astrometry — exact.** Any of ``crval_ra_deg``, ``crval_dec_deg``, ``ra`` and
+``dec`` present on both sides must be equal as a float, with no tolerance: the
+position of a lens on the sky is read from its WCS, not sampled, so a rerun that
+moves it has read the wrong cut-out. Note that the DR1 ``lens_mass.csv`` carries
+no astrometry column — its ``centre_0``/``centre_1`` are arcsecond offsets within
+the cut-out, which *are* sampled — so for a lens_mass-only bundle this check is
+reported as skipped. The tile name itself encodes the RA and Dec, and the exact
+key match above is therefore already an exact astrometry match at tile
+resolution.
+
+**Values — combined 3σ.** For a value column ``x``, each side publishes
+``x_lower_1_sigma`` and ``x_upper_1_sigma``, so::
+
+    sigma = (x_upper_1_sigma - x_lower_1_sigma) / 2
+
+is that side's 1σ half-width, and the two agree when::
+
+    |a - b| <= 3 * sqrt(sigma_a**2 + sigma_b**2)
+
+which is the "combined 3σ" of the issue. The ``_lower_3_sigma`` / ``_upper_3_sigma``
+columns are not used for the tolerance — they are the posterior's own asymmetric
+3σ bounds rather than a scale, and combining two asymmetric intervals has no
+single defensible reading — but they *are* used by the latent-completeness
+checks below.
+
+The number this reduces to is reported for every quantity as::
+
+    z = |a - b| / sqrt(sigma_a**2 + sigma_b**2)
+
+and its median and maximum across the compared tiles are the rerun scatter a
+science ruling quotes: z < 3 is the pass condition, a median z near 1 means the
+two runs differ by about their own quoted error, and a median z near 0 would mean
+they are far more alike than their error bars — which for independent sampling
+runs is its own kind of surprise.
+
+**MGE ``ell_comps`` — up to a set swap.** ``order_bases=True`` deliberately
+re-labels which basis is which, so comparing ``ell_comps_0`` against
+``ell_comps_0`` compares two labels rather than two numbers. Each group of
+``…ell_comps_N`` columns is therefore compared as an unordered set: the pair
+agrees if *some* permutation of A's entries matches B's within the combined 3σ
+rule above. With two entries that is the identity and the swap, and the check
+records which of the two matched.
+
+__Which Quantities Gate The Result__
+
+The issue's tolerances name tile identity, astrometry, ``effective_einstein_radius``
+and the per-band magnitudes, and the ``ell_comps`` set swap. Those, plus the
+latent-completeness checks, are the **gated** checks: they decide PASS/FAIL and
+the exit code.
+
+Every other value column — the sampled mass and light parameters, ``centre``,
+``einstein_radius``, ``shear_gamma_*``, ``effective_radius``, ``sersic_index`` —
+is measured and reported under the same z statistic as **informational**. They
+are the rerun scatter of quantities nobody declared a tolerance for, which is
+worth reading and is not worth failing a build over.
+
+__Latent Completeness (Catalogue A Only)__
+
+Three checks that need only one catalogue, all of them pins on regressions this
+pipeline has actually shipped:
+
+1. **No blank latent cell.** A latent whose ``add_variable`` argument misses is
+   written *blank*, not raised — the ``latent.`` prefix bug that emptied
+   ``effective_einstein_radius`` and the whole of ``magnitudes.csv`` while
+   leaving the header at full DR1 width.
+
+2. **3σ strictly outside 1σ.** ``lower_3_sigma < lower_1_sigma`` and
+   ``upper_3_sigma > upper_1_sigma`` for every latent of every row. The
+   2026-09-10 ``row.py:102`` regression published a DR1 catalogue whose latent
+   3σ bounds were *equal* to its 1σ bounds, which is not a posterior any sampler
+   produces and which silently understates every latent error bar by a factor of
+   three.
+
+3. **max_lh differs from the median somewhere.** Where a latent carries a
+   ``_max_lh`` column, the maximum-likelihood value and the median of the
+   posterior must differ for at least one (row, latent): they are computed from
+   different samples, so a table where they agree everywhere is one where one of
+   them was copied from the other. ``lens_mass.csv`` carries no ``_max_lh``
+   column at all, so for a lens_mass-only bundle this check reports as skipped
+   rather than failing.
+
+A latent column is a value column whose base name is not one of the model
+parameters listed in ``MODEL_PARAMETER_BASES`` below. The list is short and
+closed because the catalogue's model columns are: a genuinely new model
+parameter must be added to it, and until it is, it is checked as a latent — which
+only ever means it is *also* required to be non-blank and to have real 3σ
+bounds.
+
+__Output__
+
+A markdown report on stdout, and to ``--report`` when given: one table per check
+with ``n_exact`` / ``n_within`` / ``n_outside`` counts and the tiles that fell
+outside, the z-statistic summary, and a final ``RESULT: PASS`` or
+``RESULT: FAIL`` line. Exit status is 1 on FAIL, 0 on PASS, so it can gate a
+rebuild from a shell script.
+
+No fit is run and no PyAuto library is imported: this reads CSVs.
+"""
+
+import argparse
+import csv
+import math
+import statistics
+import sys
+from pathlib import Path
+
+# The products a bundle can hold, and the columns that identify a row in each.
+# `lens_mass` is required; the rest are compared when both sides carry them.
+PRODUCTS = {
+    "lens_mass": ("lens_name",),
+    "lens_sersic": ("lens_name",),
+    "source_sersic": ("lens_name",),
+    "magnitudes": ("lens_name", "waveband"),
+}
+
+REQUIRED_PRODUCT = "lens_mass"
+
+# The five flavours `AggregateCSV` writes per variable. Stripping any of them
+# off a column name leaves the variable's base name; a column carrying none of
+# them is either the bare median or a label.
+VALUE_SUFFIXES = (
+    "_max_lh",
+    "_lower_1_sigma",
+    "_upper_1_sigma",
+    "_lower_3_sigma",
+    "_upper_3_sigma",
+)
+
+# Columns that identify a row rather than measuring anything.
+LABEL_COLUMNS = ("id", "lens_name", "waveband")
+
+# Astrometry is compared exactly. `crval_ra_deg` is the only one the DR1
+# producers write today (in `magnitudes.csv`); the others are named so a future
+# producer that adds them is covered without an edit here.
+ASTROMETRY_COLUMNS = ("crval_ra_deg", "crval_dec_deg", "ra", "dec")
+
+# Sampled model parameters. Everything else with a `_lower_1_sigma` column is a
+# latent — see "__Latent Completeness__" in the module docstring.
+MODEL_PARAMETER_BASES = frozenset(
+    {
+        "centre_0",
+        "centre_1",
+        "ell_comps_0",
+        "ell_comps_1",
+        "einstein_radius",
+        "shear_gamma_1",
+        "shear_gamma_2",
+        "effective_radius",
+        "sersic_index",
+    }
+)
+
+# The quantities whose agreement the issue declares a tolerance for, and which
+# therefore decide PASS/FAIL. Everything else is measured and reported without
+# gating. `ell_comps` is gated too, but through the set-swap check rather than
+# this list.
+GATED_BASES = frozenset(
+    {
+        "effective_einstein_radius",
+        "lens_flux",
+        "lens_flux_1_fwhm",
+        "lens_flux_2_fwhm",
+        "lens_flux_3_fwhm",
+        "lens_flux_4_fwhm",
+        "lensed_source_flux",
+        "source_flux",
+        "magnification",
+    }
+)
+
+SIGMA_MULTIPLE = 3.0
+
+# A z statistic needs a scale. When both sides publish a zero 1σ half-width the
+# ratio is undefined, so the pair is compared exactly instead and reported in
+# its own count rather than being silently passed or silently failed.
+ZERO_SIGMA = 0.0
+
+
+def parse_args(argv=None):
+    """
+    Two catalogue directories, an optional tile filter and an optional report
+    path. A is the catalogue under test, B the reference.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare two built Euclid catalogues row by row: tile identity and "
+            "astrometry exactly, values within a combined 3 sigma, MGE "
+            "ell_comps up to a set swap, plus latent-completeness checks on A."
+        )
+    )
+    parser.add_argument(
+        "catalogue_a",
+        metavar="catalogue_dir_A",
+        help="Directory of the catalogue under test (holds lens_mass.csv, ...).",
+    )
+    parser.add_argument(
+        "catalogue_b",
+        metavar="catalogue_dir_B",
+        help="Directory of the reference catalogue.",
+    )
+    parser.add_argument(
+        "--tiles",
+        metavar="t1,t2,...",
+        default=None,
+        help=(
+            "Comma-separated lens_name values to restrict the comparison to. "
+            "Default: every tile the two catalogues have in common."
+        ),
+    )
+    parser.add_argument(
+        "--report",
+        metavar="out.md",
+        default=None,
+        help="Also write the markdown report to this path.",
+    )
+    return parser.parse_args(argv)
+
+
+def read_product(directory: Path, product: str):
+    """
+    ``(fieldnames, rows)`` for one product of a bundle, or ``None`` when that
+    product is not in the directory. Rows are plain dicts of strings — nothing
+    is coerced here, because a blank cell is a finding rather than a zero.
+    """
+    path = directory / f"{product}.csv"
+    if not path.is_file():
+        return None
+
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+        return reader.fieldnames or [], rows
+
+
+def row_key(row, key_columns):
+    """
+    The identity of a row: the tuple of its key columns, as strings.
+    """
+    return tuple((row.get(column) or "").strip() for column in key_columns)
+
+
+def key_label(key):
+    """
+    A key rendered for a report table: the bare tile name for a one-column key,
+    ``tile/band`` for the two-column ``magnitudes`` key.
+    """
+    return "/".join(key)
+
+
+def base_name(column):
+    """
+    The variable a column belongs to: ``einstein_radius_lower_1_sigma`` and
+    ``einstein_radius`` both belong to ``einstein_radius``.
+
+    Suffixes are stripped by exact match, so ``lens_flux_1_fwhm_lower_1_sigma``
+    resolves to ``lens_flux_1_fwhm`` rather than to ``lens_flux``.
+    """
+    for suffix in VALUE_SUFFIXES:
+        if column.endswith(suffix):
+            return column[: -len(suffix)]
+    return column
+
+
+def value_bases(fieldnames):
+    """
+    The value variables of a header, in header order: every base that carries
+    both a ``_lower_1_sigma`` and an ``_upper_1_sigma`` column, which is what
+    makes a sigma — and so a tolerance — available for it.
+    """
+    present = set(fieldnames)
+    bases = []
+    for column in fieldnames:
+        base = base_name(column)
+        if base in bases or base in LABEL_COLUMNS:
+            continue
+        if f"{base}_lower_1_sigma" in present and f"{base}_upper_1_sigma" in present:
+            bases.append(base)
+    return bases
+
+
+def ell_comps_groups(bases):
+    """
+    Group the ``…ell_comps_N`` bases by their prefix, so each group is one
+    profile's set of elliptical components.
+
+    Returns ``{prefix: [base, ...]}`` ordered by ``N``. The DR1 producers write
+    a single unprefixed group of two, ``ell_comps_0`` and ``ell_comps_1``; the
+    grouping is written generally so a producer that emits several ordered MGE
+    bases is compared per profile rather than all in one pool.
+    """
+    groups = {}
+    for base in bases:
+        parts = base.rsplit("ell_comps_", 1)
+        if len(parts) != 2 or not parts[1].isdigit():
+            continue
+        groups.setdefault(parts[0], []).append((int(parts[1]), base))
+
+    return {
+        prefix: [base for _index, base in sorted(entries)]
+        for prefix, entries in groups.items()
+    }
+
+
+def as_float(value):
+    """
+    ``float(value)`` or ``None`` for a blank or unparseable cell. A blank cell is
+    the shape of the latent bug, so it is never silently a zero.
+    """
+    if value is None:
+        return None
+    text = value.strip()
+    if text == "":
+        return None
+    try:
+        result = float(text)
+    except ValueError:
+        return None
+    return None if math.isnan(result) else result
+
+
+def sigma_of(row, base):
+    """
+    The 1σ half-width ``(upper_1_sigma - lower_1_sigma) / 2``, or ``None`` when
+    either bound is missing.
+
+    ``abs`` guards the case of a producer writing the bounds the other way
+    round: a negative scale would invert every tolerance silently.
+    """
+    lower = as_float(row.get(f"{base}_lower_1_sigma"))
+    upper = as_float(row.get(f"{base}_upper_1_sigma"))
+    if lower is None or upper is None:
+        return None
+    return abs(upper - lower) / 2.0
+
+
+def z_statistic(value_a, sigma_a, value_b, sigma_b):
+    """
+    ``|a - b| / sqrt(sigma_a**2 + sigma_b**2)``, or ``None`` when the combined
+    scale is zero — in which case there is nothing to normalise by and the pair
+    has to be judged on exact equality instead.
+    """
+    scale = math.sqrt(sigma_a**2 + sigma_b**2)
+    if scale <= ZERO_SIGMA:
+        return None
+    return abs(value_a - value_b) / scale
+
+
+class Check:
+    """
+    One check's verdict: a name, a status, the markdown table it renders, and
+    whether it gates the overall result.
+
+    ``status`` is one of ``PASS``, ``FAIL``, ``SKIPPED`` (the inputs could not
+    support the check — a missing product or a missing column) and ``INFO`` (a
+    measurement that deliberately does not gate).
+    """
+
+    def __init__(self, name, status, lines, gating=True, note=None):
+        self.name = name
+        self.status = status
+        self.lines = lines
+        self.gating = gating
+        self.note = note
+
+    @property
+    def failed(self):
+        return self.gating and self.status == "FAIL"
+
+    def render(self):
+        out = [f"### {self.name} — {self.status}", ""]
+        if self.note:
+            out += [self.note, ""]
+        out += self.lines
+        out += [""]
+        return out
+
+
+def markdown_table(header, rows):
+    """
+    A markdown table, or a single italic line when there are no rows — an empty
+    table renders as a header with nothing under it, which reads as a bug.
+    """
+    if not rows:
+        return ["_no rows_"]
+    lines = [
+        "| " + " | ".join(header) + " |",
+        "|" + "|".join("---" for _ in header) + "|",
+    ]
+    for row in rows:
+        lines.append("| " + " | ".join(str(cell) for cell in row) + " |")
+    return lines
+
+
+def format_number(value, digits=4):
+    """
+    A number for a report cell; ``n/a`` for a missing one.
+    """
+    if value is None:
+        return "n/a"
+    return f"{value:.{digits}g}"
+
+
+def check_identity(product, rows_a, rows_b, key_columns, tile_filter):
+    """
+    Tile identity, exactly, plus the reference coverage.
+
+    Two questions live here and they are not the same question, so they are two
+    checks:
+
+    * **Identity gates.** Every row of A must exist in B under an exactly equal
+      key. A row A produced that the reference has never heard of is an identity
+      error — a mis-parsed tile name, a dataset directory renamed, a lens fitted
+      from the wrong cut-out — and it fails.
+    * **Coverage does not gate.** Rows of B that A has not produced are counted
+      and reported, because the ordinary case is a rebuild in progress: five
+      tiles of a 2990-tile reference is a valid comparison of five tiles, not a
+      2985-way failure. The coverage fraction is the number a ruling reads to
+      decide whether the rebuild is finished; it is not the number that decides
+      whether it is *correct*.
+
+    Returns the two checks and the common keys, in A's order and restricted by
+    ``--tiles``, which are the rows every value check below compares.
+    """
+    keys_a = [row_key(row, key_columns) for row in rows_a]
+    keys_b = {row_key(row, key_columns) for row in rows_b}
+
+    if tile_filter is not None:
+        keys_a = [key for key in keys_a if key[0] in tile_filter]
+        keys_b = {key for key in keys_b if key[0] in tile_filter}
+
+    set_a = set(keys_a)
+    only_a = sorted(set_a - keys_b)
+    only_b = sorted(keys_b - set_a)
+    common = [key for key in keys_a if key in keys_b]
+
+    identity_lines = markdown_table(
+        ["quantity", "count"],
+        [
+            ["rows in A", len(keys_a)],
+            ["n_exact (A rows matched in B)", len(set(common))],
+            ["n_outside (in A only)", len(only_a)],
+        ],
+    )
+    if only_a:
+        identity_lines += [""]
+        identity_lines += markdown_table(
+            ["row in A with no counterpart in B"], [[key_label(key)] for key in only_a[:20]]
+        )
+        if len(only_a) > 20:
+            identity_lines += ["", f"_… {len(only_a) - 20} further rows not listed_"]
+
+    identity = Check(
+        f"{product}: tile identity (exact)",
+        "FAIL" if only_a else "PASS",
+        identity_lines,
+        note=(
+            "Keys are compared as strings with no normalisation. Only the rows "
+            "common to both sides are carried into the value checks below."
+        ),
+    )
+
+    coverage_lines = markdown_table(
+        ["quantity", "count"],
+        [
+            ["distinct rows in B (reference)", len(keys_b)],
+            ["reproduced by A", len(set(common))],
+            ["not yet in A", len(only_b)],
+            [
+                "coverage",
+                f"{100.0 * len(set(common)) / len(keys_b):.1f}%" if keys_b else "n/a",
+            ],
+        ],
+    )
+    if only_b:
+        coverage_lines += [""]
+        coverage_lines += markdown_table(
+            ["row in B not in A"], [[key_label(key)] for key in only_b[:20]]
+        )
+        if len(only_b) > 20:
+            coverage_lines += ["", f"_… {len(only_b) - 20} further rows not listed_"]
+
+    coverage = Check(
+        f"{product}: reference coverage",
+        "INFO" if only_b else "PASS",
+        coverage_lines,
+        gating=False,
+        note=(
+            "How much of the reference this build has reproduced. Informational: "
+            "a partial rebuild is a valid comparison of the rows it did build."
+        ),
+    )
+
+    return identity, coverage, common
+
+
+def check_astrometry(product, index_a, index_b, common):
+    """
+    Astrometry, exactly. Skipped when neither catalogue publishes one of
+    ``ASTROMETRY_COLUMNS`` — which is the case for a ``lens_mass``-only bundle.
+    """
+    columns = [
+        column
+        for column in ASTROMETRY_COLUMNS
+        if any(column in row for row in (index_a.get(key) for key in common) if row)
+        and any(column in row for row in (index_b.get(key) for key in common) if row)
+    ]
+
+    if not common:
+        return Check(
+            f"{product}: astrometry (exact)",
+            "SKIPPED",
+            ["_no rows in common_"],
+        )
+
+    if not columns:
+        return Check(
+            f"{product}: astrometry (exact)",
+            "SKIPPED",
+            [
+                "_no astrometry column in this product; the exact tile-name match "
+                "is the astrometric identity at tile resolution_"
+            ],
+        )
+
+    table = []
+    outside = []
+    for column in columns:
+        n_exact = 0
+        n_outside = 0
+        for key in common:
+            value_a = as_float(index_a[key].get(column))
+            value_b = as_float(index_b[key].get(column))
+            if value_a is not None and value_b is not None and value_a == value_b:
+                n_exact += 1
+            else:
+                n_outside += 1
+                outside.append((column, key_label(key), index_a[key].get(column), index_b[key].get(column)))
+        table.append([column, n_exact, n_outside])
+
+    lines = markdown_table(["column", "n_exact", "n_outside"], table)
+    if outside:
+        lines += [""]
+        lines += markdown_table(
+            ["column", "row", "A", "B"], [list(entry) for entry in outside[:20]]
+        )
+        if len(outside) > 20:
+            lines += ["", f"_… {len(outside) - 20} further rows not listed_"]
+
+    return Check(
+        f"{product}: astrometry (exact)",
+        "FAIL" if outside else "PASS",
+        lines,
+    )
+
+
+def compare_base(index_a, index_b, common, base):
+    """
+    The combined-3σ comparison of one value base across the common rows.
+
+    Returns ``(n_within, n_outside, n_missing, outside, z_values)`` where
+    ``outside`` is the list of ``(row, a, b, z)`` that failed and ``z_values``
+    every z that could be formed. A row where either side is blank, or where
+    both sigmas are zero and the values differ, counts as outside: a blank is
+    exactly the failure this comparator exists to catch, so it is never a skip.
+    """
+    n_within = 0
+    outside = []
+    n_missing = 0
+    z_values = []
+
+    for key in common:
+        row_a, row_b = index_a[key], index_b[key]
+        value_a = as_float(row_a.get(base))
+        value_b = as_float(row_b.get(base))
+        sigma_a = sigma_of(row_a, base)
+        sigma_b = sigma_of(row_b, base)
+
+        if value_a is None or value_b is None or sigma_a is None or sigma_b is None:
+            n_missing += 1
+            outside.append((key, row_a.get(base), row_b.get(base), None))
+            continue
+
+        z = z_statistic(value_a, sigma_a, value_b, sigma_b)
+        if z is None:
+            # No scale on either side: the only defensible test is equality.
+            if value_a == value_b:
+                n_within += 1
+            else:
+                outside.append((key, value_a, value_b, None))
+            continue
+
+        z_values.append(z)
+        if z <= SIGMA_MULTIPLE:
+            n_within += 1
+        else:
+            outside.append((key, value_a, value_b, z))
+
+    return n_within, len(outside), n_missing, outside, z_values
+
+
+def _values_check(product, index_a, index_b, common, bases, title, gating):
+    """
+    The shared body of the gated and informational value checks: one table row
+    per base with its counts and its z summary, then the rows that fell outside.
+    """
+    if not common or not bases:
+        return Check(
+            f"{product}: {title}",
+            "SKIPPED",
+            ["_no rows or no columns to compare_"],
+            gating=gating,
+        )
+
+    table = []
+    all_outside = []
+    for base in bases:
+        n_within, n_outside, n_missing, outside, z_values = compare_base(
+            index_a, index_b, common, base
+        )
+        table.append(
+            [
+                base,
+                len(common),
+                n_within,
+                n_outside,
+                n_missing,
+                format_number(statistics.median(z_values)) if z_values else "n/a",
+                format_number(max(z_values)) if z_values else "n/a",
+            ]
+        )
+        all_outside += [(base, *entry) for entry in outside]
+
+    lines = markdown_table(
+        [
+            "quantity",
+            "n_compared",
+            "n_within_3sigma",
+            "n_outside",
+            "n_missing",
+            "median z",
+            "max z",
+        ],
+        table,
+    )
+    lines += [
+        "",
+        "_z = |a − b| / sqrt(sigma_a² + sigma_b²); the pass condition is z ≤ 3. "
+        "`n_missing` counts rows where a value or a sigma was blank on one side, "
+        "which is counted as outside._",
+    ]
+
+    if all_outside:
+        lines += [""]
+        lines += markdown_table(
+            ["quantity", "row", "A", "B", "z"],
+            [
+                [base, key_label(key), format_number(as_float(str(a)) if a is not None else None), format_number(as_float(str(b)) if b is not None else None), format_number(z)]
+                for base, key, a, b, z in all_outside[:20]
+            ],
+        )
+        if len(all_outside) > 20:
+            lines += ["", f"_… {len(all_outside) - 20} further rows not listed_"]
+
+    status = "FAIL" if all_outside else "PASS"
+    if not gating:
+        status = "INFO" if all_outside else "PASS"
+
+    return Check(f"{product}: {title}", status, lines, gating=gating)
+
+
+def check_gated_values(product, index_a, index_b, common, bases):
+    """
+    The declared-tolerance quantities: ``effective_einstein_radius`` and the
+    per-band magnitudes. These decide the result.
+    """
+    gated = [base for base in bases if base in GATED_BASES]
+    return _values_check(
+        product,
+        index_a,
+        index_b,
+        common,
+        gated,
+        "declared quantities (combined 3σ)",
+        gating=True,
+    )
+
+
+def check_informational_values(product, index_a, index_b, common, bases):
+    """
+    Every other value column, measured under the same statistic and reported
+    without gating — the rerun scatter of quantities no tolerance was declared
+    for. ``ell_comps`` is excluded: it has its own set-swap check.
+    """
+    ell_comps = {base for group in ell_comps_groups(bases).values() for base in group}
+    rest = [base for base in bases if base not in GATED_BASES and base not in ell_comps]
+    return _values_check(
+        product,
+        index_a,
+        index_b,
+        common,
+        rest,
+        "other quantities (informational, combined 3σ)",
+        gating=False,
+    )
+
+
+def _permutations(items):
+    """
+    Every ordering of ``items``. Written out rather than imported so the cost of
+    a large group is visible: the groups here have two entries.
+    """
+    if len(items) <= 1:
+        return [list(items)]
+    result = []
+    for index, item in enumerate(items):
+        rest = list(items[:index]) + list(items[index + 1 :])
+        for tail in _permutations(rest):
+            result.append([item] + tail)
+    return result
+
+
+def check_ell_comps(product, index_a, index_b, common, bases):
+    """
+    ``ell_comps`` up to a set swap: the group agrees when *some* permutation of
+    A's entries matches B's within the combined 3σ rule.
+
+    ``n_exact`` counts the rows that matched in the identity order (the labels
+    agree) and ``n_within`` the rows that needed a permutation (the labels were
+    swapped, which ``order_bases=True`` is entitled to do). Both pass; the split
+    is reported because a build where every row needed the swap is telling you
+    something about the ordering.
+    """
+    groups = ell_comps_groups(bases)
+    if not common or not groups:
+        return Check(
+            f"{product}: MGE ell_comps (set swap)",
+            "SKIPPED",
+            ["_no ell_comps columns in this product_"],
+        )
+
+    table = []
+    outside = []
+    for prefix, group in sorted(groups.items()):
+        label = f"{prefix}ell_comps" if prefix else "ell_comps"
+        n_identity = 0
+        n_swapped = 0
+        n_outside = 0
+
+        for key in common:
+            row_a, row_b = index_a[key], index_b[key]
+            values_a = [(as_float(row_a.get(base)), sigma_of(row_a, base)) for base in group]
+            values_b = [(as_float(row_b.get(base)), sigma_of(row_b, base)) for base in group]
+
+            if any(value is None or sigma is None for value, sigma in values_a + values_b):
+                n_outside += 1
+                outside.append((label, key_label(key), "blank cell", ""))
+                continue
+
+            matched_order = None
+            for order in _permutations(list(range(len(group)))):
+                agreed = True
+                for position, index in enumerate(order):
+                    value_a, sigma_a = values_a[position]
+                    value_b, sigma_b = values_b[index]
+                    z = z_statistic(value_a, sigma_a, value_b, sigma_b)
+                    if z is None:
+                        if value_a != value_b:
+                            agreed = False
+                            break
+                    elif z > SIGMA_MULTIPLE:
+                        agreed = False
+                        break
+                if agreed:
+                    matched_order = order
+                    break
+
+            if matched_order is None:
+                n_outside += 1
+                outside.append(
+                    (
+                        label,
+                        key_label(key),
+                        ", ".join(format_number(value) for value, _ in values_a),
+                        ", ".join(format_number(value) for value, _ in values_b),
+                    )
+                )
+            elif matched_order == list(range(len(group))):
+                n_identity += 1
+            else:
+                n_swapped += 1
+
+        table.append([label, len(common), n_identity, n_swapped, n_outside])
+
+    lines = markdown_table(
+        ["group", "n_compared", "n_exact (same order)", "n_within (swapped)", "n_outside"],
+        table,
+    )
+    if outside:
+        lines += [""]
+        lines += markdown_table(
+            ["group", "row", "A", "B"], [list(entry) for entry in outside[:20]]
+        )
+        if len(outside) > 20:
+            lines += ["", f"_… {len(outside) - 20} further rows not listed_"]
+
+    return Check(
+        f"{product}: MGE ell_comps (set swap)",
+        "FAIL" if outside else "PASS",
+        lines,
+    )
+
+
+def latent_bases(fieldnames):
+    """
+    The latent columns of a header: every value base that is not a sampled model
+    parameter.
+    """
+    return [base for base in value_bases(fieldnames) if base not in MODEL_PARAMETER_BASES]
+
+
+def check_latent_completeness(product, fieldnames, rows):
+    """
+    Catalogue A's latents must be present, must carry real 3σ bounds, and must
+    not have had their max-likelihood value copied from their median. See
+    "__Latent Completeness__" in the module docstring for why each of the three
+    is a pin on a shipped regression.
+    """
+    bases = latent_bases(fieldnames)
+    if not rows or not bases:
+        return Check(
+            f"{product}: latent completeness (A only)",
+            "SKIPPED",
+            ["_no rows, or no latent columns in this product_"],
+        )
+
+    present = set(fieldnames)
+    table = []
+    findings = []
+    any_max_lh_column = False
+    max_lh_differs = False
+
+    for base in bases:
+        columns = [base] + [
+            f"{base}{suffix}" for suffix in VALUE_SUFFIXES if f"{base}{suffix}" in present
+        ]
+        n_blank = 0
+        n_collapsed = 0
+
+        has_max_lh = f"{base}_max_lh" in present
+        any_max_lh_column = any_max_lh_column or has_max_lh
+
+        for row in rows:
+            key = row.get("lens_name", "?")
+
+            blank = [column for column in columns if as_float(row.get(column)) is None]
+            if blank:
+                n_blank += 1
+                findings.append((base, key, "blank", ", ".join(blank)))
+                continue
+
+            lower_1 = as_float(row.get(f"{base}_lower_1_sigma"))
+            upper_1 = as_float(row.get(f"{base}_upper_1_sigma"))
+            lower_3 = as_float(row.get(f"{base}_lower_3_sigma"))
+            upper_3 = as_float(row.get(f"{base}_upper_3_sigma"))
+
+            if None not in (lower_1, upper_1, lower_3, upper_3):
+                if not (lower_3 < lower_1 and upper_3 > upper_1):
+                    n_collapsed += 1
+                    findings.append(
+                        (
+                            base,
+                            key,
+                            "3σ not outside 1σ",
+                            f"1σ [{format_number(lower_1)}, {format_number(upper_1)}] "
+                            f"3σ [{format_number(lower_3)}, {format_number(upper_3)}]",
+                        )
+                    )
+
+            if has_max_lh:
+                median = as_float(row.get(base))
+                max_lh = as_float(row.get(f"{base}_max_lh"))
+                if median is not None and max_lh is not None and median != max_lh:
+                    max_lh_differs = True
+
+        table.append([base, len(rows), n_blank, n_collapsed, "yes" if has_max_lh else "no"])
+
+    lines = markdown_table(
+        ["latent", "n_rows", "n_blank_rows", "n_3sigma_not_outside_1sigma", "has max_lh column"],
+        table,
+    )
+
+    if any_max_lh_column and not max_lh_differs:
+        findings.append(
+            ("(all latents)", "-", "max_lh == median everywhere", "no latent moved")
+        )
+
+    if not any_max_lh_column:
+        lines += [
+            "",
+            "_No `_max_lh` column in this product, so the max_lh-vs-median check "
+            "is not applicable here (`lens_mass.csv` publishes medians only)._",
+        ]
+
+    if findings:
+        lines += [""]
+        lines += markdown_table(
+            ["latent", "row", "finding", "detail"], [list(entry) for entry in findings[:20]]
+        )
+        if len(findings) > 20:
+            lines += ["", f"_… {len(findings) - 20} further findings not listed_"]
+
+    return Check(
+        f"{product}: latent completeness (A only)",
+        "FAIL" if findings else "PASS",
+        lines,
+    )
+
+
+def compare(directory_a: Path, directory_b: Path, tile_filter=None):
+    """
+    Run every check over every product the two bundles share, and return the
+    list of ``Check``s in report order.
+    """
+    checks = []
+
+    if read_product(directory_a, REQUIRED_PRODUCT) is None:
+        raise SystemExit(f"ERROR: no {REQUIRED_PRODUCT}.csv in {directory_a}")
+    if read_product(directory_b, REQUIRED_PRODUCT) is None:
+        raise SystemExit(f"ERROR: no {REQUIRED_PRODUCT}.csv in {directory_b}")
+
+    for product, key_columns in PRODUCTS.items():
+        table_a = read_product(directory_a, product)
+        table_b = read_product(directory_b, product)
+
+        if table_a is None or table_b is None:
+            sides = []
+            if table_a is None:
+                sides.append("A")
+            if table_b is None:
+                sides.append("B")
+            checks.append(
+                Check(
+                    f"{product}: present in both catalogues",
+                    "SKIPPED",
+                    [f"_{product}.csv absent from catalogue {' and '.join(sides)}_"],
+                )
+            )
+            continue
+
+        fieldnames_a, rows_a = table_a
+        fieldnames_b, rows_b = table_b
+
+        index_a = {row_key(row, key_columns): row for row in rows_a}
+        index_b = {row_key(row, key_columns): row for row in rows_b}
+
+        identity, coverage, common = check_identity(
+            product, rows_a, rows_b, key_columns, tile_filter
+        )
+        checks.append(identity)
+        checks.append(coverage)
+
+        bases_b = set(value_bases(fieldnames_b))
+        bases = [base for base in value_bases(fieldnames_a) if base in bases_b]
+
+        checks.append(check_astrometry(product, index_a, index_b, common))
+        checks.append(check_gated_values(product, index_a, index_b, common, bases))
+        checks.append(check_ell_comps(product, index_a, index_b, common, bases))
+        checks.append(check_latent_completeness(product, fieldnames_a, rows_a))
+        checks.append(check_informational_values(product, index_a, index_b, common, bases))
+
+    return checks
+
+
+def render_report(directory_a, directory_b, tile_filter, checks):
+    """
+    The whole markdown report: a header naming the two catalogues, a summary
+    table of every check's status, then each check in full, then the RESULT
+    line.
+    """
+    failed = [check for check in checks if check.failed]
+
+    lines = [
+        "# Catalogue comparison",
+        "",
+        f"- **A (under test)**: `{directory_a}`",
+        f"- **B (reference)**: `{directory_b}`",
+        f"- **Tile filter**: {'none' if tile_filter is None else ', '.join(sorted(tile_filter))}",
+        "",
+        "## Summary",
+        "",
+    ]
+    lines += markdown_table(
+        ["check", "status", "gates result"],
+        [[check.name, check.status, "yes" if check.gating else "no"] for check in checks],
+    )
+    lines += ["", "## Checks", ""]
+    for check in checks:
+        lines += check.render()
+
+    lines += [
+        "## Result",
+        "",
+        f"RESULT: {'FAIL' if failed else 'PASS'}"
+        + (f" ({len(failed)} gating check(s) failed)" if failed else ""),
+    ]
+    return "\n".join(lines), bool(failed)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+
+    directory_a = Path(args.catalogue_a)
+    directory_b = Path(args.catalogue_b)
+
+    for directory in (directory_a, directory_b):
+        if not directory.is_dir():
+            raise SystemExit(f"ERROR: no such catalogue directory: {directory}")
+
+    tile_filter = None
+    if args.tiles:
+        tile_filter = {tile.strip() for tile in args.tiles.split(",") if tile.strip()}
+
+    checks = compare(directory_a, directory_b, tile_filter=tile_filter)
+    report, failed = render_report(directory_a, directory_b, tile_filter, checks)
+
+    print(report)
+
+    if args.report:
+        report_path = Path(args.report)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(report + "\n")
+        print(f"\nwrote {report_path}", file=sys.stderr)
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_catalogue_latent_columns.py
+++ b/tests/test_catalogue_latent_columns.py
@@ -35,6 +35,13 @@ So this one runs the real thing:
   requires each one that is not a ``galaxies...`` model path to be, exactly, a
   key of ``util.LatentEuclid``. That catches a re-introduced prefix and a
   renamed latent without touching the disk.
+* ``test_producers_survive_an_empty_query`` points a producer at a results tree
+  holding only the *other* search and asserts it returns cleanly with no CSV,
+  rather than letting ``AggregateCSV``'s ``ValueError("The aggregator is
+  empty.")`` out. ``scripts/build_inspection_bundle.sh`` runs under ``set -e``,
+  so that exception aborted every later stage of the bundle over a stage that
+  simply had not run yet — the ordinary state of a ``vis_lp``-only tree scraped
+  with the default ``--search_name=vis_pix``.
 
 JAX-free and search-free, as the fast suite requires: no fit is run, the results
 are written by hand from PyAutoFit's serializers and the latent values are
@@ -330,6 +337,58 @@ def test_magnitudes_writes_no_blank_cells(tmp_path, monkeypatch, pipeline_config
     assert len(rows) == len(LENS_NAMES) * len(BANDS), (
         "magnitudes.csv carries one row per (lens, waveband); a different count "
         "means the de-duplication dropped a band"
+    )
+
+
+EMPTY_QUERY_PRODUCERS = ("lens_mass", "lens_sersic", "source_sersic")
+
+
+@pytest.mark.parametrize("producer", EMPTY_QUERY_PRODUCERS)
+def test_producers_survive_an_empty_query(producer, tmp_path, monkeypatch, pipeline_config):
+    """
+    A results tree that holds a completed ``vis_lp`` search and nothing else,
+    scraped by a producer whose default ``--search_name`` is ``vis_pix``: the
+    query matches nothing, and the producer must say so and return rather than
+    raise.
+
+    The tree is deliberately *not* empty — a missing sample directory is a
+    different, already-handled path — so what is under test is an aggregator
+    that found results and a query that excluded all of them, which is what
+    ``af.AggregateCSV`` raises ``ValueError("The aggregator is empty.")`` on.
+
+    The assertion is that no CSV is written, not that an empty one is: an absent
+    file is the honest record of "nothing matched", and ``build_inspection_bundle.sh``
+    and the per-lens split both already handle it.
+    """
+    import autofit as af
+    import autolens as al
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model(
+                al.Galaxy,
+                redshift=0.5,
+                mass=al.mp.Isothermal,
+                shear=al.mp.ExternalShear,
+            )
+        )
+    )
+
+    for offset, lens_name in enumerate(LENS_NAMES):
+        _write_result(
+            model,
+            path_prefix=Path(SAMPLE) / lens_name,
+            name="vis_lp",
+            unique_tag="initial_lens_model",
+            offset=1.0 + offset,
+        )
+
+    inspect_path = tmp_path / "inspect"
+    _run_producer(producer, monkeypatch, pipeline_config, inspect_path)
+
+    assert not (inspect_path / f"{producer}.csv").exists(), (
+        f"{producer}.py wrote a CSV for a query that matched nothing; an empty "
+        "query should leave no product behind"
     )
 
 

--- a/tests/test_compare_catalogues.py
+++ b/tests/test_compare_catalogues.py
@@ -1,0 +1,318 @@
+"""
+The row-level catalogue comparator's verdicts.
+
+``scripts/tools/compare_catalogues.py`` is the tool that decides whether a
+rebuilt DR1 catalogue is the same catalogue as the June reference. Nothing else
+in this repository reads catalogue *values*: ``tests/test_catalogue_parity.py``
+compares producer headers out of the syntax tree, and
+``tests/test_catalogue_latent_columns.py`` runs the producers and asserts their
+cells are non-blank. So the comparator is the only thing standing between a
+plausible-looking rebuild and a science ruling, and its verdicts are what this
+module pins.
+
+Five cases, one per rule the comparator implements, each built from a pair of
+tiny CSVs written here rather than from a real bundle:
+
+* ``test_identical_catalogues_pass`` — the same numbers on both sides is a PASS
+  and exit code 0. Without this the other four cases could all be satisfied by a
+  comparator that fails everything.
+* ``test_einstein_radius_outside_three_sigma_fails`` — one tile moved far
+  outside the combined 3σ fails, **and the failing tile is named in the report**.
+  A comparator that fails without saying which row is not usable.
+* ``test_swapped_mge_bases_pass`` — ``ell_comps_0`` and ``ell_comps_1``
+  exchanged is a PASS, because ``order_bases=True`` deliberately re-labels the
+  bases; comparing label to label rather than set to set would fail every
+  ordered rebuild.
+* ``test_blank_latent_cell_fails`` — a blank ``effective_einstein_radius`` cell
+  fails. This is the ``latent.`` prefix regression, which is written blank
+  rather than raised.
+* ``test_three_sigma_equal_to_one_sigma_fails`` — 3σ bounds equal to the 1σ
+  bounds fail. This is the 2026-09-10 ``row.py:102`` regression, which shipped a
+  published DR1 catalogue whose latent error bars were understated threefold.
+
+The comparator imports no PyAuto library and runs no fit, so these are pure-CSV
+tests: fast, and safe in the ``not slow`` suite.
+"""
+
+import csv
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+
+TILE_A = "Tile102005065RA0135279431487DECNEG0701599765928"
+TILE_B = "Tile102007299RA0702283866574DECNEG0660415308762"
+
+# The value bases the synthetic lens_mass.csv carries: the two elliptical
+# components and the Einstein radius are sampled model parameters, and
+# `effective_einstein_radius` is the latent whose blank cells this comparator
+# was written to catch.
+BASES = ("ell_comps_0", "ell_comps_1", "einstein_radius", "effective_einstein_radius")
+
+VALUE_SUFFIXES = ("_lower_1_sigma", "_upper_1_sigma", "_lower_3_sigma", "_upper_3_sigma")
+
+
+@pytest.fixture(scope="module")
+def comparator():
+    """
+    ``scripts/tools/compare_catalogues.py`` loaded by path: it is a script run
+    with ``python scripts/tools/...``, not an importable package member, so it
+    is loaded the way ``tests/test_catalogue_latent_columns.py`` loads a
+    producer.
+    """
+    path = PROJECT_ROOT / "scripts" / "tools" / "compare_catalogues.py"
+    spec = importlib.util.spec_from_file_location("_compare_catalogues_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _columns():
+    """
+    The header of the synthetic ``lens_mass.csv``: the two label columns, then
+    five columns per base, in the order ``AggregateCSV`` writes them.
+    """
+    header = ["id", "lens_name"]
+    for base in BASES:
+        header.append(base)
+        header += [f"{base}{suffix}" for suffix in VALUE_SUFFIXES]
+    return header
+
+
+def _row(lens_name, values, *, blank=(), collapsed=()):
+    """
+    One CSV row from ``{base: (median, sigma)}``.
+
+    The four bound columns are built from the median and the sigma, so a row is
+    self-consistent by construction and a test that wants an *in*consistent one
+    has to ask for it: ``blank`` empties every column of a base (the latent
+    prefix bug) and ``collapsed`` writes the 3σ bounds equal to the 1σ bounds
+    (the ``row.py:102`` bug).
+    """
+    row = {"id": f"{lens_name}_id", "lens_name": lens_name}
+    for base, (median, sigma) in values.items():
+        if base in blank:
+            row[base] = ""
+            for suffix in VALUE_SUFFIXES:
+                row[f"{base}{suffix}"] = ""
+            continue
+        row[base] = repr(median)
+        row[f"{base}_lower_1_sigma"] = repr(median - sigma)
+        row[f"{base}_upper_1_sigma"] = repr(median + sigma)
+        if base in collapsed:
+            row[f"{base}_lower_3_sigma"] = repr(median - sigma)
+            row[f"{base}_upper_3_sigma"] = repr(median + sigma)
+        else:
+            row[f"{base}_lower_3_sigma"] = repr(median - 3 * sigma)
+            row[f"{base}_upper_3_sigma"] = repr(median + 3 * sigma)
+    return row
+
+
+def _write_catalogue(directory, rows):
+    """
+    Write ``lens_mass.csv`` into ``directory`` — the one product the comparator
+    requires on both sides.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    with open(directory / "lens_mass.csv", "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=_columns())
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+    return directory
+
+
+def _baseline_values(offset=0.0):
+    """
+    A self-consistent set of values, with a sigma small enough that a 0.5 shift
+    is many sigma away and large enough that the 3σ interval is not degenerate.
+    """
+    return {
+        "ell_comps_0": (0.10 + offset, 0.01),
+        "ell_comps_1": (-0.20 + offset, 0.01),
+        "einstein_radius": (1.50 + offset, 0.02),
+        "effective_einstein_radius": (1.40 + offset, 0.02),
+    }
+
+
+def _run(comparator, directory_a, directory_b, tmp_path, extra=()):
+    """
+    Run the comparator's ``main`` over the two directories and return
+    ``(exit_code, report_text)``. The report is read back from ``--report``
+    rather than captured off stdout, because the file is what a rebuild keeps.
+    """
+    report = tmp_path / "report.md"
+    code = comparator.main(
+        [str(directory_a), str(directory_b), "--report", str(report), *extra]
+    )
+    return code, report.read_text()
+
+
+def _status_of(report, check_name):
+    """
+    The status the summary table records for one check.
+    """
+    for line in report.splitlines():
+        if line.startswith(f"| {check_name} |"):
+            return line.split("|")[2].strip()
+    raise AssertionError(f"no '{check_name}' row in the report summary:\n{report}")
+
+
+def test_identical_catalogues_pass(comparator, tmp_path, capsys):
+    """
+    Two identical catalogues are a PASS with exit code 0.
+
+    This is the control: every other case here asserts a FAIL, and a comparator
+    that returned FAIL unconditionally would satisfy all of them.
+    """
+    rows = [
+        _row(TILE_A, _baseline_values()),
+        _row(TILE_B, _baseline_values(offset=0.3)),
+    ]
+    directory_a = _write_catalogue(tmp_path / "a", rows)
+    directory_b = _write_catalogue(tmp_path / "b", rows)
+
+    code, report = _run(comparator, directory_a, directory_b, tmp_path)
+
+    assert "RESULT: PASS" in report
+    assert code == 0
+    assert _status_of(report, "lens_mass: tile identity (exact)") == "PASS"
+    assert _status_of(report, "lens_mass: declared quantities (combined 3σ)") == "PASS"
+    assert _status_of(report, "lens_mass: MGE ell_comps (set swap)") == "PASS"
+    assert _status_of(report, "lens_mass: latent completeness (A only)") == "PASS"
+
+
+def test_einstein_radius_outside_three_sigma_fails(comparator, tmp_path):
+    """
+    One tile whose ``effective_einstein_radius`` has moved far outside the
+    combined 3σ fails, and the report names that tile.
+
+    ``effective_einstein_radius`` is the gated quantity; the other tile is left
+    identical so the failure cannot be blamed on the whole table.
+    """
+    good = _row(TILE_A, _baseline_values())
+
+    values_b = _baseline_values(offset=0.3)
+    moved = dict(values_b)
+    # 0.5 against a 0.02 sigma on each side is z ≈ 18, far outside the 3 the
+    # comparator allows.
+    moved["effective_einstein_radius"] = (
+        values_b["effective_einstein_radius"][0] + 0.5,
+        values_b["effective_einstein_radius"][1],
+    )
+
+    directory_a = _write_catalogue(tmp_path / "a", [good, _row(TILE_B, moved)])
+    directory_b = _write_catalogue(tmp_path / "b", [good, _row(TILE_B, values_b)])
+
+    code, report = _run(comparator, directory_a, directory_b, tmp_path)
+
+    assert "RESULT: FAIL" in report
+    assert code == 1
+    assert _status_of(report, "lens_mass: declared quantities (combined 3σ)") == "FAIL"
+    assert TILE_B in report, "the failing tile must be named, not just counted"
+
+    # The tile that agrees is not dragged into the failure.
+    outside_section = report.split("### lens_mass: declared quantities")[1].split("###")[0]
+    assert TILE_A not in outside_section
+
+
+def test_swapped_mge_bases_pass(comparator, tmp_path):
+    """
+    ``ell_comps_0`` and ``ell_comps_1`` exchanged between the two catalogues is
+    a PASS: ``order_bases=True`` re-labels the bases on purpose, so the pair is
+    compared as a set.
+
+    The rest of the row is left alone, so a comparator that passed this by
+    ignoring ``ell_comps`` altogether would still have to fail the other cases.
+    """
+    values = _baseline_values()
+    swapped = dict(values)
+    swapped["ell_comps_0"], swapped["ell_comps_1"] = (
+        values["ell_comps_1"],
+        values["ell_comps_0"],
+    )
+
+    directory_a = _write_catalogue(tmp_path / "a", [_row(TILE_A, swapped)])
+    directory_b = _write_catalogue(tmp_path / "b", [_row(TILE_A, values)])
+
+    code, report = _run(comparator, directory_a, directory_b, tmp_path)
+
+    assert _status_of(report, "lens_mass: MGE ell_comps (set swap)") == "PASS"
+    assert "RESULT: PASS" in report
+    assert code == 0
+
+    # And the swap is reported as a swap, not as an identity match: a build
+    # where every row needed the permutation is worth seeing.
+    section = report.split("### lens_mass: MGE ell_comps")[1].split("###")[0]
+    assert "| ell_comps | 1 | 0 | 1 | 0 |" in section
+
+
+def test_blank_latent_cell_fails(comparator, tmp_path):
+    """
+    A blank ``effective_einstein_radius`` in catalogue A fails the
+    latent-completeness check — the ``latent.`` prefix regression, which
+    ``add_variable`` writes as an empty cell rather than raising.
+    """
+    values = _baseline_values()
+    directory_a = _write_catalogue(
+        tmp_path / "a", [_row(TILE_A, values, blank=("effective_einstein_radius",))]
+    )
+    directory_b = _write_catalogue(tmp_path / "b", [_row(TILE_A, values)])
+
+    code, report = _run(comparator, directory_a, directory_b, tmp_path)
+
+    assert _status_of(report, "lens_mass: latent completeness (A only)") == "FAIL"
+    assert "RESULT: FAIL" in report
+    assert code == 1
+    assert "blank" in report
+
+
+def test_three_sigma_equal_to_one_sigma_fails(comparator, tmp_path):
+    """
+    3σ bounds equal to the 1σ bounds fail: no sampler produces that posterior,
+    and the DR1 catalogue published on 2026-09-10 did exactly this, understating
+    every latent error bar by a factor of three.
+
+    The medians are identical on both sides, so nothing but the collapsed bounds
+    can be what fails.
+    """
+    values = _baseline_values()
+    directory_a = _write_catalogue(
+        tmp_path / "a", [_row(TILE_A, values, collapsed=("effective_einstein_radius",))]
+    )
+    directory_b = _write_catalogue(tmp_path / "b", [_row(TILE_A, values)])
+
+    code, report = _run(comparator, directory_a, directory_b, tmp_path)
+
+    assert _status_of(report, "lens_mass: latent completeness (A only)") == "FAIL"
+    assert _status_of(report, "lens_mass: declared quantities (combined 3σ)") == "PASS"
+    assert "RESULT: FAIL" in report
+    assert code == 1
+    assert "3σ not outside 1σ" in report
+
+
+def test_tiles_filter_restricts_the_comparison(comparator, tmp_path):
+    """
+    ``--tiles`` scopes every check to the named tiles, which is how a rebuild in
+    progress is compared against the full reference without the tiles it has not
+    reached yet counting against it.
+    """
+    values = _baseline_values()
+    moved = dict(values)
+    moved["effective_einstein_radius"] = (values["effective_einstein_radius"][0] + 0.5, 0.02)
+
+    directory_a = _write_catalogue(
+        tmp_path / "a", [_row(TILE_A, values), _row(TILE_B, moved)]
+    )
+    directory_b = _write_catalogue(
+        tmp_path / "b", [_row(TILE_A, values), _row(TILE_B, values)]
+    )
+
+    code, report = _run(comparator, directory_a, directory_b, tmp_path, extra=[f"--tiles={TILE_A}"])
+
+    assert "RESULT: PASS" in report
+    assert code == 0
+    assert TILE_B not in report


### PR DESCRIPTION
Phase 2 of #60 — items 5–7 of the issue's plan. Phase 1 (#61, ordered MGE bases
and the low-disk output config) is merged; this is the half that gates the
**catalogue build** rather than the reruns.

## Scripts Changed

| Path | Change |
|---|---|
| `hpc/batch_cpu/submit_build_inspection_bundle` | **New.** The SLURM job this repo had no way to launch: runs `scripts/build_inspection_bundle.sh` over a results tree already on the cluster. Partition `ral`, 6 h, 8 GB, 1 task / 4 cpus. `SAMPLE` (default `dr1_prelim_grade_ab`), `RUN_TAG`, `OUTPUT_DIR` and `SED_OUTPUT_DIR` are `--export` overrides; `PROJECT_PATH` and `PYAUTO_HPC_BASE` carry RAL defaults and honour an override, because `sbatch` does not carry the login shell's exports into the job. |
| `hpc/README.md` | Route table gains the catalogue-build row; the partition-names bullet records that this one script uses `--partition=ral` because RAL has no `cpu` partition. |
| `hpc/sync` | `submit` / `push-submit` usage and `help` list the new script. `hpc/sync submit cpu submit_build_inspection_bundle` cds into `hpc/batch_cpu/` on the cluster and `sbatch`es the basename, which is why the logs land in `output/` and `error/` beside it. |
| `scripts/tools/compare_catalogues.py` | **New.** The row-level comparator (see below). |
| `catalogue/scripts/lens_mass.py` | Guards `af.AggregateCSV`'s `ValueError("The aggregator is empty.")` and returns, as `deblending.py` and `magnitudes.py` already do. |
| `catalogue/scripts/lens_sersic.py` | Same guard — it had the same crash. |
| `catalogue/scripts/source_sersic.py` | Same guard — it had the same crash. |
| `config/build/no_run.yaml` | The comparator is excluded from the smoke runner with a reason (it takes two catalogue directories, not the runner's `--dataset`/`--sample`, and a checkout has no second catalogue). `tests/test_repo_invariants.py` requires this. |
| `tests/test_compare_catalogues.py` | **New**, 6 cases. |
| `tests/test_catalogue_latent_columns.py` | 3 new cases pinning the empty-query guard, one per producer. |

### Which producers got the empty-aggregator guard

| Producer | Before | Action |
|---|---|---|
| `lens_mass.py` | raised | **guarded** |
| `lens_sersic.py` | raised | **guarded** |
| `source_sersic.py` | raised | **guarded** |
| `deblending.py` | already guarded (`AggregateFITS`, per dataset) | none |
| `magnitudes.py` | already guarded (`AggregateCSV`) | none |
| `multi_wavelength.py` | already guarded (`AggregateImages`, per dataset) | none |

So the issue named one crash and there were three: `lens_sersic.py` and
`source_sersic.py` abort `build_inspection_bundle.sh` at stages 4 and 5 exactly
as `lens_mass.py` did at stage 3.

## The comparator

`python scripts/tools/compare_catalogues.py <A> <B> [--tiles t1,t2] [--report out.md]`,
A the catalogue under test and B the reference. Rules, all stated in the module
docstring:

- **Tile identity — exact.** Keys (`lens_name`, or `(lens_name, waveband)` for
  `magnitudes.csv`) compared as strings with no normalisation. A row of A with no
  counterpart in B fails. Rows of B that A has not built are reported separately
  as **reference coverage**, which does *not* gate: five tiles of a 2990-tile
  reference is a valid comparison of five tiles, not a 2985-way failure.
- **Astrometry — exact.** `crval_ra_deg` / `crval_dec_deg` / `ra` / `dec` where
  present on both sides. `lens_mass.csv` publishes none (its `centre_0/1` are
  sampled arcsecond offsets), so for a lens_mass-only bundle this reports
  SKIPPED — the exact tile-name match is already an exact astrometric match at
  tile resolution.
- **Declared quantities — combined 3σ.** `effective_einstein_radius` and the
  per-band magnitudes. σ is each side's 1σ half-width
  `(upper_1_sigma − lower_1_sigma)/2`, and the pair agrees when
  `|a − b| ≤ 3·sqrt(σa² + σb²)`. These gate the result.
- **MGE `ell_comps` — up to a set swap.** `order_bases=True` re-labels the bases
  deliberately, so each `…ell_comps_N` group is compared as an unordered set; the
  report splits "same order" from "swapped", because a build where every row
  needed the permutation is worth seeing.
- **Latent completeness, on A only.** No blank cell in any latent column (the
  `latent.` prefix regression, which is written blank rather than raised); 3σ
  bounds strictly outside the 1σ bounds (the 2026-09-10 `row.py:102` regression,
  which shipped a published DR1 catalogue whose latent error bars were
  understated threefold); and `max_lh ≠ median` for at least one latent, where a
  `_max_lh` column exists at all.
- Every other value column is measured under the same statistic and reported as
  **informational** — the rerun scatter of quantities nobody declared a tolerance
  for.

For every quantity the report prints the median and max of
`z = |a − b| / sqrt(σa² + σb²)`, which is how the rerun scatter between two
same-library builds is quoted in a ruling. Exit code 1 on FAIL.

## Comparator baseline (the pre-fix bundle vs the June reference)

Run once on the laptop as the witness for this PR. **A** =
`inspect/dr1_prelim_grade_ab_ordered_v2/` in the `euclid_dr1_prelim` science
clone (the pre-fix build, 5 tiles), **B** = the June reference
`catalogue/catalogue/dr1_prelim_grade_ab_catalogue_csvs_20260623/` (2990 rows).
No catalogue was built and no `output*` tree was touched. `RESULT: FAIL`, exit 1.

| check | status | gates result |
|---|---|---|
| lens_mass: tile identity (exact) | PASS | yes |
| lens_mass: reference coverage | INFO (5 / 2990 = 0.2%) | no |
| lens_mass: astrometry (exact) | SKIPPED | yes |
| lens_mass: declared quantities (combined 3σ) | **FAIL** | yes |
| lens_mass: MGE ell_comps (set swap) | **FAIL** | yes |
| lens_mass: latent completeness (A only) | **FAIL** | yes |
| lens_mass: other quantities (informational, combined 3σ) | INFO | no |
| lens_sersic / source_sersic / magnitudes | SKIPPED | — |

`lens_sersic.csv`, `source_sersic.csv` and `magnitudes.csv` are absent from A;
only `lens_mass.csv` was built.

**Declared quantities**

| quantity | n_compared | n_within_3σ | n_outside | n_missing | median z | max z |
|---|---|---|---|---|---|---|
| effective_einstein_radius | 5 | 0 | 5 | 5 | n/a | n/a |

All five `effective_einstein_radius` cells in A are **blank** — this is the
pre-fix build, so there is nothing to compare and no z can be formed. The same
blanks are what fails latent completeness (`n_blank_rows = 5 / 5`). This is the
expected pre-fix signature and is the thing the post-342629 rebuild has to clear.

**MGE `ell_comps`**

| group | n_compared | n_exact (same order) | n_within (swapped) | n_outside |
|---|---|---|---|---|
| ell_comps | 5 | 0 | 0 | **5** |

Neither ordering matches within combined 3σ on any of the five tiles.

**Informational scatter** — the number this baseline is really for:

| quantity | n_compared | n_within_3σ | n_outside | median z | max z |
|---|---|---|---|---|---|
| centre_0 | 5 | 2 | 3 | 8.86 | 152.4 |
| centre_1 | 5 | 0 | 5 | 4.51 | 11.96 |
| einstein_radius | 5 | 3 | 2 | 2.30 | 84.6 |
| shear_gamma_1 | 5 | 2 | 3 | 5.03 | 117.9 |
| shear_gamma_2 | 5 | 0 | 5 | 7.34 | 15.98 |

Read that as measurement, not verdict: **A and B are two independent runs of the
same model on the same data, and they disagree by roughly 2–9 times their own
combined error bar, with excursions past 100σ.** The posteriors are extremely
tight (`einstein_radius` 1σ half-widths of ~0.0015 on values near 3), so a
0.3-arcsec shift between runs is z ≈ 85. That is the rerun scatter the DR1
parity question is actually about, and it is the baseline the post-342629
rebuild will be judged against — a rebuild that lands *inside* these numbers is
reproducing the reference, and one that reproduces these z values has changed
nothing.

The full report is reproducible with:

```bash
python scripts/tools/compare_catalogues.py \
    /mnt/c/Users/Jammy/Science/euclid_dr1_prelim/inspect/dr1_prelim_grade_ab_ordered_v2 \
    /mnt/c/Users/Jammy/Science/euclid/catalogue/catalogue/dr1_prelim_grade_ab_catalogue_csvs_20260623 \
    --report parity.md
```

## Tests

`python -m pytest -q -m "not slow" tests` from the worktree: **103 passed, 3
deselected**, against a `main` baseline of 94 passed / 3 deselected.

- `tests/test_compare_catalogues.py` (6): identical catalogues PASS with exit 0
  (the control — every other case asserts FAIL); an `effective_einstein_radius`
  moved outside combined 3σ FAILs *and names the tile*, with the agreeing tile
  left out of the failure section; swapped MGE bases PASS and are reported as a
  swap; a blank latent cell FAILs; 3σ equal to 1σ FAILs while the value check
  still passes, so only the collapsed bounds can be what failed; and `--tiles`
  scopes every check.
- `tests/test_catalogue_latent_columns.py` (3 new, parametrized over the three
  producers): a completed `vis_lp`-only result tree scraped with the default
  `--search_name=vis_pix` returns cleanly and writes no CSV. Verified red before
  the fix — reverting `lens_mass.py` to `main` fails that case with the
  `ValueError`.

Both are CSV-only or serializer-only: no fit, no JAX, no search. The comparator
imports no PyAuto library at all.

## CI

PyAutoHeart's reusable `smoke-tests.yml` skips its matrix unless `scripts/`,
`config/`, `.github/` or the smoke lists change. This diff touches
`scripts/tools/compare_catalogues.py` and `config/build/no_run.yaml`, so the
path filter should let both the `unit` and `slow` jobs run rather than skipping
them — the `hpc/` and `catalogue/` changes alone would not have been enough.
Checked and reported on the PR once the runs report.

Part of #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CybZmqjyQRDpfK3Cs1JaW2
