### PR TITLE
feat(hpc): SED chain runs on CPU by default — JAX on the CPU backend like vis_lp

### DIFF
--- a/hpc/README.md
+++ b/hpc/README.md
@@ -1,9 +1,13 @@
 # Running the pipeline on a cluster
 
 This directory holds everything needed to run `scripts/initial_lens_model.py` (and the
-other fitting pipelines) under SLURM: example submission scripts for a GPU route and a
-CPU route in `batch_gpu/` and `batch_cpu/`, and the `sync` script that moves code,
+other fitting pipelines) under SLURM: example submission scripts for a CPU route and a
+GPU route in `batch_cpu/` and `batch_gpu/`, and the `sync` script that moves code,
 datasets, logs and results between your machine and the cluster.
+
+The initial lens model has both routes and the GPU one is the faster per lens. The
+SED chain runs on **CPU by default** (`batch_cpu/submit_sersic_waveband`), with the
+GPU script kept as an option; see the route table below.
 
 Read this page once to pick a route. Everything else about the fits themselves is in
 `start_here.py`; the submission scripts only decide *where* and *how* that script runs.
@@ -16,6 +20,8 @@ Read this page once to pick a route. Everything else about the fits themselves i
 | A large sample and many CPU cores, or no GPU | **Two-stage CPU** | `batch_cpu/submit_initial_lens_model_two_stage` | One submission; `vis_lp` under JAX on the CPU backend, then `vis_pix` with the Numba sparse operator and a process pool, as two consecutive Python processes. Measured on 8 cores with the committed config: 3 h 17 min per lens (26 min `vis_lp`, 2 h 51 min `vis_pix`). |
 | As above, but you want different walltime, memory or core counts per stage, or to re-run one stage alone | **Two-stage CPU, two jobs** | `batch_cpu/submit_initial_lens_model_vis_lp` then `batch_cpu/submit_initial_lens_model_vis_pix` | The same two stages as two array jobs. Submit the second once the first has finished. |
 | A cluster where JAX is unavailable or broken | **Numba only** | `batch_cpu/submit_initial_lens_model` | Both stages in one process with JAX disabled. The `vis_lp` stage is markedly slower this way. |
+| The VIS fits are done and you want the multi-band SED chain (Sersic VIS fit + every other waveband) | **SED chain, CPU** (default) | `batch_cpu/submit_sersic_waveband` | `vis_lp` (short-circuited from its cached zip) then the VIS Sersic fit then one Sersic fit per non-VIS band, in one process with JAX pinned to the CPU backend. 8 cores, 64 GB, 12 h, partition `ral`, writes to `output_sed/` via `PYAUTO_OUTPUT_DIR`. |
+| As above, but a GPU node is free and the sample is small | **SED chain, GPU** (optional) | `batch_gpu/submit_sersic_waveband` | The identical chain on a GPU node. Both SED analyses are `use_jax=True`, so the only difference from the CPU default is which backend the same JAX likelihood runs on. |
 | The fits are finished and you want the catalogue built where the results already live | **Catalogue build** | `batch_cpu/submit_build_inspection_bundle` | No fitting: runs `scripts/build_inspection_bundle.sh` over an existing results tree and writes `inspect/<sample>[_<run_tag>]/`. 4 cores, 8 GB, 6 h, partition `ral`. `SAMPLE`, `RUN_TAG`, `OUTPUT_DIR` and `SED_OUTPUT_DIR` are `--export` overrides. |
 
 Both figures come from the acceptance runs recorded below, with the committed,
@@ -72,6 +78,14 @@ is `--number_of_cores` pool processes and giving each worker a full set of BLAS
 threads oversubscribes the node. The scripts set these per stage; the two-job scripts
 carry one block each, and the single-submission script applies each block with `env`
 on its own command line so nothing leaks between the stages.
+
+The SED chain has no such split, which is why `batch_cpu/submit_sersic_waveband` is a
+single process with a single environment block. Both of its stages —
+`scripts/sersic_lens_model.py` and `scripts/lens_model_waveband.py` — build their
+analysis with `use_jax=True`, so the whole chain is one JAX likelihood with the CPU
+backend pinned, exactly like `vis_lp` above: no Numba stage, no pool, no fork boundary
+to preserve. It must therefore *not* be passed `--use_cpu`, which sets
+`use_jax = not use_cpu` and would swap both SED likelihoods to Numba.
 
 The stages also run in separate Python processes. This is a conservative default rather
 than a measured necessity. PyAutoFit documents that a forked worker whose *likelihood*
@@ -182,11 +196,11 @@ shell profile.
 2. **The project path.** Export `PROJECT_PATH` to the project's root on the cluster
    before submitting; the scripts read it and it is the same location as
    `$HPC_BASE/$PROJECT_NAME` in `sync.conf`.
-3. **The partition names.** The fitting scripts use `--partition=cpu` and
-   `--partition=gpu`; `batch_cpu/submit_build_inspection_bundle` uses
-   `--partition=ral`, because RAL — the cluster the DR1 catalogue is built on —
-   has no `cpu` partition. Rename them to your cluster's partitions, or override
-   on the command line:
+3. **The partition names.** The initial-lens-model fitting scripts use
+   `--partition=cpu` and `--partition=gpu`; `batch_cpu/submit_build_inspection_bundle`
+   and `batch_cpu/submit_sersic_waveband` use `--partition=ral`, because RAL — the
+   cluster the DR1 catalogue is built on — has no `cpu` partition. Rename them to your
+   cluster's partitions, or override on the command line:
    `sbatch --partition=<name> hpc/batch_cpu/submit_initial_lens_model_two_stage`.
 4. **Submit from the script's directory**, or via `hpc/sync submit`. The `-o` / `-e`
    directives are relative paths into `output/` and `error/` beside the script, and

--- a/hpc/batch_cpu/submit_sersic_waveband
+++ b/hpc/batch_cpu/submit_sersic_waveband
@@ -1,0 +1,158 @@
+#!/bin/bash -l
+#
+# SED chain (Sersic VIS fit + every other waveband) on CPU -- the default route.
+#
+# WHAT THIS DOES
+#   Runs `scripts/sersic_lens_model_waveband.py` with JAX pinned to the CPU
+#   backend: `vis_lp` (short-circuited if its result zip is already in the tree)
+#   -> the VIS Sersic fit -> one Sersic fit per non-VIS band, all in one Python
+#   process inside a single SLURM allocation.
+#
+# WHY CPU IS THE DEFAULT
+#   Both SED stages are already JAX likelihoods -- `scripts/sersic_lens_model.py`
+#   and `scripts/lens_model_waveband.py` build their analysis with `use_jax=True`
+#   ("JAX is always on for this search"). Nothing in the model code is
+#   GPU-specific; the backend is chosen by the environment. So the CPU route is
+#   the *same* JAX likelihood with the backend pinned to CPU -- exactly what
+#   stage 1 of `batch_cpu/submit_initial_lens_model_two_stage` does for `vis_lp`,
+#   and the `env` line below is that stage's line with a different driver.
+#
+#   `batch_gpu/submit_sersic_waveband` runs the identical chain on a GPU node
+#   and remains available; it is the optional route, for when a GPU is free and
+#   the sample is small.
+#
+# DO NOT PASS `--use_cpu`
+#   That flag sets `use_jax = not use_cpu` on the analyses, which is what the
+#   `vis_pix` stage of the initial lens model wants (Numba sparse operator,
+#   forked pool) and is wrong here: it would swap both SED likelihoods from JAX
+#   to Numba and lose the reason this route is fast. Pinning the *backend* is the
+#   whole of what "run on CPU" means for this chain.
+#
+# WHY THE `vis_lp` HASH IS UNCHANGED
+#   `number_of_cores` never reaches the `vis_lp` search dictionary (only
+#   `vis_pix` reads it, `scripts/initial_lens_model.py`), so passing
+#   `--number_of_cores` here does not perturb the `vis_lp` search settings and
+#   the seeded result zip still resolves to the same hash -- the chain
+#   short-circuits with "Fit Already Completed: skipping non-linear search"
+#   rather than re-fitting.
+#
+# CPU COUNT AND WALLTIME
+#   The parallelism here is JAX/BLAS *threads*, not a process pool, so
+#   `--cpus-per-task` is spent the way stage 1 of the two-stage script spends it;
+#   8 is a sensible starting point and the threaded speed-up flattens off beyond
+#   it. Walltime is sized from the euclid precedent on 4 cores -- 5-12 min for
+#   the Sersic fit and 5-30 min per band, with up to 8 bands per tile, so a worst
+#   case near 4 h; 12 h leaves headroom for a slow node.
+
+#SBATCH -J euclid_sersic_waveband
+#SBATCH -n 1
+#SBATCH --cpus-per-task=8
+#SBATCH -o output/output.%A_%a.out
+#SBATCH -e error/error.%A_%a.err
+#SBATCH --partition=ral
+#SBATCH -t 12:00:00
+#SBATCH --mem=64gb
+#SBATCH --array=0-9
+#SBATCH --mail-type=END,FAIL
+#SBATCH --mail-user=your.email@institution.ac.uk
+
+# -----------------------------------------------------------------------------
+# Environment
+#
+# Set PROJECT_PATH to this project on the HPC before submitting:
+#
+#   export PROJECT_PATH=/PATH/TO/LARGE_STORAGE/YOUR_USERNAME/euclid_strong_lens_modeling_pipeline
+#   sbatch hpc/batch_cpu/submit_sersic_waveband
+#
+# This is the same location as $HPC_BASE/$PROJECT_NAME in hpc/sync.conf.
+#
+# Nothing JAX-related and no thread counts are exported here: the run below
+# carries its own on its `env` line.
+# -----------------------------------------------------------------------------
+source $PROJECT_PATH/activate.sh
+
+# Stop the job the moment something fails, rather than carrying on.
+set -e
+
+THREADS=$SLURM_CPUS_PER_TASK
+
+# -------------------------------
+# Output directory
+#
+# The SED chain fits every waveband, so it produces many more result folders
+# than a VIS-only run. `PYAUTO_OUTPUT_DIR` sends them to their own tree, keeping
+# `output/` (the initial lens model results) readable. The catalogue's stages 6
+# and 7 - `catalogue/scripts/multi_wavelength.py` and
+# `catalogue/scripts/magnitudes.py` - read this tree by name.
+#
+# Both upstream stages cache-short-circuit if their result zips already exist
+# at $PYAUTO_OUTPUT_DIR/<sample>/<dataset>/initial_lens_model/vis_lp/<hash>.zip
+# and .../sersic_lens_model/vis/<hash>.zip, so copying existing results into
+# this tree before submitting skips straight to the wavebands.
+# -------------------------------
+export PYAUTO_OUTPUT_DIR=output_sed
+
+# -------------------------------
+# Sample
+# -------------------------------
+sample=q1_walsmley
+
+# -------------------------------
+# Dataset list
+# -------------------------------
+datasets=(
+102018665_NEG570040238507752998
+)
+
+INDEX=$SLURM_ARRAY_TASK_ID
+dataset="${datasets[$INDEX]}"
+
+echo "=========================================="
+echo "Array task : $INDEX / ${#datasets[@]}"
+echo "Sample     : $sample"
+echo "Dataset    : $dataset"
+echo "CPUs       : $THREADS"
+echo "Output dir : $PYAUTO_OUTPUT_DIR"
+date
+
+# Fail fast if JAX is not actually on the CPU backend. This is the mirror of the
+# guard in `batch_gpu/submit_sersic_waveband`, and it exists for the same reason:
+# a chain that silently runs on the wrong backend looks alive and burns its whole
+# walltime. Here the wrong backend would be a GPU this job never allocated (an
+# inherited JAX_PLATFORMS, or a node whose CUDA JAX build picks a device), which
+# would either fail on a device it may not use or take resources the CPU
+# partition did not grant. The guard also trips when `activate.sh` found no
+# environment at all, because then JAX is not importable -- read the `.err` file
+# before blaming the backend.
+env JAX_PLATFORM_NAME=cpu JAX_PLATFORMS=cpu \
+    python3 -c 'import jax; b = jax.default_backend(); print(f"JAX backend: {b}"); raise SystemExit(0 if b == "cpu" else 1)' || {
+    echo "ERROR: JAX is not on the CPU backend on $(hostname); refusing to run. Check that the environment activated and that no JAX_PLATFORMS/CUDA_VISIBLE_DEVICES is inherited from your shell." >&2
+    exit 1
+}
+
+# -----------------------------------------------------------------------------
+# The SED chain: vis_lp (forced --stage=vis_lp inside the driver) -> Sersic VIS
+# -> every other waveband. JAX on the CPU backend.
+#
+# JAX_PLATFORM_NAME / JAX_PLATFORMS keep JAX off any GPU that was not allocated.
+# Every linear algebra library gets the full allocation, because this run's
+# parallelism is threads: the searches evaluate a batch of models on the device
+# rather than through a pool.
+# -----------------------------------------------------------------------------
+echo ""
+echo "---- SED chain (JAX on CPU) ----"
+date
+
+env JAX_PLATFORM_NAME=cpu \
+    JAX_PLATFORMS=cpu \
+    OPENBLAS_NUM_THREADS=$THREADS \
+    MKL_NUM_THREADS=$THREADS \
+    OMP_NUM_THREADS=$THREADS \
+    VECLIB_MAXIMUM_THREADS=$THREADS \
+    NUMEXPR_NUM_THREADS=$THREADS \
+    NPROC=$THREADS \
+    python3 $PROJECT_PATH/scripts/sersic_lens_model_waveband.py --sample=$sample --dataset=$dataset \
+        --number_of_cores=$THREADS
+
+echo "Finished: $dataset"
+date

--- a/hpc/batch_gpu/submit_sersic_waveband
+++ b/hpc/batch_gpu/submit_sersic_waveband
@@ -1,4 +1,11 @@
 #!/bin/bash -l
+#
+# SED chain (Sersic VIS fit + every other waveband) on a GPU node -- the
+# OPTIONAL route. The default is `batch_cpu/submit_sersic_waveband`, which runs
+# the identical chain with JAX pinned to the CPU backend; both SED analyses are
+# `use_jax=True`, so the only difference between the two scripts is which
+# backend the same JAX likelihood lands on. Prefer this one when a GPU node is
+# free and the sample is small; prefer the CPU default otherwise.
 
 #SBATCH -J euclid_sersic_waveband
 #SBATCH --partition=gpu

--- a/hpc/sync
+++ b/hpc/sync
@@ -104,8 +104,9 @@ LOG_DIRS=(
 #
 # `output/`      the main VIS results tree.
 # `output_sed/`  the multi-band SED tree written by
-#                hpc/batch_gpu/submit_sersic_waveband (PYAUTO_OUTPUT_DIR), which
-#                the catalogue's stages 6-7 read.
+#                hpc/batch_cpu/submit_sersic_waveband (PYAUTO_OUTPUT_DIR) - or by
+#                hpc/batch_gpu/submit_sersic_waveband, the optional GPU route -
+#                which the catalogue's stages 6-7 read.
 # `inspect/`     the per-lens inspection bundles built by
 #                scripts/build_inspection_bundle.sh.
 # A directory that does not exist on the HPC is skipped rather than failing.
@@ -570,6 +571,7 @@ print_help() {
     echo "                                    submit_initial_lens_model_vis_lp"
     echo "                                    submit_initial_lens_model_vis_pix"
     echo "                                    submit_build_inspection_bundle"
+    echo "                                    submit_sersic_waveband"
     echo "                                  GPU scripts:"
     echo "                                    submit_initial_lens_model"
     echo "                                    submit_full_model"

--- a/scripts/sersic_lens_model.py
+++ b/scripts/sersic_lens_model.py
@@ -250,7 +250,9 @@ def fit_sersic(
     Nautilus settles this twelve-parameter space with a much smaller live-point set
     than the ``vis_lp`` fit needs (``n_live=100`` against 750), and ``n_like_max``
     caps a runaway fit. ``batch_size`` controls how many models are evaluated
-    simultaneously on the GPU; JAX is always on for this search.
+    simultaneously on the JAX backend (CPU by default on RAL, via
+    ``hpc/batch_cpu/submit_sersic_waveband``; GPU optional); JAX is always on for
+    this search.
     """
     analysis = util.AnalysisImaging(
         dataset=dataset,


### PR DESCRIPTION
## Summary

The SED chain (Sersic VIS fit + per-band waveband fits, driver
`scripts/sersic_lens_model_waveband.py`) had exactly one submit script,
`hpc/batch_gpu/submit_sersic_waveband`, which refuses to start unless
`jax.default_backend() == "gpu"`. This adds the CPU route and makes it the default, so
future SED submissions run on CPU like everything else in the project.

The CPU route is not a different likelihood. Both SED stages already build their
analysis with `use_jax=True` (`scripts/sersic_lens_model.py`, "JAX is always on for this
search", and `scripts/lens_model_waveband.py`), so nothing in the model code is
GPU-specific — the backend is chosen by the environment. `hpc/batch_cpu/submit_sersic_waveband`
therefore runs the same chain with JAX pinned to the CPU backend, using the *same*
`env JAX_PLATFORM_NAME=cpu JAX_PLATFORMS=cpu OPENBLAS/MKL/OMP/VECLIB/NUMEXPR_NUM_THREADS=$THREADS NPROC=$THREADS`
block that stage 1 of `hpc/batch_cpu/submit_initial_lens_model_two_stage` uses for
`vis_lp` — byte for byte, with only the driver and its arguments different.

Two details that are easy to get wrong, and are written into the script's header:

- **`--use_cpu` is deliberately not passed.** It sets `use_jax = not use_cpu`, which is
  what the `vis_pix` stage of the initial lens model wants (Numba sparse operator,
  forked pool) and is wrong here: it would swap both SED likelihoods from JAX to Numba.
  Pinning the *backend* is the whole of what "run on CPU" means for this chain.
- **The seeded `vis_lp` hash is unchanged.** `number_of_cores` never reaches the `vis_lp`
  search dictionary (only `vis_pix` reads it), so `--number_of_cores` does not perturb
  the search settings and the copied result zip still short-circuits.

The backend assertion is the mirror of the GPU script's, inverted: the job exits within
seconds unless the backend is `cpu`, instead of discovering a mis-pinned environment
after a 12 h fit. Allocation is 8 CPUs / 64 GB / 12 h on partition `ral`, array 0-9,
with `PYAUTO_OUTPUT_DIR=output_sed` and the dataset list carried over from the GPU
script. The 12 h walltime is sized from the euclid precedent on 4 cores (5-12 min Sersic,
5-30 min per band, up to 8 bands per tile — a worst case near 4 h).

The GPU script keeps working and is re-labelled in its header as the optional route.
GPU job 342648 is untouched: it is not cancelled or resubmitted, and this PR only
changes what the *next* submissions use.

## Scripts Changed

- `hpc/batch_cpu/submit_sersic_waveband` — **new**, the default SED-chain submit: JAX
  pinned to the CPU backend, inverted backend assertion, partition `ral`, 8 CPUs, 64 GB,
  12 h, array 0-9, `PYAUTO_OUTPUT_DIR=output_sed`, no `--use_cpu`.
- `hpc/batch_gpu/submit_sersic_waveband` — header only: re-labelled as the optional GPU
  route, pointing at the CPU default. No behavioural change.
- `hpc/README.md` — route table gains the SED CPU (default) and SED GPU (optional) rows;
  intro prose says the SED chain is CPU by default; "Why the CPU route uses two
  processes" gains the paragraph explaining why the SED chain is a single process with a
  single environment block and must not be given `--use_cpu`; the partition-names note
  now lists `submit_sersic_waveband` alongside `submit_build_inspection_bundle` as the
  scripts using `--partition=ral`.
- `hpc/sync` — the `output_sed/` `PULL_DIRS` comment names the CPU script (GPU as the
  alternative); `submit_sersic_waveband` is listed under the CPU scripts in the `submit`
  usage text.
- `scripts/sersic_lens_model.py` — `batch_size` docstring: models are evaluated
  simultaneously "on the JAX backend (CPU by default on RAL … ; GPU optional)" rather
  than "on the GPU".

## Test Plan

- [x] `bash -n` on both submit scripts.
- [x] The CPU script's `env` block diffed against stage 1 of
      `submit_initial_lens_model_two_stage`: the eight environment lines are identical;
      only the driver (`sersic_lens_model_waveband.py`) and its arguments differ.
- [x] Local dry run from the science clone on tile
      `Tile102005065RA0135279431487DECNEG0701599765928`, with a scratch
      `PYAUTO_OUTPUT_DIR` seeded by copying that tile's finished
      `initial_lens_model/vis_lp/a678f2bfaa0cb85b6ae2c89ba6ffb3df.zip`, `THREADS=4`,
      the script's own environment block, under a timeout:
      - the standalone backend guard printed `JAX backend: cpu` and exited 0;
      - `autofit.non_linear.search.abstract_search - INFO - Starting non-linear search with JAX (CPU: cpu).`
      - `vis_lp - INFO - The output path of this fit is …/initial_lens_model/vis_lp/a678f2bfaa0cb85b6ae2c89ba6ffb3df`
        — the seeded hash, unchanged by `--number_of_cores`;
      - `vis_lp - INFO - Fit Already Completed: skipping non-linear search.`
      - the Sersic `vis` search then started: `Running search with JAX vectorization`
        and `JAX jit compilation of vectorized (vmap) likelihood function complete in 2.7 seconds`,
        followed by Nautilus sampling. Killed at the timeout; scratch tree deleted.
- [x] `python3 -m pytest -q tests/` — 106 passed.
- Not run: no cluster submission. The script's SLURM behaviour is exercised the first
  time the remaining tiles are submitted from RAL.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AELxUSfSPRz2SDnnVJHohi
