### PR TITLE
wcs.json: record the lensed source's multiple images beside the lens centre

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ This script can be run as a black-box, with key output being generated, includin
 - A SIE plus shear lens mass model.
 - Deblended images of the lens and source galaxies.
 - Lens light and source models using a multi Gaussian Expansion.
+- A `files/wcs.json` record beside every fit: the lens light centre on the sky
+  (RA / Dec), the source light centre in the source plane, and the lensed
+  source's multiple images — the lens equation solved for that centre with
+  `al.PointSolver` — in the image plane (arcsec) and on the sky (RA / Dec).
+  Written by `util.AnalysisImaging.save_results` (`util.wcs_dict_from` documents
+  every key); a pixelized source (`vis_pix`) has no light centre, so its source
+  keys are `null`.
 
 Here is an example of the output, which shows the lens and source galaxies debelended and a source reconstruction
 in the source-plane:

--- a/catalogue/README.md
+++ b/catalogue/README.md
@@ -162,6 +162,13 @@ Every producer can also be run on its own; each takes `--sample`,
 - **Master CSVs are split per lens.** `catalogue_util.write_per_tile_csv` drops
   each lens's rows into its own folder so a single lens folder is
   self-contained and can be shipped on its own.
+- **Sky positions come from `files/wcs.json`**, which `util.AnalysisImaging`
+  writes beside every fit: the max-likelihood lens light centre as
+  `crval_ra_deg` / `crval_dec_deg` (the RA is `magnitudes.py`'s label column),
+  the source light centre in the source plane, and the lensed source's multiple
+  images in arcsec and RA / Dec (`util.wcs_dict_from`). Read it through the
+  aggregator (`agg.values("wcs")`), which decodes PyAutoFit's JSON envelope.
+  No producer publishes the image positions yet.
 
 ---
 

--- a/tests/test_latent_run_level.py
+++ b/tests/test_latent_run_level.py
@@ -304,3 +304,48 @@ def test_no_latent_is_none_nan_or_exactly_zero(latent_summary):
     }
 
     assert not bad, f"latent values must be finite and non-zero; got {bad}"
+
+
+def test_a_real_mode_fit_writes_the_lensed_source_images_to_wcs_json(latent_summary):
+    """
+    ``util.AnalysisImaging.save_results`` writes ``files/wcs.json`` beside the
+    latent summary, and since the model here has a light-profile source it
+    must carry the lensed source's multiple images: the run-level proof that
+    the point solver runs at the end of a real fit and its record survives the
+    zip. The values are checked in ``test_wcs_dict.py``; this asserts they are
+    written, finite, one per image, and that the source is still quadruply
+    imaged at a max-likelihood Einstein radius drawn within 10 per cent of the
+    truth's.
+    """
+    summary_path, _ = latent_summary
+
+    import autolens as al
+
+    wcs_path = summary_path.parent.parent / "wcs.json"
+    assert wcs_path.is_file(), f"save_results must write {wcs_path}"
+
+    # `output_to_json` writes PyAutoFit's dictable envelope ({"type": "dict",
+    # "arguments": ...}, lists as {"type": "list", "values": ...}); read it back
+    # the way the aggregator hands it to `catalogue/scripts/magnitudes.py`.
+    wcs_dict = al.from_json(file_path=wcs_path)
+
+    for key in ("crval_ra_deg", "crval_dec_deg"):
+        assert np.isfinite(wcs_dict[key])
+
+    for key in ("source_centre_y_arcsec", "source_centre_x_arcsec"):
+        assert np.isfinite(wcs_dict[key])
+
+    image_keys = (
+        "lensed_source_image_y_arcsec",
+        "lensed_source_image_x_arcsec",
+        "lensed_source_image_ra_deg",
+        "lensed_source_image_dec_deg",
+    )
+    lengths = {key: len(wcs_dict[key]) for key in image_keys}
+
+    assert set(lengths.values()) == {4}, (
+        "the simulated source is quadruply imaged; wcs.json must carry one "
+        f"entry per image in each of the four lists, got {lengths}"
+    )
+    for key in image_keys:
+        assert np.all(np.isfinite(wcs_dict[key])), f"{key} must be finite"

--- a/tests/test_wcs_dict.py
+++ b/tests/test_wcs_dict.py
@@ -1,0 +1,334 @@
+"""
+Known-answer tests for the ``files/wcs.json`` record ``util.wcs_dict_from``
+builds and ``util.AnalysisImaging.save_results`` writes: the fitted lens light
+centre on the sky, and the lensed source's multiple images — the lens equation
+solved for the source light centre with ``al.PointSolver`` — in the image plane
+and on the sky.
+
+The fixture is the committed simulated dataset
+``dataset/simulated/euclid_dr1_like/`` and its ``truth.json``. Two of its
+records are independent known answers here:
+
+* ``truth["positions"]`` — the multiple images ``scripts/simulator.py`` solved
+  for the truth tracer with the same ``al.PointSolver`` settings
+  (``util.LENSED_SOURCE_PIXEL_SCALE_PRECISION`` /
+  ``util.LENSED_SOURCE_MAGNIFICATION_THRESHOLD``), so the images a fit records
+  for that tracer must be the same points;
+* the simulated cut-out's own TAN WCS (``scripts/simulator.py::
+  image_wcs_header_from``: north-up, ``CD1_1 < 0``, ``CD2_2 > 0``, reference
+  pixel at the frame centre), against which every sky value is checked by
+  hand — the small-angle offsets from the header's ``CRVAL``, not a round trip
+  through the code under test.
+
+These tests are deliberately **JAX-free** (``use_jax=False`` everywhere, as
+``AGENTS.md`` requires) and run no non-linear search; the one real-mode fit
+that proves ``save_results`` actually *writes* the record is
+``test_latent_run_level.py`` (``slow``).
+"""
+
+import inspect
+import json
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+import util  # noqa: E402
+
+
+SIMULATED_SAMPLE = "simulated"
+SIMULATED_DATASET = "euclid_dr1_like"
+SIMULATED_PATH = PROJECT_ROOT / "dataset" / SIMULATED_SAMPLE / SIMULATED_DATASET
+
+# The image positions are solved to `LENSED_SOURCE_PIXEL_SCALE_PRECISION`
+# arcsec; in practice they replay `truth.json` bit for bit.
+POSITION_ABS = 2.0 * util.LENSED_SOURCE_PIXEL_SCALE_PRECISION
+
+# The small-angle offsets from CRVAL hold to second order in the angle: the
+# gnomonic projection's cross term at 1.5" and declination -51 is ~1.5e-9 deg
+# (5 micro-arcsec), so this tolerance is a few times that and still a hundred
+# times below the 1.4e-6 deg of a 0.005" solver step.
+SKY_ABS_DEG = 1e-8
+
+# The keys `wcs_dict_from` always writes, in the order it writes them.
+WCS_KEYS = (
+    "crpix_x",
+    "crpix_y",
+    "crval_ra_deg",
+    "crval_dec_deg",
+    "source_centre_y_arcsec",
+    "source_centre_x_arcsec",
+    "lensed_source_image_y_arcsec",
+    "lensed_source_image_x_arcsec",
+    "lensed_source_image_ra_deg",
+    "lensed_source_image_dec_deg",
+)
+SOURCE_KEYS = WCS_KEYS[4:]
+IMAGE_KEYS = WCS_KEYS[6:]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def push_config():
+    from autolens import conf
+
+    conf.instance.push(
+        new_path=PROJECT_ROOT / "config", output_path=PROJECT_ROOT / "output"
+    )
+
+
+@pytest.fixture(scope="session")
+def truth():
+    with open(SIMULATED_PATH / "truth.json") as f:
+        return json.load(f)
+
+
+def _profile_from(entry):
+    """
+    Rebuild one profile from its ``truth.json`` record, filtering the recorded
+    parameters against the constructor signature (``truth.json`` also records
+    derived parameters such as ``Isothermal.slope``).
+    """
+    import autolens as al
+
+    cls = {
+        "Sersic": al.lp.Sersic,
+        "Isothermal": al.mp.Isothermal,
+        "ExternalShear": al.mp.ExternalShear,
+    }[entry["type"]]
+
+    accepted = set(inspect.signature(cls.__init__).parameters) - {"self"}
+
+    return cls(
+        **{
+            key: tuple(value) if isinstance(value, list) else value
+            for key, value in entry["parameters"].items()
+            if key in accepted
+        }
+    )
+
+
+@pytest.fixture(scope="session")
+def truth_galaxies(truth):
+    """The truth galaxies in ``truth.json`` order: the lens first, the source last."""
+    import autolens as al
+
+    return [
+        al.Galaxy(
+            redshift=galaxy["redshift"],
+            **{
+                profile_name: _profile_from(entry)
+                for profile_name, entry in galaxy["profiles"].items()
+            },
+        )
+        for galaxy in truth["model"].values()
+    ]
+
+
+@pytest.fixture(scope="session")
+def euclid_dataset():
+    return util.load_vis_dataset(SIMULATED_DATASET, sample_name=SIMULATED_SAMPLE)
+
+
+@pytest.fixture(scope="session")
+def wcs_dict(truth_galaxies, euclid_dataset):
+    """The record for the truth tracer — solved once for the module."""
+    import autolens as al
+
+    return util.wcs_dict_from(
+        tracer=al.Tracer(galaxies=truth_galaxies),
+        data=euclid_dataset.dataset.data,
+        pixel_wcs=euclid_dataset.pixel_wcs,
+    )
+
+
+def _header_crval(euclid_dataset):
+    return (
+        float(euclid_dataset.header["CRVAL1"]),
+        float(euclid_dataset.header["CRVAL2"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The schema
+# ---------------------------------------------------------------------------
+
+
+def test_the_record_has_one_schema(wcs_dict):
+    assert tuple(wcs_dict) == WCS_KEYS
+
+
+def test_the_record_is_json_serialisable(wcs_dict):
+    """
+    ``save_results`` hands the dict to ``output_to_json``; a NumPy scalar or
+    array left inside would raise there, after the search has finished.
+    """
+    round_trip = json.loads(json.dumps(wcs_dict))
+
+    assert round_trip == wcs_dict
+
+
+# ---------------------------------------------------------------------------
+# The lens light centre (the keys the DR1 chain already read)
+# ---------------------------------------------------------------------------
+
+
+def test_crval_is_the_lens_light_centre_on_the_sky(wcs_dict, truth, euclid_dataset):
+    """
+    The truth lens light sits at the image-plane origin, which the simulator
+    made the WCS reference pixel — so the lens centre on the sky *is* the
+    header's ``CRVAL``, and the origin's WCS pixel is its ``CRPIX``.
+    """
+    lens = next(iter(truth["model"].values()))
+    assert lens["profiles"]["bulge"]["parameters"]["centre"] == [0.0, 0.0]
+
+    crval_ra_deg, crval_dec_deg = _header_crval(euclid_dataset)
+
+    assert wcs_dict["crval_ra_deg"] == pytest.approx(crval_ra_deg, abs=SKY_ABS_DEG)
+    assert wcs_dict["crval_dec_deg"] == pytest.approx(crval_dec_deg, abs=SKY_ABS_DEG)
+    assert wcs_dict["crpix_x"] == pytest.approx(float(euclid_dataset.header["CRPIX1"]))
+    assert wcs_dict["crpix_y"] == pytest.approx(float(euclid_dataset.header["CRPIX2"]))
+
+
+# ---------------------------------------------------------------------------
+# The lensed source
+# ---------------------------------------------------------------------------
+
+
+def test_the_source_centre_is_the_source_light_centre(wcs_dict, truth):
+    source = list(truth["model"].values())[-1]
+    centre_y, centre_x = source["profiles"]["bulge"]["parameters"]["centre"]
+
+    assert wcs_dict["source_centre_y_arcsec"] == pytest.approx(centre_y)
+    assert wcs_dict["source_centre_x_arcsec"] == pytest.approx(centre_x)
+
+
+def test_the_lensed_source_images_are_the_simulators_positions(wcs_dict, truth):
+    """
+    ``truth["positions"]`` is what ``scripts/simulator.py`` solved for this
+    tracer with the same solver settings, and what every fit of the dataset
+    reads back as its positions constraint — the record must name the same
+    points, as a set (the solver's output order is not part of its contract).
+    """
+    recorded = sorted(
+        zip(
+            wcs_dict["lensed_source_image_y_arcsec"],
+            wcs_dict["lensed_source_image_x_arcsec"],
+        )
+    )
+    expected = sorted((y, x) for y, x in truth["positions"])
+
+    assert len(recorded) == len(expected) == 4, (
+        "the simulated source is quadruply imaged; "
+        f"recorded {len(recorded)} images against {len(expected)} in truth.json"
+    )
+    assert np.asarray(recorded) == pytest.approx(np.asarray(expected), abs=POSITION_ABS)
+
+
+def test_the_lensed_source_sky_positions_follow_the_header(wcs_dict, euclid_dataset):
+    """
+    Checked by hand against the simulated header rather than through the code
+    under test. ``scripts/simulator.py`` writes a north-up TAN WCS with the
+    reference pixel at the frame centre, and PyAutoArray loads the FITS
+    without a row flip, so PyAutoLens's positive ``y`` is the FITS row-1
+    direction — south — and positive ``x`` is the FITS column direction, west
+    under ``CD1_1 < 0``. Hence, to first order in the angle::
+
+        dec = CRVAL2 - y / 3600
+        (ra - CRVAL1) * cos(dec) = -x / 3600
+
+    with the lens at the reference pixel. The sign of ``y`` is the point of the
+    test: a record that put the images north of where the light is would pass
+    every round-trip check and mislead every cross-match.
+    """
+    header = euclid_dataset.header
+    assert float(header["CD1_1"]) < 0.0 and float(header["CD2_2"]) > 0.0
+    assert float(header["CD1_2"]) == 0.0 and float(header["CD2_1"]) == 0.0
+
+    crval_ra_deg, crval_dec_deg = _header_crval(euclid_dataset)
+
+    for y, x, ra, dec in zip(*(wcs_dict[key] for key in IMAGE_KEYS)):
+        assert dec == pytest.approx(crval_dec_deg - y / 3600.0, abs=SKY_ABS_DEG)
+        assert (ra - crval_ra_deg) * np.cos(np.radians(dec)) == pytest.approx(
+            -x / 3600.0, abs=SKY_ABS_DEG
+        )
+
+
+def test_the_source_centre_reads_an_mge_basis(truth_galaxies):
+    """
+    ``vis_lp``'s source is one MGE ``Basis``, whose ``centre`` is the centre
+    its Gaussians share — the centre the lens equation is solved for.
+    """
+    import autolens as al
+
+    basis = al.lp_basis.Basis(
+        profile_list=[
+            al.lp.Gaussian(centre=(0.08, 0.12), sigma=sigma) for sigma in (0.1, 0.2)
+        ]
+    )
+    tracer = al.Tracer(
+        galaxies=[truth_galaxies[0], al.Galaxy(redshift=1.0, bulge=basis)]
+    )
+
+    assert util.source_centre_from(tracer=tracer) == (0.08, 0.12)
+
+
+def test_a_source_without_a_light_centre_writes_null(truth_galaxies, euclid_dataset):
+    """
+    A pixelized source (``vis_pix``, the Delaunay stages) has no light profile,
+    so there is no centre to solve for: the six source keys are ``null`` and
+    the four lens keys are written exactly as before.
+    """
+    import autolens as al
+
+    tracer = al.Tracer(galaxies=[truth_galaxies[0], al.Galaxy(redshift=1.0)])
+
+    wcs_dict = util.wcs_dict_from(
+        tracer=tracer,
+        data=euclid_dataset.dataset.data,
+        pixel_wcs=euclid_dataset.pixel_wcs,
+    )
+
+    assert tuple(wcs_dict) == WCS_KEYS
+    assert all(wcs_dict[key] is None for key in SOURCE_KEYS)
+    assert wcs_dict["crval_ra_deg"] == pytest.approx(
+        _header_crval(euclid_dataset)[0], abs=SKY_ABS_DEG
+    )
+
+
+def test_a_solver_failure_is_logged_and_written_as_null(
+    truth_galaxies, euclid_dataset, monkeypatch, caplog
+):
+    """
+    ``save_results`` runs after the search has finished; a raise there would
+    lose the fit to its own record. The four image keys are ``null``, the
+    source centre and the lens keys are still written, and the failure is on
+    the log.
+    """
+    import autolens as al
+
+    def raise_(**kwargs):
+        raise RuntimeError("no triangles")
+
+    monkeypatch.setattr(util, "lensed_source_image_positions_from", raise_)
+
+    with caplog.at_level(logging.WARNING, logger="util"):
+        wcs_dict = util.wcs_dict_from(
+            tracer=al.Tracer(galaxies=truth_galaxies),
+            data=euclid_dataset.dataset.data,
+            pixel_wcs=euclid_dataset.pixel_wcs,
+        )
+
+    assert tuple(wcs_dict) == WCS_KEYS
+    assert all(wcs_dict[key] is None for key in IMAGE_KEYS)
+    assert wcs_dict["source_centre_y_arcsec"] == pytest.approx(0.08)
+    assert "no triangles" in caplog.text

--- a/util.py
+++ b/util.py
@@ -4,7 +4,8 @@ import json
 import numpy as np
 from pathlib import Path
 from PIL import Image
-from typing import List, Optional
+from typing import List, Optional, Tuple
+import logging
 
 import matplotlib.pyplot as plt
 from autolens import conf as _conf
@@ -711,8 +712,8 @@ class AnalysisImaging(al.AnalysisImaging):
         For this analysis it outputs the following:
 
         - The maximum log likelihood tracer of the fit.
-        - The World Coordinate System (WCS) information of the dataset, which is used to convert between pixel and
-          world coordinates.
+        - ``wcs.json``: where the fitted lens sits on the sky and where its lensed source's multiple
+          images fall in the image plane — the record ``wcs_dict_from`` builds.
 
         Parameters
         ----------
@@ -724,39 +725,185 @@ class AnalysisImaging(al.AnalysisImaging):
         """
         super().save_results(paths=paths, result=result)
 
-        lens_light_centre = result.max_log_likelihood_tracer.galaxies[0].bulge.centre
-
-        lens_light_centre_wcs_pix = (
-            self.dataset.data.geometry.pixel_coordinates_wcs_2d_from(
-                scaled_coordinates_2d=lens_light_centre
-            )
+        wcs_dict = wcs_dict_from(
+            tracer=result.max_log_likelihood_tracer,
+            data=self.dataset.data,
+            pixel_wcs=self.kwargs["pixel_wcs"],
         )
-        lens_light_centre_wcs_pix_y = lens_light_centre_wcs_pix[0]
-        lens_light_centre_wcs_pix_x = lens_light_centre_wcs_pix[1]
-
-        pixel_wcs = self.kwargs["pixel_wcs"]
-
-        ra_c_deg, dec_c_deg = pixel_wcs.wcs_pix2world(
-            lens_light_centre_wcs_pix_x, lens_light_centre_wcs_pix_y, 1
-        )
-
-        data_centre_wcs_pix = self.dataset.data.geometry.pixel_coordinates_wcs_2d_from(
-            scaled_coordinates_2d=(0.0, 0.0)
-        )
-        data_centre_wcs_pix_y = data_centre_wcs_pix[0]
-        data_centre_wcs_pix_x = data_centre_wcs_pix[1]
-
-        wcs_dict = {
-            "crpix_x": data_centre_wcs_pix_x,
-            "crpix_y": data_centre_wcs_pix_y,
-            "crval_ra_deg": float(ra_c_deg),
-            "crval_dec_deg": float(dec_c_deg),
-        }
 
         output_to_json(
             obj=wcs_dict,
             file_path=paths._files_path / "wcs.json",
         )
+
+
+# ---------------------------------------------------------------------------
+# The WCS record (files/wcs.json)
+# ---------------------------------------------------------------------------
+
+# The `al.PointSolver` settings the lensed source's image-plane positions are
+# solved with. They are `scripts/simulator.py`'s (`positions_from_tracer`), so
+# the images a fit records for a tracer and the `positions.json` the simulator
+# solves for the same tracer agree to `pixel_scale_precision`.
+LENSED_SOURCE_PIXEL_SCALE_PRECISION = 0.005
+LENSED_SOURCE_MAGNIFICATION_THRESHOLD = 0.1
+
+
+def source_centre_from(tracer) -> Optional[Tuple[float, float]]:
+    """
+    The source-plane (y, x) centre of the source galaxy's light, in arcsec, or
+    ``None`` when the source carries no light profile with a centre.
+
+    The source galaxy is the tracer's last — the order every pipeline model and
+    ``truth.json`` use, and the one ``LatentLens`` indexes by. Its light is the
+    first light profile the galaxy holds: a single MGE ``Basis`` in ``vis_lp``,
+    whose ``centre`` is the centre its Gaussians share, or a ``Sersic`` in the
+    SED chain. A pixelized source (``vis_pix`` and the Delaunay stages) has no
+    light profile and so no centre — there is nothing to solve for.
+    """
+    source_galaxy = tracer.galaxies[-1]
+
+    for profile in source_galaxy.cls_list_from(cls=al.LightProfile):
+        centre = getattr(profile, "centre", None)
+        if centre is not None:
+            return float(centre[0]), float(centre[1])
+
+    return None
+
+
+def lensed_source_image_positions_from(
+    tracer, data, source_centre: Tuple[float, float]
+) -> al.Grid2DIrregular:
+    """
+    The image-plane (y, x) positions, in arcsec, that the tracer maps onto
+    ``source_centre``: the lens equation solved with ``al.PointSolver`` on a
+    uniform grid spanning the cut-out, exactly as ``scripts/simulator.py``
+    solves a mock's ``positions.json``.
+
+    The solver tiles the image plane with triangles, keeps those which trace
+    onto the source-plane point and subdivides them down to
+    ``LENSED_SOURCE_PIXEL_SCALE_PRECISION`` arcsec, then drops images whose
+    magnification is below ``LENSED_SOURCE_MAGNIFICATION_THRESHOLD``. A source
+    that is not multiply imaged returns fewer than two positions.
+    """
+    grid = al.Grid2D.uniform(
+        shape_native=data.shape_native,
+        pixel_scales=data.pixel_scales,
+        origin=data.origin,
+    )
+
+    solver = al.PointSolver.for_grid(
+        grid=grid,
+        pixel_scale_precision=LENSED_SOURCE_PIXEL_SCALE_PRECISION,
+        magnification_threshold=LENSED_SOURCE_MAGNIFICATION_THRESHOLD,
+    )
+
+    return solver.solve(tracer=tracer, source_plane_coordinate=source_centre)
+
+
+def wcs_dict_from(tracer, data, pixel_wcs) -> dict:
+    """
+    The record ``AnalysisImaging.save_results`` writes to ``files/wcs.json``:
+    where the fitted lens sits on the sky, and where its lensed source's
+    multiple images fall.
+
+    ``crval_ra_deg`` / ``crval_dec_deg`` are the maximum-likelihood lens light
+    centre converted to RA / Dec through ``pixel_wcs`` — despite the FITS-style
+    name, not the cut-out's reference pixel; ``catalogue/scripts/magnitudes.py``
+    reads the RA back as its ``crval_ra_deg`` label column — and ``crpix_x`` /
+    ``crpix_y`` the 1-based WCS pixel of the image-plane origin ``(0, 0)``.
+
+    ``source_centre_y_arcsec`` / ``source_centre_x_arcsec`` is the source
+    galaxy's light centre in the source plane (``source_centre_from``), and
+    ``lensed_source_image_y_arcsec`` / ``lensed_source_image_x_arcsec`` and
+    ``lensed_source_image_ra_deg`` / ``lensed_source_image_dec_deg`` are its
+    multiple images in the image plane, in arcsec and on the sky, one entry
+    per image (``lensed_source_image_positions_from``). All six are ``null``
+    for a source with no light centre — a pixelized source — and the four
+    image lists are ``null`` if the solver raises: a search that has finished
+    must not be lost to a post-fit record, so that failure is logged, never
+    raised. Every other key is always present, so a reader has one schema.
+
+    Parameters
+    ----------
+    tracer
+        The maximum log likelihood tracer of the fit; its first galaxy is the
+        lens, its last the source.
+    data
+        The fitted image, whose geometry converts image-plane arcsec to WCS
+        pixels and whose extent bounds the solver's grid.
+    pixel_wcs
+        The dataset's celestial ``astropy.wcs.WCS``, converting those pixels to
+        RA / Dec.
+
+    Notes
+    -----
+    Every sky value goes through the FITS pixel the light sits in, so it is
+    right whichever way the cut-out is oriented. The array is loaded from the
+    FITS without a row flip (``autonerves.fitsable``), so its native row 0 is
+    FITS row 1 — the bottom row of a standard north-up image — and PyAutoLens's
+    positive ``y`` (native row 0 upward on its own plots) is therefore the FITS
+    row-1 direction: south, for a north-up ``CD`` matrix. Do not read a
+    ``lensed_source_image_y_arcsec`` as "north of the lens"; read the
+    ``_dec_deg`` beside it.
+    """
+
+    def sky_from(scaled_coordinates_2d):
+        pixel_y, pixel_x = data.geometry.pixel_coordinates_wcs_2d_from(
+            scaled_coordinates_2d=scaled_coordinates_2d
+        )
+        ra_deg, dec_deg = pixel_wcs.wcs_pix2world(pixel_x, pixel_y, 1)
+        return float(ra_deg), float(dec_deg)
+
+    lens_light_centre = tracer.galaxies[0].bulge.centre
+    lens_ra_deg, lens_dec_deg = sky_from(lens_light_centre)
+
+    data_centre_wcs_pix_y, data_centre_wcs_pix_x = (
+        data.geometry.pixel_coordinates_wcs_2d_from(scaled_coordinates_2d=(0.0, 0.0))
+    )
+
+    wcs_dict = {
+        "crpix_x": data_centre_wcs_pix_x,
+        "crpix_y": data_centre_wcs_pix_y,
+        "crval_ra_deg": lens_ra_deg,
+        "crval_dec_deg": lens_dec_deg,
+        "source_centre_y_arcsec": None,
+        "source_centre_x_arcsec": None,
+        "lensed_source_image_y_arcsec": None,
+        "lensed_source_image_x_arcsec": None,
+        "lensed_source_image_ra_deg": None,
+        "lensed_source_image_dec_deg": None,
+    }
+
+    source_centre = source_centre_from(tracer=tracer)
+
+    if source_centre is None:
+        return wcs_dict
+
+    wcs_dict["source_centre_y_arcsec"] = source_centre[0]
+    wcs_dict["source_centre_x_arcsec"] = source_centre[1]
+
+    try:
+        positions = lensed_source_image_positions_from(
+            tracer=tracer, data=data, source_centre=source_centre
+        )
+    except Exception as e:  # noqa: BLE001 — a finished search outlives its record
+        logging.getLogger(__name__).warning(
+            "wcs.json: the point solver raised for the source centre "
+            f"{source_centre}; the lensed-source image positions are written "
+            f"as null ({type(e).__name__}: {e})"
+        )
+        return wcs_dict
+
+    positions = [(float(y), float(x)) for y, x in np.asarray(positions).reshape(-1, 2)]
+    sky = [sky_from(position) for position in positions]
+
+    wcs_dict["lensed_source_image_y_arcsec"] = [y for y, _ in positions]
+    wcs_dict["lensed_source_image_x_arcsec"] = [x for _, x in positions]
+    wcs_dict["lensed_source_image_ra_deg"] = [ra for ra, _ in sky]
+    wcs_dict["lensed_source_image_dec_deg"] = [dec for _, dec in sky]
+
+    return wcs_dict
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`util.AnalysisImaging.save_results` wrote `files/wcs.json` with only the max-likelihood lens light centre on the sky (`crval_ra_deg` / `crval_dec_deg`, plus `crpix_x` / `crpix_y`). It now also records:

- `source_centre_y_arcsec` / `source_centre_x_arcsec` — the source galaxy's light centre in the source plane (for `vis_lp`, the shared centre of its MGE `Basis`);
- `lensed_source_image_{y,x}_arcsec` and `lensed_source_image_{ra,dec}_deg` — the lensed source's multiple images in the image plane and on the sky, one entry per image: the lens equation solved for that centre with `al.PointSolver`, using the same settings `scripts/simulator.py` uses to write a mock's `positions.json`, so the two agree bit for bit on the committed simulated dataset.

The record is built by a new module-level `util.wcs_dict_from` (with `source_centre_from` and `lensed_source_image_positions_from`) so it can be tested without a search. The schema is fixed: the six source keys are `null` for a source with no light centre (the pixelized `vis_pix` stage), and the four image lists are `null` if the solver raises — logged, never raised, so a finished search is never lost to its own record. The four pre-existing keys are unchanged.

**Orientation note (documented in the helper):** PyAutoArray loads FITS without a row flip, so PyAutoLens's positive `y` is the FITS row-1 direction — south on a north-up image. Sky values are correct because they go through the FITS pixel the light sits in; a raw `y_arcsec` must not be read as "north of the lens".

## Tests

- `tests/test_wcs_dict.py` (fast, JAX-free, no search): lens centre against the simulated header's `CRVAL` / `CRPIX`; images against `truth["positions"]`; every sky value checked by hand against the header's north-up `CD` matrix (small-angle offsets from `CRVAL`, 1e-8 deg); the MGE-basis centre; the pixelized-source and solver-failure branches; JSON serialisability.
- `tests/test_latent_run_level.py` (slow): the real-mode fit now also asserts `wcs.json` is written with four finite images, decoded through `al.from_json` the way the aggregator hands it to `magnitudes.py`.
- Local: fast suite 103 → 112 passed; slow 3 → 4 passed. Solving on the real Q1 cut-out with its real header takes 0.13 s.

## Docs

README "Overview" and `catalogue/README.md` "Conventions" describe the record. No catalogue producer publishes the image positions yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqZdi6m2pxkJJKVKjyhHWL

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqZdi6m2pxkJJKVKjyhHWL)_