### PR TITLE
wcs.json: pixelized-source clumps off the mapper, and no null keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,16 @@ This script can be run as a black-box, with key output being generated, includin
 - Deblended images of the lens and source galaxies.
 - Lens light and source models using a multi Gaussian Expansion.
 - A `files/wcs.json` record beside every fit: the lens light centre on the sky
-  (RA / Dec), the source light centre in the source plane, and the lensed
-  source's multiple images — the lens equation solved for that centre with
-  `al.PointSolver` — in the image plane (arcsec) and on the sky (RA / Dec).
-  Written by `util.AnalysisImaging.save_results` (`util.wcs_dict_from` documents
-  every key); a pixelized source (`vis_pix`) has no light centre, so its source
-  keys are `null`.
+  (RA / Dec), the source position in the source plane, and the lensed source's
+  multiple images — the lens equation solved for that position with
+  `al.PointSolver` — in the image plane (arcsec) and on the sky (RA / Dec). For
+  a light-profile source (`vis_lp`, the SED chain) the position is the light
+  centre; for a pixelized source (`vis_pix`, the Delaunay stages) it is the peak
+  of the brightest clump of the reconstruction, and `source_clumps` lists every
+  clump with its multiple images read off the fit's mapper (the brightest model
+  pixel of each image region). Written by `util.AnalysisImaging.save_results`;
+  `util.wcs_dict_from` documents every key. An unavailable value is an absent
+  key, never `null`, and `source_model` says which case applied.
 
 Here is an example of the output, which shows the lens and source galaxies debelended and a source reconstruction
 in the source-plane:

--- a/catalogue/README.md
+++ b/catalogue/README.md
@@ -165,10 +165,14 @@ Every producer can also be run on its own; each takes `--sample`,
 - **Sky positions come from `files/wcs.json`**, which `util.AnalysisImaging`
   writes beside every fit: the max-likelihood lens light centre as
   `crval_ra_deg` / `crval_dec_deg` (the RA is `magnitudes.py`'s label column),
-  the source light centre in the source plane, and the lensed source's multiple
-  images in arcsec and RA / Dec (`util.wcs_dict_from`). Read it through the
-  aggregator (`agg.values("wcs")`), which decodes PyAutoFit's JSON envelope.
-  No producer publishes the image positions yet.
+  the source position in the source plane (a light centre, or the brightest
+  clump's peak for a pixelized source), and its multiple images in arcsec and
+  RA / Dec solved with `al.PointSolver`; a pixelized source also carries
+  `source_clumps`, every clump's peak and images read off the fit's mapper
+  (`util.wcs_dict_from` documents the keys). Read it through the aggregator
+  (`agg.values("wcs")`), which decodes PyAutoFit's JSON envelope; that envelope
+  drops `None` values, so an unavailable value is an absent key and
+  `source_model` says why. No producer publishes the image positions yet.
 
 ---
 

--- a/tests/test_latent_run_level.py
+++ b/tests/test_latent_run_level.py
@@ -332,6 +332,9 @@ def test_a_real_mode_fit_writes_the_lensed_source_images_to_wcs_json(latent_summ
     for key in ("crval_ra_deg", "crval_dec_deg"):
         assert np.isfinite(wcs_dict[key])
 
+    assert wcs_dict["source_model"] == "light_profile"
+    assert "source_clumps" not in wcs_dict
+
     for key in ("source_centre_y_arcsec", "source_centre_x_arcsec"):
         assert np.isfinite(wcs_dict[key])
 

--- a/tests/test_wcs_dict.py
+++ b/tests/test_wcs_dict.py
@@ -20,6 +20,18 @@ records are independent known answers here:
   hand — the small-angle offsets from the header's ``CRVAL``, not a round trip
   through the code under test.
 
+The pixelized leg builds the ``vis_pix`` stage as a zero-free-parameter model
+on the same dataset (the ``Delaunay`` mesh mirrored from
+``test_compute_latent_variable.py``'s ``pixelized_source_model`` fixture, at the
+same quarter size) and fits it once, so the clumps read off the mapper have the
+truth source and the truth images to be checked against.
+
+The on-disk shape is asserted through ``al.output_to_json`` + ``al.from_json``,
+the pair ``save_results`` and the aggregator actually use — never ``json.dumps``:
+PyAutoFit's envelope drops ``None``-valued keys, which is why the record's
+contract is *absent when unavailable* and every test here asserts absence, not
+``None``.
+
 These tests are deliberately **JAX-free** (``use_jax=False`` everywhere, as
 ``AGENTS.md`` requires) and run no non-linear search; the one real-mode fit
 that proves ``save_results`` actually *writes* the record is
@@ -56,20 +68,54 @@ POSITION_ABS = 2.0 * util.LENSED_SOURCE_PIXEL_SCALE_PRECISION
 SKY_ABS_DEG = 1e-8
 
 # The keys `wcs_dict_from` always writes, in the order it writes them.
-WCS_KEYS = (
-    "crpix_x",
-    "crpix_y",
-    "crval_ra_deg",
-    "crval_dec_deg",
-    "source_centre_y_arcsec",
-    "source_centre_x_arcsec",
+LENS_KEYS = ("crpix_x", "crpix_y", "crval_ra_deg", "crval_dec_deg", "source_model")
+
+# The keys present once the source was located: the solved position and its
+# images (the `al.PointSolver` route).
+CENTRE_KEYS = ("source_centre_y_arcsec", "source_centre_x_arcsec")
+IMAGE_KEYS = (
     "lensed_source_image_y_arcsec",
     "lensed_source_image_x_arcsec",
     "lensed_source_image_ra_deg",
     "lensed_source_image_dec_deg",
 )
-SOURCE_KEYS = WCS_KEYS[4:]
-IMAGE_KEYS = WCS_KEYS[6:]
+SOURCE_KEYS = CENTRE_KEYS + IMAGE_KEYS
+
+# The keys of one `source_clumps` entry (the mapper route), in written order.
+CLUMP_KEYS = (
+    "peak_y_arcsec",
+    "peak_x_arcsec",
+    "peak_value",
+    "mesh_pixels",
+    "image_y_arcsec",
+    "image_x_arcsec",
+    "image_ra_deg",
+    "image_dec_deg",
+)
+
+# The mapper route reports the brightest *data pixel* of each image region of
+# the source's model image, so it is quantised to the 0.1" pixel grid and reads
+# the peak of an extended (PSF-convolved, mesh-smoothed) image rather than the
+# point-source position: measured 0.10-0.13" from `truth["positions"]`.
+MAPPER_IMAGE_ABS = 0.2
+
+# The solver route on the clump's peak mesh pixel, which sits a few
+# milli-arcsec from the truth source centre: measured within 0.035" of
+# `truth["positions"]`.
+SOLVER_FROM_PEAK_ABS = 0.1
+
+# The clump peak is the centre of a mesh pixel, so it is the truth source centre
+# to within the mesh spacing there: measured 0.004".
+PEAK_ABS = 0.05
+
+# The `vis_pix` mesh, mirrored from `scripts/initial_lens_model.py` at the size
+# `test_compute_latent_variable.py` uses for the fast suite.
+HILBERT_PIXELS = 150
+EDGE_PIXELS_TOTAL = 30
+HILBERT_WEIGHT_POWER = 3.5
+HILBERT_WEIGHT_FLOOR = 0.01
+ADAPT_IMAGE_FLOOR = 0.01
+SOURCE_PATH = "('galaxies', 'source')"
 
 
 # ---------------------------------------------------------------------------
@@ -151,6 +197,114 @@ def wcs_dict(truth_galaxies, euclid_dataset):
     )
 
 
+def _analysis_from(euclid_dataset, adapt_images=None):
+    """The pipeline analysis as the fits build it, NumPy, no RGB plot."""
+    return util.AnalysisImaging(
+        dataset=euclid_dataset.dataset,
+        adapt_images=adapt_images,
+        positions_likelihood_list=None,
+        use_jax=False,
+        dataset_main_path=euclid_dataset.dataset_main_path,
+        title_prefix="VIS",
+        plot_rgb=False,
+        skip_rgb_plot=True,
+        psf_lowest_resolution=euclid_dataset.psf_lowest_resolution,
+        psf_lowest_resolution_fwhm=euclid_dataset.psf_lowest_resolution_fwhm,
+        pixel_wcs=euclid_dataset.pixel_wcs,
+        magzero=euclid_dataset.magzero,
+    )
+
+
+@pytest.fixture(scope="session")
+def pixelized_fit(truth_galaxies, euclid_dataset):
+    """
+    The ``vis_pix`` stage fitted once at zero free parameters: the truth lens
+    as an instance, the source a ``Delaunay`` ``Pixelization`` whose mesh is a
+    ``Hilbert`` grid drawn from the truth source's lensed image plus the
+    circle-edge ring, exactly as ``test_compute_latent_variable.py``'s
+    ``pixelized_source_model`` fixture builds it (see there for why the mesh
+    travels in ``AdaptImages``).
+    """
+    import autofit as af
+    import autolens as al
+
+    lens, sersic_source = truth_galaxies[0], truth_galaxies[-1]
+    dataset = euclid_dataset.dataset
+
+    adapt_data = al.Tracer(
+        galaxies=[lens, sersic_source]
+    ).galaxy_image_2d_dict_from(grid=dataset.grids.lp)[sersic_source]
+    adapt_data = adapt_data + np.max(adapt_data) * ADAPT_IMAGE_FLOOR
+
+    image_plane_mesh_grid = al.image_mesh.Hilbert(
+        pixels=HILBERT_PIXELS,
+        weight_power=HILBERT_WEIGHT_POWER,
+        weight_floor=HILBERT_WEIGHT_FLOOR,
+    ).image_plane_mesh_grid_from(mask=dataset.mask, adapt_data=adapt_data)
+
+    image_plane_mesh_grid = al.image_mesh.append_with_circle_edge_points(
+        image_plane_mesh_grid=image_plane_mesh_grid,
+        centre=dataset.mask.mask_centre,
+        radius=euclid_dataset.mask_radius + dataset.mask.pixel_scale / 2.0,
+        n_points=EDGE_PIXELS_TOTAL,
+    )
+
+    adapt_images = al.AdaptImages(
+        galaxy_name_image_dict={SOURCE_PATH: adapt_data},
+        galaxy_name_image_plane_mesh_grid_dict={SOURCE_PATH: image_plane_mesh_grid},
+    )
+
+    model = af.Collection(
+        galaxies=af.Collection(
+            lens=af.Model.from_instance(lens),
+            source=af.Model(
+                al.Galaxy,
+                redshift=sersic_source.redshift,
+                pixelization=af.Model(
+                    al.Pixelization,
+                    mesh=al.mesh.Delaunay(
+                        pixels=image_plane_mesh_grid.shape[0],
+                        zeroed_pixels=EDGE_PIXELS_TOTAL,
+                    ),
+                    regularization=al.reg.AdaptSplit(),
+                ),
+            ),
+        )
+    )
+    assert model.prior_count == 0
+
+    analysis = _analysis_from(euclid_dataset, adapt_images=adapt_images)
+
+    return analysis.fit_from(instance=model.instance_from_vector([]))
+
+
+@pytest.fixture(scope="session")
+def pixelized_wcs_dict(pixelized_fit, euclid_dataset):
+    """The record for the pixelized fit — clumps read and solved once for the module."""
+    return util.wcs_dict_from(
+        tracer=pixelized_fit.tracer,
+        data=euclid_dataset.dataset.data,
+        pixel_wcs=euclid_dataset.pixel_wcs,
+        fit=pixelized_fit,
+    )
+
+
+def _on_disk(wcs_dict, tmp_path):
+    """
+    The record as it comes back off disk: written by ``al.output_to_json`` and
+    read by ``al.from_json``, the pair ``save_results`` and the aggregator use.
+    """
+    import autolens as al
+
+    path = tmp_path / "wcs.json"
+    al.output_to_json(obj=wcs_dict, file_path=path)
+    return al.from_json(file_path=path)
+
+
+def _sorted_positions(ys, xs):
+    return sorted(zip(ys, xs))
+
+
 def _header_crval(euclid_dataset):
     return (
         float(euclid_dataset.header["CRVAL1"]),
@@ -163,18 +317,38 @@ def _header_crval(euclid_dataset):
 # ---------------------------------------------------------------------------
 
 
-def test_the_record_has_one_schema(wcs_dict):
-    assert tuple(wcs_dict) == WCS_KEYS
+def test_a_light_profile_source_writes_the_solver_keys(wcs_dict):
+    assert tuple(wcs_dict) == LENS_KEYS + SOURCE_KEYS
+    assert wcs_dict["source_model"] == "light_profile"
+    assert "source_clumps" not in wcs_dict
 
 
-def test_the_record_is_json_serialisable(wcs_dict):
+def test_the_record_survives_the_json_envelope(wcs_dict, pixelized_wcs_dict, tmp_path):
     """
-    ``save_results`` hands the dict to ``output_to_json``; a NumPy scalar or
-    array left inside would raise there, after the search has finished.
+    ``save_results`` writes with ``output_to_json`` and the aggregator reads
+    with ``from_json``. PyAutoFit's envelope drops ``None`` values and would
+    raise on a NumPy scalar, so the record must contain neither: both records
+    must come back off disk equal to what was written, nested clump list
+    included.
     """
-    round_trip = json.loads(json.dumps(wcs_dict))
+    assert _on_disk(wcs_dict, tmp_path / "lp") == wcs_dict
+    assert _on_disk(pixelized_wcs_dict, tmp_path / "pix") == pixelized_wcs_dict
 
-    assert round_trip == wcs_dict
+
+def test_nothing_is_written_as_null(wcs_dict, pixelized_wcs_dict):
+    """A ``None`` would silently vanish on disk; the contract is an absent key."""
+
+    def has_none(value):
+        if value is None:
+            return True
+        if isinstance(value, dict):
+            return any(has_none(v) for v in value.values())
+        if isinstance(value, list):
+            return any(has_none(v) for v in value)
+        return False
+
+    assert not has_none(wcs_dict)
+    assert not has_none(pixelized_wcs_dict)
 
 
 # ---------------------------------------------------------------------------
@@ -282,11 +456,13 @@ def test_the_source_centre_reads_an_mge_basis(truth_galaxies):
     assert util.source_centre_from(tracer=tracer) == (0.08, 0.12)
 
 
-def test_a_source_without_a_light_centre_writes_null(truth_galaxies, euclid_dataset):
+def test_a_source_with_neither_light_nor_fit_writes_no_source_keys(
+    truth_galaxies, euclid_dataset
+):
     """
-    A pixelized source (``vis_pix``, the Delaunay stages) has no light profile,
-    so there is no centre to solve for: the six source keys are ``null`` and
-    the four lens keys are written exactly as before.
+    A bare source galaxy has no light centre, and without a ``fit`` a pixelized
+    one has no reconstruction to read: ``source_model`` says ``"none"`` and
+    no source key is written — never ``null``.
     """
     import autolens as al
 
@@ -298,19 +474,33 @@ def test_a_source_without_a_light_centre_writes_null(truth_galaxies, euclid_data
         pixel_wcs=euclid_dataset.pixel_wcs,
     )
 
-    assert tuple(wcs_dict) == WCS_KEYS
-    assert all(wcs_dict[key] is None for key in SOURCE_KEYS)
+    assert tuple(wcs_dict) == LENS_KEYS
+    assert wcs_dict["source_model"] == "none"
     assert wcs_dict["crval_ra_deg"] == pytest.approx(
         _header_crval(euclid_dataset)[0], abs=SKY_ABS_DEG
     )
 
 
-def test_a_solver_failure_is_logged_and_written_as_null(
+def test_a_pixelized_source_without_a_fit_writes_no_source_keys(
+    pixelized_fit, euclid_dataset
+):
+    wcs_dict = util.wcs_dict_from(
+        tracer=pixelized_fit.tracer,
+        data=euclid_dataset.dataset.data,
+        pixel_wcs=euclid_dataset.pixel_wcs,
+        fit=None,
+    )
+
+    assert tuple(wcs_dict) == LENS_KEYS
+    assert wcs_dict["source_model"] == "none"
+
+
+def test_a_solver_failure_is_logged_and_its_keys_left_absent(
     truth_galaxies, euclid_dataset, monkeypatch, caplog
 ):
     """
     ``save_results`` runs after the search has finished; a raise there would
-    lose the fit to its own record. The four image keys are ``null``, the
+    lose the fit to its own record. The four image keys are absent, the
     source centre and the lens keys are still written, and the failure is on
     the log.
     """
@@ -328,7 +518,123 @@ def test_a_solver_failure_is_logged_and_written_as_null(
             pixel_wcs=euclid_dataset.pixel_wcs,
         )
 
-    assert tuple(wcs_dict) == WCS_KEYS
-    assert all(wcs_dict[key] is None for key in IMAGE_KEYS)
+    assert tuple(wcs_dict) == LENS_KEYS + CENTRE_KEYS
     assert wcs_dict["source_centre_y_arcsec"] == pytest.approx(0.08)
     assert "no triangles" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# The pixelized source (vis_pix): clumps read off the mapper
+# ---------------------------------------------------------------------------
+
+
+def test_a_pixelized_source_writes_its_clumps_and_the_solver_keys(pixelized_wcs_dict):
+    assert tuple(pixelized_wcs_dict) == LENS_KEYS + ("source_clumps",) + SOURCE_KEYS
+    assert pixelized_wcs_dict["source_model"] == "pixelized"
+
+    clumps = pixelized_wcs_dict["source_clumps"]
+
+    assert len(clumps) == 1, (
+        "the simulated source is one smooth Sersic, which the default threshold "
+        f"isolates as one clump; got {len(clumps)}"
+    )
+    assert tuple(clumps[0]) == CLUMP_KEYS
+    assert clumps[0]["mesh_pixels"] >= util.SOURCE_CLUMP_MIN_PIXELS
+    assert clumps[0]["peak_value"] > 0.0
+
+
+def test_the_clump_peak_is_the_truth_source_centre(pixelized_wcs_dict, truth):
+    """
+    The clump's peak mesh pixel sits on the truth source centre to within the
+    mesh spacing there, and it is the position the solver keys are solved for.
+    """
+    source = list(truth["model"].values())[-1]
+    centre_y, centre_x = source["profiles"]["bulge"]["parameters"]["centre"]
+
+    clump = pixelized_wcs_dict["source_clumps"][0]
+
+    assert clump["peak_y_arcsec"] == pytest.approx(centre_y, abs=PEAK_ABS)
+    assert clump["peak_x_arcsec"] == pytest.approx(centre_x, abs=PEAK_ABS)
+    assert pixelized_wcs_dict["source_centre_y_arcsec"] == clump["peak_y_arcsec"]
+    assert pixelized_wcs_dict["source_centre_x_arcsec"] == clump["peak_x_arcsec"]
+
+
+def test_the_clump_images_off_the_mapper_are_the_truth_images(pixelized_wcs_dict, truth):
+    """
+    Each of the four image regions the mapper attributes to the clump has its
+    brightest model pixel within two pixels of a distinct truth image.
+    """
+    clump = pixelized_wcs_dict["source_clumps"][0]
+    recorded = _sorted_positions(clump["image_y_arcsec"], clump["image_x_arcsec"])
+    expected = sorted((y, x) for y, x in truth["positions"])
+
+    assert len(recorded) == 4, (
+        "the simulated source is quadruply imaged and the mapper must find "
+        f"four image regions; got {len(recorded)}"
+    )
+    assert np.asarray(recorded) == pytest.approx(np.asarray(expected), abs=MAPPER_IMAGE_ABS)
+    assert len(clump["image_ra_deg"]) == len(clump["image_dec_deg"]) == 4
+
+
+def test_the_solver_keys_for_a_pixelized_source_are_the_truth_images(
+    pixelized_wcs_dict, truth
+):
+    """
+    The solver route on the clump peak lands on the truth images to a few
+    hundredths of an arcsecond — closer than the mapper route, which is
+    quantised to data pixels — so the two routes are checked separately, at
+    their own tolerances.
+    """
+    recorded = _sorted_positions(
+        pixelized_wcs_dict["lensed_source_image_y_arcsec"],
+        pixelized_wcs_dict["lensed_source_image_x_arcsec"],
+    )
+    expected = sorted((y, x) for y, x in truth["positions"])
+
+    assert len(recorded) == 4
+    assert np.asarray(recorded) == pytest.approx(
+        np.asarray(expected), abs=SOLVER_FROM_PEAK_ABS
+    )
+
+
+def test_the_clump_sky_positions_follow_the_header(pixelized_wcs_dict, euclid_dataset):
+    """The mapper-route images get the same by-hand sky check as the solver route."""
+    crval_ra_deg, crval_dec_deg = _header_crval(euclid_dataset)
+    clump = pixelized_wcs_dict["source_clumps"][0]
+
+    for y, x, ra, dec in zip(
+        clump["image_y_arcsec"],
+        clump["image_x_arcsec"],
+        clump["image_ra_deg"],
+        clump["image_dec_deg"],
+    ):
+        assert dec == pytest.approx(crval_dec_deg - y / 3600.0, abs=SKY_ABS_DEG)
+        assert (ra - crval_ra_deg) * np.cos(np.radians(dec)) == pytest.approx(
+            -x / 3600.0, abs=SKY_ABS_DEG
+        )
+
+
+def test_a_clump_finder_failure_is_logged_and_leaves_only_the_lens_keys(
+    pixelized_fit, euclid_dataset, monkeypatch, caplog
+):
+    """
+    With no clumps there is no peak to solve for either, so the record is the
+    lens keys plus ``source_model == "pixelized"``, and the failure is logged.
+    """
+
+    def raise_(**kwargs):
+        raise RuntimeError("no mapper")
+
+    monkeypatch.setattr(util, "pixelized_source_clumps_from", raise_)
+
+    with caplog.at_level(logging.WARNING, logger="util"):
+        wcs_dict = util.wcs_dict_from(
+            tracer=pixelized_fit.tracer,
+            data=euclid_dataset.dataset.data,
+            pixel_wcs=euclid_dataset.pixel_wcs,
+            fit=pixelized_fit,
+        )
+
+    assert tuple(wcs_dict) == LENS_KEYS
+    assert wcs_dict["source_model"] == "pixelized"
+    assert "no mapper" in caplog.text

--- a/util.py
+++ b/util.py
@@ -725,10 +725,20 @@ class AnalysisImaging(al.AnalysisImaging):
         """
         super().save_results(paths=paths, result=result)
 
+        try:
+            fit = result.max_log_likelihood_fit
+        except Exception as e:  # noqa: BLE001 — a finished search outlives its record
+            logging.getLogger(__name__).warning(
+                "wcs.json: the maximum log likelihood fit could not be built, so a "
+                f"pixelized source's clumps are not recorded ({type(e).__name__}: {e})"
+            )
+            fit = None
+
         wcs_dict = wcs_dict_from(
             tracer=result.max_log_likelihood_tracer,
             data=self.dataset.data,
             pixel_wcs=self.kwargs["pixel_wcs"],
+            fit=fit,
         )
 
         output_to_json(
@@ -747,6 +757,21 @@ class AnalysisImaging(al.AnalysisImaging):
 # solves for the same tracer agree to `pixel_scale_precision`.
 LENSED_SOURCE_PIXEL_SCALE_PRECISION = 0.005
 LENSED_SOURCE_MAGNIFICATION_THRESHOLD = 0.1
+
+# The `Inversion.source_clumps_from` settings a pixelized source's clumps are
+# found with — the library's own `subplot_mappings` defaults
+# (`autoarray/config/visualize/general.yaml`, `inversion:`), restated here so
+# the record does not move when a visualization config does. A mesh pixel is in
+# a clump if its reconstructed value exceeds `threshold` times the maximum;
+# ~0.5 isolates one smooth source, ~0.2 merges two nearby galaxies into one
+# clump, ~0.8 splits a source into its star-forming knots.
+SOURCE_CLUMP_THRESHOLD = 0.5
+SOURCE_CLUMP_MIN_PIXELS = 3
+SOURCE_CLUMP_TOTAL = 5
+
+# The pixelized source is always the last plane, mapped by the inversion's one
+# mapper (every pipeline model has a single pixelized plane).
+SOURCE_CLUMP_MAPPER_INDEX = 0
 
 
 def source_centre_from(tracer) -> Optional[Tuple[float, float]]:
@@ -801,28 +826,124 @@ def lensed_source_image_positions_from(
     return solver.solve(tracer=tracer, source_plane_coordinate=source_centre)
 
 
-def wcs_dict_from(tracer, data, pixel_wcs) -> dict:
+def pixelized_source_clumps_from(fit) -> List[dict]:
+    """
+    The bright clumps of a pixelized source's reconstruction, each with its
+    source-plane peak and the image-plane pixels it maps to — read off the
+    fit's mapper, not solved.
+
+    ``Inversion.source_clumps_from`` thresholds the reconstruction at
+    ``SOURCE_CLUMP_THRESHOLD`` times its maximum, splits what is left into
+    connected groups over the mesh neighbour graph, drops groups smaller than
+    ``SOURCE_CLUMP_MIN_PIXELS`` and keeps the ``SOURCE_CLUMP_TOTAL`` brightest.
+    ``Inversion.mappings_from`` then reads each clump's multiple images off the
+    mapper's mapping matrix as connected image-plane regions
+    (``autoarray.inversion.mappings``, PyAutoArray#517). Per clump this returns:
+
+    - ``peak_y_arcsec`` / ``peak_x_arcsec`` — the source-plane centre of the
+      clump's brightest mesh pixel (the peak, not the mean of the clump);
+    - ``peak_value`` — the reconstructed value there;
+    - ``mesh_pixels`` — how many mesh pixels the clump spans;
+    - ``image_y_arcsec`` / ``image_x_arcsec`` — one entry per image region: the
+      brightest pixel of the source's *model* image inside that region (what a
+      fibre is pointed at; ``ImageRegion.brightest_coordinate_from``), largest
+      region first.
+
+    Clumps are ordered brightest first, so the first is the source's main
+    structure and the rest are companions or star-forming knots.
+    """
+    inversion = fit.inversion
+    mapper = inversion.cls_list_from(cls=al.Mapper)[SOURCE_CLUMP_MAPPER_INDEX]
+
+    reconstruction = np.asarray(inversion.reconstruction_dict[mapper])
+    mesh_grid = np.asarray(mapper.source_plane_mesh_grid)
+    model_image = fit.model_images_of_planes_list[-1]
+
+    mappings = inversion.mappings_from(
+        mapper_index=SOURCE_CLUMP_MAPPER_INDEX,
+        threshold=SOURCE_CLUMP_THRESHOLD,
+        min_pixels=SOURCE_CLUMP_MIN_PIXELS,
+        total_clumps=SOURCE_CLUMP_TOTAL,
+    )
+
+    clumps = []
+
+    for mapping in mappings:
+        pix_indexes = np.asarray(mapping.pix_indexes)
+        peak_index = int(pix_indexes[int(np.argmax(reconstruction[pix_indexes]))])
+
+        images = [
+            region.brightest_coordinate_from(array=model_image)
+            for region in mapping.image_regions
+            if len(region.slim_indexes) > 0
+        ]
+
+        clumps.append(
+            {
+                "peak_y_arcsec": float(mesh_grid[peak_index, 0]),
+                "peak_x_arcsec": float(mesh_grid[peak_index, 1]),
+                "peak_value": float(reconstruction[peak_index]),
+                "mesh_pixels": int(pix_indexes.shape[0]),
+                "image_y_arcsec": [float(y) for y, _ in images],
+                "image_x_arcsec": [float(x) for _, x in images],
+            }
+        )
+
+    return clumps
+
+
+def wcs_dict_from(tracer, data, pixel_wcs, fit=None) -> dict:
     """
     The record ``AnalysisImaging.save_results`` writes to ``files/wcs.json``:
     where the fitted lens sits on the sky, and where its lensed source's
     multiple images fall.
 
-    ``crval_ra_deg`` / ``crval_dec_deg`` are the maximum-likelihood lens light
-    centre converted to RA / Dec through ``pixel_wcs`` — despite the FITS-style
-    name, not the cut-out's reference pixel; ``catalogue/scripts/magnitudes.py``
-    reads the RA back as its ``crval_ra_deg`` label column — and ``crpix_x`` /
-    ``crpix_y`` the 1-based WCS pixel of the image-plane origin ``(0, 0)``.
+    Always present:
 
-    ``source_centre_y_arcsec`` / ``source_centre_x_arcsec`` is the source
-    galaxy's light centre in the source plane (``source_centre_from``), and
-    ``lensed_source_image_y_arcsec`` / ``lensed_source_image_x_arcsec`` and
-    ``lensed_source_image_ra_deg`` / ``lensed_source_image_dec_deg`` are its
-    multiple images in the image plane, in arcsec and on the sky, one entry
-    per image (``lensed_source_image_positions_from``). All six are ``null``
-    for a source with no light centre — a pixelized source — and the four
-    image lists are ``null`` if the solver raises: a search that has finished
-    must not be lost to a post-fit record, so that failure is logged, never
-    raised. Every other key is always present, so a reader has one schema.
+    - ``crval_ra_deg`` / ``crval_dec_deg`` — the maximum-likelihood lens light
+      centre converted to RA / Dec through ``pixel_wcs``. Despite the FITS-style
+      name this is not the cut-out's reference pixel;
+      ``catalogue/scripts/magnitudes.py`` reads the RA back as its
+      ``crval_ra_deg`` label column.
+    - ``crpix_x`` / ``crpix_y`` — the 1-based WCS pixel of the image-plane
+      origin ``(0, 0)``.
+    - ``source_model`` — how the source was located: ``"light_profile"`` (its
+      light has a centre — the MGE ``Basis`` of ``vis_lp``, the ``Sersic`` of
+      the SED chain), ``"pixelized"`` (a ``Pixelization`` source and a ``fit``
+      to read its reconstruction from — ``vis_pix``, the Delaunay stages) or
+      ``"none"`` (neither, or no ``fit`` was given for a pixelized source).
+
+    Present when the source was located (``source_model != "none"``):
+
+    - ``source_centre_y_arcsec`` / ``source_centre_x_arcsec`` — the source
+      position the lens equation is solved for, in the source plane: the light
+      centre (``source_centre_from``), or the peak of the brightest clump of the
+      reconstruction.
+    - ``lensed_source_image_y_arcsec`` / ``lensed_source_image_x_arcsec`` and
+      ``lensed_source_image_ra_deg`` / ``lensed_source_image_dec_deg`` — that
+      position's multiple images in the image plane, in arcsec and on the sky,
+      one entry per image (``lensed_source_image_positions_from``, the
+      ``al.PointSolver`` route). Empty lists mean the solver found no image;
+      the four are *absent* if the solver raised, which is logged rather than
+      raised so a search that has finished is never lost to its own record.
+
+    Present for a pixelized source whose clumps could be read
+    (``source_model == "pixelized"``):
+
+    - ``source_clumps`` — one entry per bright clump of the reconstruction,
+      brightest first (``pixelized_source_clumps_from``): its ``peak_*`` in the
+      source plane and its ``image_*`` in the image plane read off the fit's
+      mapper — the brightest model pixel of each image region — plus the same
+      images on the sky as ``image_ra_deg`` / ``image_dec_deg``. Absent if the
+      clump finder raised (logged), in which case the solver keys are absent
+      too, since there is no peak to solve for. The two routes differ on
+      purpose: the solver keys are the sub-pixel lens-equation solution for one
+      point, the mapper keys are data pixels of every clump and can merge two
+      images into one arc or split one across a critical curve.
+
+    Nothing is ever written as ``null``: PyAutoFit's ``output_to_json`` drops
+    ``None``-valued keys on write, so an unavailable value is an absent key,
+    and ``source_model`` says why.
 
     Parameters
     ----------
@@ -835,6 +956,10 @@ def wcs_dict_from(tracer, data, pixel_wcs) -> dict:
     pixel_wcs
         The dataset's celestial ``astropy.wcs.WCS``, converting those pixels to
         RA / Dec.
+    fit
+        The maximum log likelihood ``FitImaging``, needed only for a pixelized
+        source (its inversion holds the reconstruction and the mapper). ``None``
+        records such a source as ``"none"``.
 
     Notes
     -----
@@ -847,6 +972,7 @@ def wcs_dict_from(tracer, data, pixel_wcs) -> dict:
     ``lensed_source_image_y_arcsec`` as "north of the lens"; read the
     ``_dec_deg`` beside it.
     """
+    logger = logging.getLogger(__name__)
 
     def sky_from(scaled_coordinates_2d):
         pixel_y, pixel_x = data.geometry.pixel_coordinates_wcs_2d_from(
@@ -867,15 +993,38 @@ def wcs_dict_from(tracer, data, pixel_wcs) -> dict:
         "crpix_y": data_centre_wcs_pix_y,
         "crval_ra_deg": lens_ra_deg,
         "crval_dec_deg": lens_dec_deg,
-        "source_centre_y_arcsec": None,
-        "source_centre_x_arcsec": None,
-        "lensed_source_image_y_arcsec": None,
-        "lensed_source_image_x_arcsec": None,
-        "lensed_source_image_ra_deg": None,
-        "lensed_source_image_dec_deg": None,
+        "source_model": "none",
     }
 
     source_centre = source_centre_from(tracer=tracer)
+
+    if source_centre is not None:
+        wcs_dict["source_model"] = "light_profile"
+
+    elif fit is not None and fit.tracer.planes[-1].has(cls=al.Pixelization):
+        wcs_dict["source_model"] = "pixelized"
+
+        try:
+            clumps = pixelized_source_clumps_from(fit=fit)
+        except Exception as e:  # noqa: BLE001 — a finished search outlives its record
+            logger.warning(
+                "wcs.json: the pixelized source's clumps could not be read off the "
+                f"fit's mapper; `source_clumps` is not written ({type(e).__name__}: {e})"
+            )
+            return wcs_dict
+
+        for clump in clumps:
+            sky = [
+                sky_from((y, x))
+                for y, x in zip(clump["image_y_arcsec"], clump["image_x_arcsec"])
+            ]
+            clump["image_ra_deg"] = [ra for ra, _ in sky]
+            clump["image_dec_deg"] = [dec for _, dec in sky]
+
+        wcs_dict["source_clumps"] = clumps
+
+        if clumps:
+            source_centre = (clumps[0]["peak_y_arcsec"], clumps[0]["peak_x_arcsec"])
 
     if source_centre is None:
         return wcs_dict
@@ -888,10 +1037,10 @@ def wcs_dict_from(tracer, data, pixel_wcs) -> dict:
             tracer=tracer, data=data, source_centre=source_centre
         )
     except Exception as e:  # noqa: BLE001 — a finished search outlives its record
-        logging.getLogger(__name__).warning(
+        logger.warning(
             "wcs.json: the point solver raised for the source centre "
-            f"{source_centre}; the lensed-source image positions are written "
-            f"as null ({type(e).__name__}: {e})"
+            f"{source_centre}; the lensed-source image positions are not written "
+            f"({type(e).__name__}: {e})"
         )
         return wcs_dict
 


### PR DESCRIPTION
## Summary

Follow-up to #71. A pixelized source (`vis_pix`, the Delaunay stages) has no light centre, so #71 wrote it no source keys. `util.wcs_dict_from` now takes the max-likelihood `fit` (handed over by `save_results`) and, when the source plane is a `Pixelization`:

- finds the reconstruction's bright clumps with `Inversion.source_clumps_from` at the library's `subplot_mappings` defaults (threshold 0.5 × max, ≥ 3 mesh pixels, 5 brightest) — the clump finder that shipped in PyAutoArray#517 (`image-source-mappings` phase 1);
- reads each clump's multiple images **off the fit's mapper** as connected image-plane regions (`Inversion.mappings_from`), reporting the brightest model pixel of each region;
- writes them as `source_clumps` (per clump: `peak_{y,x}_arcsec`, `peak_value`, `mesh_pixels`, `image_{y,x}_arcsec`, `image_{ra,dec}_deg`), brightest first;
- fills the solver keys (`source_centre_*`, `lensed_source_image_*`) by solving the lens equation with `al.PointSolver` for the **brightest clump's peak mesh pixel**, so those keys mean the same thing for every stage.

The two routes are kept deliberately: the solver keys are the sub-pixel lens-equation solution for one point; the mapper keys are data pixels of every clump and can merge two images into one arc or split one across a critical curve.

On the simulated lens: one clump at the default threshold, its peak 0.004" from the truth source centre, the solver images within 0.035" of `truth["positions"]`, the mapper images within 0.13" (quantised to 0.1" data pixels).

## Contract fix

PyAutoFit's `output_to_json` **drops `None`-valued keys**, so the "null for a pixelized source" that #71 documented never reached disk (a `vis_pix` record had only the four lens keys). The record now never holds `None`: an unavailable value is an absent key, and a new always-present `source_model` (`"light_profile"` / `"pixelized"` / `"none"`) says why. Both failure branches (clump finder, point solver) log and leave their keys absent; `save_results` also tolerates a fit that cannot be rebuilt. README and `catalogue/README.md` restated.

## Tests

- `tests/test_wcs_dict.py` (fast, JAX-free): a zero-free-parameter `vis_pix` fit (mesh mirrored from `test_compute_latent_variable.py`), asserting the single clump, its peak against the truth source centre, both image routes against `truth["positions"]` at their own tolerances, the clump images' sky positions by hand against the header, the no-fit and clump-finder-failure branches. The on-disk shape is now asserted through `al.output_to_json` + `al.from_json` (the pair `save_results` and the aggregator use) instead of `json.dumps`, and a null-free invariant walks both records. 9 → 17 tests.
- `tests/test_latent_run_level.py` (slow): also asserts `source_model == "light_profile"` on the real fit.
- Local: fast suite 112 → 120 passed; slow 4 passed.

Note for the reviewer: as on #65/#67/#71, this diff touches only `util.py`, `tests/` and docs, so the Heart smoke gate will skip every pytest job on the PR (`draft/bug/pyautoheart/smoke_gate_skips_pytest_runners_on_pr.md`); the push to `main` runs the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqZdi6m2pxkJJKVKjyhHWL

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqZdi6m2pxkJJKVKjyhHWL)_